### PR TITLE
Refactor CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,18 +100,11 @@ endif(RESOLVE_USE_HIP)
 configure_file(
   ${CMAKE_SOURCE_DIR}/resolve/resolve_defs.hpp.in
   ${CMAKE_BINARY_DIR}/resolve/resolve_defs.hpp)
-
-# include build directory for Fortran name mangling header
-# TODO - target based includes
-include_directories(${CMAKE_BINARY_DIR})
-
 install(
   FILES ${CMAKE_BINARY_DIR}/resolve/resolve_defs.hpp
   DESTINATION include/resolve
   )
 
-# TODO - fix this
-include_directories(${CMAKE_SOURCE_DIR})
 
 # Enable testing
 enable_testing()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,7 +25,7 @@
             "installDir": "${sourceDir}/install",
             "generator": "Unix Makefiles"
         },
-	      {
+	    {
             "name": "ascent",
             "inherits": "cuda",
             "displayName": "Ascent Build",

--- a/cmake/ReSolveConfig.cmake.in
+++ b/cmake/ReSolveConfig.cmake.in
@@ -4,6 +4,10 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/ReSolveTargets.cmake")
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD @CMAKE_CXX_STANDARD@)
+endif()
+
 include(CheckLanguage)
 # This must come before enable_language(CUDA)
 if(@RESOLVE_USE_CUDA@)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -71,8 +71,11 @@ set(CONSUMER_PATH ${CMAKE_INSTALL_PREFIX}/share/examples)
 install(PROGRAMS test.sh DESTINATION ${CONSUMER_PATH})
 
 # Select consumer app
+# TODO - have an outer loop that adds a unique consumer test for each backend supproted
 if(RESOLVE_USE_CUDA)
   set(RESOLVE_CONSUMER_APP "testKLU_Rf_FGMRES.cpp")
+elseif(RESOLVE_USE_HIP)
+  set(RESOLVE_CONSUMER_APP "testKLU_RocSolver.cpp")
 else()
   set(RESOLVE_CONSUMER_APP "testKLU.cpp")
 endif()

--- a/examples/resolve_consumer/CMakeLists.txt
+++ b/examples/resolve_consumer/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ReSolve REQUIRED)
 
 # Build example with KLU factorization and KLU refactorization
 add_executable(consume.exe consumer.cpp)
-target_link_libraries(consume.exe PUBLIC ReSolve::ReSolve)
+target_link_libraries(consume.exe PRIVATE ReSolve::ReSolve)
 
 #------------------------------------------------------------------------------------
 # Testing of exported Resolve Configurations

--- a/examples/resolve_consumer/CMakeLists.txt
+++ b/examples/resolve_consumer/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ReSolve REQUIRED)
 
 # Build example with KLU factorization and KLU refactorization
 add_executable(consume.exe consumer.cpp)
-target_link_libraries(consume.exe PRIVATE ReSolve::ReSolve)
+target_link_libraries(consume.exe PUBLIC ReSolve::ReSolve)
 
 #------------------------------------------------------------------------------------
 # Testing of exported Resolve Configurations

--- a/resolve/cpu/CMakeLists.txt
+++ b/resolve/cpu/CMakeLists.txt
@@ -17,12 +17,7 @@ set(ReSolve_CPU_HEADER_INSTALL
 
 # First create dummy backend
 add_library(resolve_backend_cpu SHARED ${ReSolve_CPU_SRC})
-target_link_libraries(resolve_backend_cpu PRIVATE resolve_logger)
-
-target_include_directories(resolve_backend_cpu INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
-)
+target_link_libraries(resolve_backend_cpu PUBLIC resolve_logger)
 
 # install include headers
 install(FILES ${ReSolve_CPU_HEADER_INSTALL} DESTINATION include/resolve/cpu)

--- a/resolve/utilities/logger/CMakeLists.txt
+++ b/resolve/utilities/logger/CMakeLists.txt
@@ -17,8 +17,9 @@ set(Logger_HEADER_INSTALL
 # Build shared library ReSolve
 add_library(resolve_logger SHARED ${Logger_SRC})
 
-target_include_directories(resolve_logger INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+target_include_directories(resolve_logger PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/resolve/workspace/CMakeLists.txt
+++ b/resolve/workspace/CMakeLists.txt
@@ -47,9 +47,10 @@ if(RESOLVE_USE_HIP)
   target_link_libraries(resolve_workspace PUBLIC resolve_backend_hip)
 endif(RESOLVE_USE_HIP)  
 
-target_include_directories(resolve_workspace INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(resolve_workspace PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+  $<INSTALL_INTERFACE:include>
 )
 
 # install include headers


### PR DESCRIPTION
- removes blanket `include_directories` everywhere (closes #15)

I will close remainder of #15 for AMD in Incline PR #53