### PR TITLE
Enable HIP support in Gramm-Schmidt and FGMRES

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,11 +39,15 @@ if(RESOLVE_USE_CUDA)
 
 endif(RESOLVE_USE_CUDA)
 
-# Create CUDA examples
+# Create HIP examples
 if(RESOLVE_USE_HIP)
   # Build example with KLU factorization and rocsolver Rf refactorization
   add_executable(klu_rocsolverrf.exe r_KLU_rocsolverrf.cpp)
   target_link_libraries(klu_rocsolverrf.exe PRIVATE ReSolve)
+
+  # Build example with KLU factorization, rocsolver Rf refactorization, and FGMRES iterative refinement
+  add_executable(klu_rocsolverrf_fgmres.exe r_KLU_rocSolverRf_FGMRES.cpp)
+  target_link_libraries(klu_rocsolverrf_fgmres.exe PRIVATE ReSolve)
 endif(RESOLVE_USE_HIP)
 
 # Install all examples in bin directory

--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 
       //matrix_handler->setValuesChanged(true, "cuda");
       FGMRES->resetMatrix(A);
-      FGMRES->setupPreconditioner("CuSolverRf", Rf);
+      FGMRES->setupPreconditioner("LU", Rf);
       
       matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", "cuda"); 
 

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
                   << status << std::endl;    
         vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         status = Rf->solve(vec_rhs, vec_x);
-        FGMRES->setupPreconditioner("CuSolverRf", Rf);
+        FGMRES->setupPreconditioner("LU", Rf);
       }
       //if (i%2!=0)  vec_x->setToZero(ReSolve::memory::DEVICE);
       real_type norm_x =  vector_handler->dot(vec_x, vec_x, "cuda");

--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -169,15 +169,16 @@ int main(int argc, char *argv[])
 
       //matrix_handler->setValuesChanged(true, "hip");
       FGMRES->resetMatrix(A);
-      FGMRES->setupPreconditioner("CuSolverRf", Rf);
+      FGMRES->setupPreconditioner("LU", Rf);
       
       matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", "hip"); 
-
+      real_type rnrm = sqrt(vector_handler->dot(vec_r, vec_r, "hip"));
       std::cout << "\t 2-Norm of the residual (before IR): " 
                 << std::scientific << std::setprecision(16) 
-                << sqrt(vector_handler->dot(vec_r, vec_r, "hip"))/norm_b << "\n";
+                << rnrm/norm_b << "\n";
 
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+     if(!std::isnan(rnrm) && !std::isinf(rnrm)) {
       FGMRES->solve(vec_rhs, vec_x);
 
       std::cout << "FGMRES: init nrm: " 
@@ -186,7 +187,8 @@ int main(int argc, char *argv[])
                 << " final nrm: "
                 << FGMRES->getFinalResidualNorm()/norm_b
                 << " iter: " << FGMRES->getNumIter() << "\n";
-    }
+     }
+     }
 
   } // for (int i = 0; i < numSystems; ++i)
 

--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -140,27 +140,28 @@ int main(int argc, char *argv[])
       matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", "hip"); 
       printf("\t 2-Norm of the residual : %16.16e\n", sqrt(vector_handler->dot(vec_r, vec_r, "hip"))/norm_b);
       if (i == 1) {
-        ReSolve::matrix::Csc* L_csc = (ReSolve::matrix::Csc*) KLU->getLFactor();
-        ReSolve::matrix::Csc* U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
-        ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
-        ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
-        matrix_handler->csc2csr(L_csc,L, "hip");
-        matrix_handler->csc2csr(U_csc,U, "hip");
+        ReSolve::matrix::Csc* L /* _csc */ = (ReSolve::matrix::Csc*) KLU->getLFactor();
+        ReSolve::matrix::Csc* U /* _csc */ = (ReSolve::matrix::Csc*) KLU->getUFactor();
+        // ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
+        // ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
+        // matrix_handler->csc2csr(L_csc,L, "hip");
+        // matrix_handler->csc2csr(U_csc,U, "hip");
         if (L == nullptr) {printf("ERROR");}
         index_type* P = KLU->getPOrdering();
         index_type* Q = KLU->getQOrdering();
         Rf->setup(A, L, U, P, Q, vec_rhs);
+        Rf->refactorize();
         std::cout<<"about to set FGMRES" <<std::endl;
         GS->setup(A->getNumRows(), FGMRES->getRestart()); 
         FGMRES->setup(A); 
       }
     } else {
       //status =  KLU->refactorize();
-      std::cout<<"Using CUSOLVER RF"<<std::endl;
+      std::cout<<"Using ROCSOLVER RF"<<std::endl;
       status = Rf->refactorize();
-      std::cout<<"CUSOLVER RF refactorization status: "<<status<<std::endl;      
+      std::cout<<"ROCSOLVER RF refactorization status: "<<status<<std::endl;      
       status = Rf->solve(vec_rhs, vec_x);
-      std::cout<<"CUSOLVER RF solve status: "<<status<<std::endl;      
+      std::cout<<"ROCSOLVER RF solve status: "<<status<<std::endl;      
 
       vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, "hip");

--- a/resolve/CMakeLists.txt
+++ b/resolve/CMakeLists.txt
@@ -12,12 +12,12 @@ add_subdirectory(utilities)
 set(ReSolve_SRC
     LinSolver.cpp
     LinSolverDirectKLU.cpp
+    GramSchmidt.cpp
+    LinSolverIterativeFGMRES.cpp
 )
 
 # C++ code that links to CUDA SDK libraries
 set(ReSolve_CUDASDK_SRC
-    LinSolverIterativeFGMRES.cpp
-    GramSchmidt.cpp
     LinSolverDirectCuSolverGLU.cpp
     LinSolverDirectCuSolverRf.cpp
 )

--- a/resolve/CMakeLists.txt
+++ b/resolve/CMakeLists.txt
@@ -12,6 +12,10 @@ add_subdirectory(utilities)
 set(ReSolve_SRC
     LinSolver.cpp
     LinSolverDirectKLU.cpp
+)
+
+# Temporary until there is CPU-only option for FGMRES
+set(ReSolve_GPU_SRC
     GramSchmidt.cpp
     LinSolverIterativeFGMRES.cpp
 )
@@ -86,6 +90,11 @@ set(ReSolve_Targets_List
     resolve_tpl
     resolve_workspace
 )
+
+# Temporary until there is CPU-only option for FGMRES
+if(RESOLVE_USE_GPU)
+  set(ReSolve_SRC ${ReSolve_SRC} ${ReSolve_GPU_SRC})
+endif()
 
 # If CUDA support is enabled add CUDA SDK specific code and dependencies
 if(RESOLVE_USE_CUDA)

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -161,7 +161,6 @@ namespace ReSolve
 
           vec_v_->setData(V->getVectorData(i + 1, memory::DEVICE), memory::DEVICE);
           vector_handler_->gemv("T", n, i + 1, &ONE, &ZERO, V,  vec_v_, vec_Hcolumn_, memspace);
-
           // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
           vector_handler_->gemv("N", n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace );  
 

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -118,6 +118,9 @@ namespace ReSolve
     vector_type* vec_v = new vector_type(n_);
     vector_type* vec_z = new vector_type(n_);
     //V[0] = b-A*x_0
+    //debug
+    d_Z_->setToZero(memory::DEVICE);
+    d_V_->setToZero(memory::DEVICE);
 
     rhs->deepCopyVectorData(d_V_->getData(memory::DEVICE), 0, memory::DEVICE);  
     matrix_handler_->matvec(A_, x, d_V_, &MINUSONE, &ONE, "csr", memspace_); 
@@ -193,7 +196,6 @@ namespace ReSolve
             h_H_[i * (restart_ + 1) + k] = -h_s_[k1] * t + h_c_[k1] * h_H_[i * (restart_ + 1) + k];
           }
         } // if i!=0
-
         double Hii = h_H_[i * (restart_ + 1) + i];
         double Hii1 = h_H_[(i) * (restart_ + 1) + i + 1];
         double gam = sqrt(Hii * Hii + Hii1 * Hii1);
@@ -258,9 +260,9 @@ namespace ReSolve
     return 0;
   }
 
-  int  LinSolverIterativeFGMRES::setupPreconditioner(std::string name, LinSolverDirect* LU_solver)
+  int  LinSolverIterativeFGMRES::setupPreconditioner(std::string type, LinSolverDirect* LU_solver)
   {
-    if (name != "CuSolverRf") {
+    if (type != "LU") {
       out::warning() << "Only cusolverRf tri solve can be used as a preconditioner at this time." << std::endl;
       return 1;
     } else {

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -10,8 +10,9 @@ namespace ReSolve
 {
   using out = io::Logger;
 
-  LinSolverIterativeFGMRES::LinSolverIterativeFGMRES()
+  LinSolverIterativeFGMRES::LinSolverIterativeFGMRES(std::string memspace)
   {
+    memspace_ = memspace;
     this->matrix_handler_ = nullptr;
     this->vector_handler_ = nullptr;
     tol_ = 1e-14; //default
@@ -25,8 +26,10 @@ namespace ReSolve
 
   LinSolverIterativeFGMRES::LinSolverIterativeFGMRES(MatrixHandler* matrix_handler,
                                                      VectorHandler* vector_handler,
-                                                     GramSchmidt*   gs)
+                                                     GramSchmidt*   gs,
+                                                     std::string memspace)
   {
+    memspace_ = memspace;
     this->matrix_handler_ = matrix_handler;
     this->vector_handler_ = vector_handler;
     this->GS_ = gs;
@@ -46,8 +49,10 @@ namespace ReSolve
                                                      index_type conv_cond,
                                                      MatrixHandler* matrix_handler,
                                                      VectorHandler* vector_handler,
-                                                     GramSchmidt*   gs)
+                                                     GramSchmidt*   gs,
+                                                     std::string memspace)
   {
+    memspace_ = memspace;
     this->matrix_handler_ = matrix_handler;
     this->vector_handler_ = vector_handler;
     this->GS_ = gs;
@@ -115,10 +120,10 @@ namespace ReSolve
     //V[0] = b-A*x_0
 
     rhs->deepCopyVectorData(d_V_->getData(memory::DEVICE), 0, memory::DEVICE);  
-    matrix_handler_->matvec(A_, x, d_V_, &MINUSONE, &ONE, "csr", "cuda"); 
+    matrix_handler_->matvec(A_, x, d_V_, &MINUSONE, &ONE, "csr", memspace_); 
     rnorm = 0.0;
-    bnorm = vector_handler_->dot(rhs, rhs, "cuda");
-    rnorm = vector_handler_->dot(d_V_, d_V_, "cuda");
+    bnorm = vector_handler_->dot(rhs, rhs, memspace_);
+    rnorm = vector_handler_->dot(d_V_, d_V_, memspace_);
 
     //rnorm = ||V_1||
     rnorm = sqrt(rnorm);
@@ -154,7 +159,7 @@ namespace ReSolve
 
       // normalize first vector
       t = 1.0 / rnorm;
-      vector_handler_->scal(&t, d_V_, "cuda");
+      vector_handler_->scal(&t, d_V_, memspace_);
       // initialize norm history
       h_rs_[0] = rnorm;
       i = -1;
@@ -175,11 +180,11 @@ namespace ReSolve
 
         vec_v->setData( d_V_->getVectorData(i + 1, memory::DEVICE), memory::DEVICE);
 
-        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO,"csr", "cuda"); 
+        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO,"csr", memspace_); 
 
         // orthogonalize V[i+1], form a column of h_H_
 
-        GS_->orthogonalize(n_, d_V_, h_H_, i, "cuda");  ;
+        GS_->orthogonalize(n_, d_V_, h_H_, i, memspace_);  ;
         if(i != 0) {
           for(int k = 1; k <= i; k++) {
             k1 = k - 1;
@@ -229,7 +234,7 @@ namespace ReSolve
       // get solution
       for(j = 0; j <= i; j++) {
         vec_z->setData( d_Z_->getVectorData(j, memory::DEVICE), memory::DEVICE);
-        vector_handler_->axpy(&h_rs_[j], vec_z, x, "cuda");
+        vector_handler_->axpy(&h_rs_[j], vec_z, x, memspace_);
       }
 
       /* test solution */
@@ -240,8 +245,8 @@ namespace ReSolve
       }
 
       rhs->deepCopyVectorData(d_V_->getData(memory::DEVICE), 0, memory::DEVICE);  
-      matrix_handler_->matvec(A_, x, d_V_, &MINUSONE, &ONE,"csr", "cuda"); 
-      rnorm = vector_handler_->dot(d_V_, d_V_, "cuda");
+      matrix_handler_->matvec(A_, x, d_V_, &MINUSONE, &ONE,"csr", memspace_); 
+      rnorm = vector_handler_->dot(d_V_, d_V_, memspace_);
       // rnorm = ||V_1||
       rnorm = sqrt(rnorm);
 
@@ -308,7 +313,7 @@ namespace ReSolve
   int  LinSolverIterativeFGMRES::resetMatrix(matrix::Sparse* new_matrix)
   {
     A_ = new_matrix;
-    matrix_handler_->setValuesChanged(true, "cuda");
+    matrix_handler_->setValuesChanged(true, memspace_);
     return 0;
   }
 

--- a/resolve/LinSolverIterativeFGMRES.hpp
+++ b/resolve/LinSolverIterativeFGMRES.hpp
@@ -13,17 +13,19 @@ namespace ReSolve
     using vector_type = vector::Vector;
 
     public:
-    LinSolverIterativeFGMRES();
+    LinSolverIterativeFGMRES(std::string memspace = "cuda");
     LinSolverIterativeFGMRES( MatrixHandler* matrix_handler,
                               VectorHandler* vector_handler,
-                              GramSchmidt*   gs);
+                              GramSchmidt*   gs,
+                              std::string memspace = "cuda");
     LinSolverIterativeFGMRES(index_type restart,
                              real_type  tol,
                              index_type maxit,
                              index_type conv_cond,
                              MatrixHandler* matrix_handler,
                              VectorHandler* vector_handler,
-                             GramSchmidt*   gs);
+                             GramSchmidt*   gs,
+                             std::string memspace = "cuda");
     ~LinSolverIterativeFGMRES();
 
     int solve(vector_type* rhs, vector_type* x);
@@ -47,6 +49,8 @@ namespace ReSolve
 
     private:
     //remember matrix handler and vector handler are inherited.
+
+    std::string memspace_;
 
     real_type tol_;
     index_type maxit_;

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -140,7 +140,8 @@ namespace ReSolve { namespace vector {
   real_type* Vector::getData(index_type i, memory::MemorySpace memspace)
   {
     if ((memspace == memory::HOST) && (cpu_updated_ == false) && (gpu_updated_ == true )) {
-      copyData(memspace, memory::HOST);
+      // remember IN FIRST OUT SECOND!!!
+      copyData(memory::DEVICE, memspace);  
       owns_cpu_data_ = true;
     } 
 
@@ -174,7 +175,6 @@ namespace ReSolve { namespace vector {
       //allocate first
       mem_.allocateArrayOnDevice(&d_data_, n_ * k_);
     } 
-
     switch(control)  {
       case 0: //cpu->cuda
         mem_.copyArrayHostToDevice(d_data_, h_data_, n_current_ * k_);

--- a/tests/functionality/testKLU_Rf_FGMRES.cpp
+++ b/tests/functionality/testKLU_Rf_FGMRES.cpp
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
   error_sum += status;
   
   FGMRES->resetMatrix(A);
-  status = FGMRES->setupPreconditioner("CuSolverRf", Rf);
+  status = FGMRES->setupPreconditioner("LU", Rf);
   error_sum += status;
 
   vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);


### PR DESCRIPTION
FGMRES solver and GS now build with HIP. This is still a hack. Example `klu_rocsolverrf_fgmres.exe` builds cleanly, but segfaults at execution. Needs some debugging.

This is a proposal how to get rid of hard-wired CUDA ID parameters.