### PR TITLE
Fix segfault in examples

### DIFF
--- a/examples/r_KLU_rf.cpp
+++ b/examples/r_KLU_rf.cpp
@@ -139,12 +139,8 @@ int main(int argc, char *argv[] )
         index_type* Q = KLU->getQOrdering();
         Rf->setup(A, L, U, P, Q); 
 
-        delete [] P;
-        delete [] Q;
         delete L;
-        delete L_csc;
         delete U;
-        delete U_csc;
       }
     } else {
       //status =  KLU->refactorize();

--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -189,8 +189,16 @@ int main(int argc, char *argv[])
 
   } // for (int i = 0; i < numSystems; ++i)
 
+  delete A;
+  delete KLU;
+  delete Rf;
   delete [] x;
   delete [] rhs;
+  delete vec_r;
+  delete vec_x;
+  delete workspace_CUDA;
+  delete matrix_handler;
+  delete vector_handler;
 
   return 0;
 }

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -217,8 +217,16 @@ int main(int argc, char *argv[])
 
   }
 
+  delete A;
+  delete KLU;
+  delete Rf;
   delete [] x;
   delete [] rhs;
+  delete vec_r;
+  delete vec_x;
+  delete workspace_CUDA;
+  delete matrix_handler;
+  delete vector_handler;
 
   return 0;
 }


### PR DESCRIPTION
Delete all objects created in examples and avoid double delete. This is quick fix to `rocsolver-dev` branch.