### PR TITLE
Trying to restore test install

### DIFF
--- a/buildsystem/build.sh
+++ b/buildsystem/build.sh
@@ -190,7 +190,7 @@ if [[ $TEST -eq 1 ]]; then
   echo Testing
   echo
   ctest $CTESTARGS || exit 1
-  make test_install
+  make test_install || exit 1
   popd
 fi
 

--- a/buildsystem/build.sh
+++ b/buildsystem/build.sh
@@ -190,6 +190,7 @@ if [[ $TEST -eq 1 ]]; then
   echo Testing
   echo
   ctest $CTESTARGS || exit 1
+  make test_install
   popd
 fi
 


### PR DESCRIPTION
In some of the refactorings of the CI pipelines configuration we accidentally removed out `make test_install` test. This PR tries to restore it.