### PR TITLE
Fix warnings in HIP branch.

### DIFF
--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -157,7 +157,8 @@ namespace ReSolve
   {
     if (Numeric_ != nullptr){
       P_ = new index_type[A_->getNumRows()];
-      std::memcpy(P_, Numeric_->Pnum, A_->getNumRows() * sizeof(index_type));
+      size_t nrows = static_cast<size_t>(A_->getNumRows());
+      std::memcpy(P_, Numeric_->Pnum, nrows * sizeof(index_type));
       return P_;
     } else {
       return nullptr;
@@ -169,7 +170,8 @@ namespace ReSolve
   {
     if (Numeric_ != nullptr){
       Q_ = new index_type[A_->getNumRows()];
-      std::memcpy(Q_, Symbolic_->Q, A_->getNumRows() * sizeof(index_type));
+      size_t nrows = static_cast<size_t>(A_->getNumRows());
+      std::memcpy(Q_, Symbolic_->Q, nrows * sizeof(index_type));
       return Q_;
     } else {
       return nullptr;

--- a/resolve/MemoryUtils.hpp
+++ b/resolve/MemoryUtils.hpp
@@ -44,6 +44,15 @@ namespace ReSolve
       
       template <typename I, typename T>
       int copyArrayHostToDevice(T* dst, const T* src, I n);
+
+      /// Implemented here as it is always needed
+      template <typename I, typename T>
+      int copyArrayHostToHost(T* dst, const T* src, I n)
+      {
+        size_t nelements = static_cast<size_t>(n);
+        memcpy(dst, src, nelements * sizeof(T));
+        return 0;
+      }
   };
 
 } // namespace ReSolve

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -113,9 +113,9 @@ namespace ReSolve
 
     switch(control)  {
       case 0: //cpu->cpu
-        std::memcpy(h_row_data_, row_data, (nnz_current) * sizeof(index_type));
-        std::memcpy(h_col_data_, col_data, (nnz_current) * sizeof(index_type));
-        std::memcpy(h_val_data_, val_data, (nnz_current) * sizeof(real_type));
+        mem_.copyArrayHostToHost(h_row_data_, row_data, nnz_current);
+        mem_.copyArrayHostToHost(h_col_data_, col_data, nnz_current);
+        mem_.copyArrayHostToHost(h_val_data_, val_data, nnz_current);
         h_data_updated_ = true;
         owns_cpu_data_ = true;
         owns_cpu_vals_ = true;

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -109,9 +109,9 @@ namespace ReSolve
 
     switch(control)  {
       case 0: //cpu->cpu
-        std::memcpy(h_col_data_, col_data, (n_ + 1) * sizeof(index_type));
-        std::memcpy(h_row_data_, row_data, (nnz_current) * sizeof(index_type));
-        std::memcpy(h_val_data_, val_data, (nnz_current) * sizeof(real_type));
+        mem_.copyArrayHostToHost(h_col_data_, col_data,      n_ + 1);
+        mem_.copyArrayHostToHost(h_row_data_, row_data, nnz_current);
+        mem_.copyArrayHostToHost(h_val_data_, val_data, nnz_current);
         h_data_updated_ = true;
         owns_cpu_data_ = true;
         owns_cpu_vals_ = true;

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -111,9 +111,9 @@ namespace ReSolve
     //copy	
     switch(control)  {
       case 0: //cpu->cpu
-        std::memcpy(h_row_data_, row_data, (n_ + 1) * sizeof(index_type));
-        std::memcpy(h_col_data_, col_data, (nnz_current) * sizeof(index_type));
-        std::memcpy(h_val_data_, val_data, (nnz_current) * sizeof(real_type));
+        mem_.copyArrayHostToHost(h_row_data_, row_data,      n_ + 1);
+        mem_.copyArrayHostToHost(h_col_data_, col_data, nnz_current);
+        mem_.copyArrayHostToHost(h_val_data_, val_data, nnz_current);
         h_data_updated_ = true;
         owns_cpu_data_ = true;
         owns_cpu_vals_ = true;

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -50,7 +50,7 @@ namespace ReSolve {
       LinAlgWorkspaceCpu* workspace_{nullptr};
       bool values_changed_{true}; ///< needed for matvec
 
-      MemoryHandler mem_; ///< Device memory manager object
+      // MemoryHandler mem_; ///< Device memory manager object not used for now
   };
 
 } // namespace ReSolve

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -228,7 +228,7 @@ namespace ReSolve { namespace matrix {
 
     switch(control)  {
       case 0: //cpu->cpu
-        std::memcpy(h_val_data_, new_vals, (nnz_current) * sizeof(real_type));
+        mem_.copyArrayHostToHost(h_val_data_, new_vals, nnz_current);
         h_data_updated_ = true;
         owns_cpu_vals_ = true;
         break;

--- a/resolve/utilities/logger/Logger.cpp
+++ b/resolve/utilities/logger/Logger.cpp
@@ -59,7 +59,7 @@ namespace ReSolve
      */
     void Logger::updateVerbosity(std::vector<std::ostream*>& output_streams)
     {
-      for (size_t i = NONE; i <= EVERYTHING; ++i)
+      for (std::size_t i = NONE; i <= EVERYTHING; ++i)
       {
         output_streams[i] = i > verbosity_ ? &nullstream_ : logger_;
       }

--- a/resolve/utilities/logger/Logger.cpp
+++ b/resolve/utilities/logger/Logger.cpp
@@ -59,7 +59,7 @@ namespace ReSolve
      */
     void Logger::updateVerbosity(std::vector<std::ostream*>& output_streams)
     {
-      for (int i = NONE; i <= EVERYTHING; ++i)
+      for (size_t i = NONE; i <= EVERYTHING; ++i)
       {
         output_streams[i] = i > verbosity_ ? &nullstream_ : logger_;
       }

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -104,7 +104,7 @@ namespace ReSolve { namespace vector {
 
     switch(control)  {
       case 0: //cpu->cpu
-        std::memcpy(h_data_, data, (n_current_ * k_) * sizeof(real_type));
+        mem_.copyArrayHostToHost(h_data_, data, n_current_ * k_);
         owns_cpu_data_ = true;
         cpu_updated_ = true;
         gpu_updated_ = false;
@@ -322,7 +322,7 @@ namespace ReSolve { namespace vector {
     } else {
       real_type* data = this->getData(i, memspaceOut);
       if (memspaceOut == "cpu") {
-        std::memcpy(dest, data, n_current_ * sizeof(real_type));
+        mem_.copyArrayHostToHost(dest, data, n_current_);
       } else {
       if ((memspaceOut == "cuda") || (memspaceOut == "hip")) {
           mem_.copyArrayDeviceToDevice(dest, data, n_current_);
@@ -338,7 +338,7 @@ namespace ReSolve { namespace vector {
   {
     real_type* data = this->getData(memspaceOut);
     if (memspaceOut == "cpu") {
-      std::memcpy(dest, data, n_current_ * k_ * sizeof(real_type));
+      mem_.copyArrayHostToHost(dest, data, n_current_ * k_);
     } else {
       if ((memspaceOut == "cuda") || (memspaceOut == "hip")) {
         mem_.copyArrayDeviceToDevice(dest, data, n_current_ * k_);

--- a/resolve/workspace/LinAlgWorkspaceCpu.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "LinAlgWorkspaceCpu.hpp"
 
 namespace ReSolve

--- a/resolve/workspace/LinAlgWorkspaceCpu.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.hpp
@@ -12,7 +12,7 @@ namespace ReSolve
       ~LinAlgWorkspaceCpu();
       void initializeHandles();
     private:
-      MemoryHandler mem_;
+      // MemoryHandler mem_; ///< Memory handler not needed for now
   };
 
 }

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -46,7 +46,7 @@ namespace ReSolve
       //info - but we need info
       rocsparse_mat_info  info_A_;
 
-      MemoryHandler mem_;
+      // MemoryHandler mem_; ///< Memory handler not needed for now
   };
 
 } // namespace ReSolve


### PR DESCRIPTION
Fix warnings due to unused variables and implicity type conversion between `size_t` and `index_type`.
