### PR TITLE
Fix warnings stemming from rocsolver class

### DIFF
--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -141,12 +141,8 @@ int main(int argc, char *argv[])
       matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", "hip"); 
       printf("\t 2-Norm of the residual : %16.16e\n", sqrt(vector_handler->dot(vec_r, vec_r, "hip"))/norm_b);
       if (i == 1) {
-        ReSolve::matrix::Csc* L /* _csc */ = (ReSolve::matrix::Csc*) KLU->getLFactor();
-        ReSolve::matrix::Csc* U /* _csc */ = (ReSolve::matrix::Csc*) KLU->getUFactor();
-        // ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
-        // ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
-        // matrix_handler->csc2csr(L_csc,L, "hip");
-        // matrix_handler->csc2csr(U_csc,U, "hip");
+        ReSolve::matrix::Csc* L = (ReSolve::matrix::Csc*) KLU->getLFactor();
+        ReSolve::matrix::Csc* U = (ReSolve::matrix::Csc*) KLU->getUFactor();
         if (L == nullptr) {printf("ERROR");}
         index_type* P = KLU->getPOrdering();
         index_type* Q = KLU->getQOrdering();
@@ -193,8 +189,17 @@ int main(int argc, char *argv[])
 
   } // for (int i = 0; i < numSystems; ++i)
 
+  delete A;
+  delete A_coo;
+  delete KLU;
+  delete Rf;
   delete [] x;
   delete [] rhs;
+  delete vec_r;
+  delete vec_x;
+  delete workspace_HIP;
+  delete matrix_handler;
+  delete vector_handler;
 
   return 0;
 }

--- a/examples/r_KLU_rocsolverrf.cpp
+++ b/examples/r_KLU_rocsolverrf.cpp
@@ -135,20 +135,13 @@ int main(int argc, char *argv[] )
         vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         Rf->setup(A, L, U, P, Q, vec_rhs); 
         Rf->refactorize();
-       //dont do it here 
-      //  delete [] P;
-      //  delete [] Q;
       }
     } else {
-      //status =  KLU->refactorize();
       std::cout<<"Using rocsolver rf"<<std::endl;
       status = Rf->refactorize();
       std::cout<<"rocsolver rf refactorization status: "<<status<<std::endl;      
       status = Rf->solve(vec_rhs, vec_x);
       std::cout<<"rocsolver rf solve status: "<<status<<std::endl;      
-      //std::cout<<"KLU re-factorization status: "<<status<<std::endl;
-      //status = KLU->solve(vec_rhs, vec_x);
-      //std::cout<<"KLU solve status: "<<status<<std::endl;      
     }
     vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
@@ -164,6 +157,7 @@ int main(int argc, char *argv[] )
 
   //now DELETE
   delete A;
+  delete A_coo;
   delete KLU;
   delete Rf;
   delete [] x;

--- a/resolve/LinSolver.cpp
+++ b/resolve/LinSolver.cpp
@@ -13,12 +13,6 @@ namespace ReSolve
     //destroy the matrix and hadlers
   }
 
-  int LinSolver::setup(matrix::Sparse* A)
-  {
-    this->A_ = A;
-    return 0;
-  }
-
   real_type LinSolver::evaluateResidual()
   {
     //to be implemented
@@ -40,6 +34,17 @@ namespace ReSolve
     delete U_;
     delete [] P_;
     delete [] Q_;
+  }
+
+  int LinSolverDirect::setup(matrix::Sparse* A,
+                             matrix::Sparse* /* L */,
+                             matrix::Sparse* /* U */,
+                             index_type*     /* P */,
+                             index_type*     /* Q */,
+                             vector_type*  /* rhs */)
+  {
+    this->A_ = A;
+    return 0;
   }
 
   int LinSolverDirect::analyze()
@@ -92,6 +97,11 @@ namespace ReSolve
   {
   }
 
+  int LinSolverIterative::setup(matrix::Sparse* A)
+  {
+    this->A_ = A;
+    return 0;
+  }
 
   int LinSolverIterative::solve(vector_type* /* rhs */, vector_type* /* init_guess */)
   {

--- a/resolve/LinSolver.hpp
+++ b/resolve/LinSolver.hpp
@@ -31,7 +31,6 @@ namespace ReSolve
       LinSolver();
       virtual ~LinSolver();
 
-      virtual int setup(matrix::Sparse* A);
       real_type evaluateResidual();
         
     protected:  
@@ -49,6 +48,13 @@ namespace ReSolve
       LinSolverDirect();
       virtual ~LinSolverDirect();
       //return 0 if successful!
+      virtual int setup(matrix::Sparse* A,
+                        matrix::Sparse* L,
+                        matrix::Sparse* U,
+                        index_type*     P,
+                        index_type*     Q,
+                        vector_type*  rhs);
+                        
       virtual int analyze(); //the same as symbolic factorization
       virtual int factorize();
       virtual int refactorize();
@@ -72,6 +78,7 @@ namespace ReSolve
     public:
       LinSolverIterative();
       ~LinSolverIterative();
+      virtual int setup(matrix::Sparse* A);
 
       virtual int  solve(vector_type* rhs, vector_type* init_guess);
   };

--- a/resolve/LinSolverDirectCuSolverGLU.cpp
+++ b/resolve/LinSolverDirectCuSolverGLU.cpp
@@ -8,6 +8,8 @@
 
 namespace ReSolve
 {
+  using vector_type = vector::Vector;
+
   LinSolverDirectCuSolverGLU::LinSolverDirectCuSolverGLU(LinAlgWorkspaceCUDA* workspace)
   {
     this->workspace_ = workspace;
@@ -22,7 +24,12 @@ namespace ReSolve
     delete M_;
   }
 
-  int LinSolverDirectCuSolverGLU::setup(matrix::Sparse* A, matrix::Sparse* L, matrix::Sparse* U, index_type* P, index_type* Q)
+  int LinSolverDirectCuSolverGLU::setup(matrix::Sparse* A,
+                                        matrix::Sparse* L,
+                                        matrix::Sparse* U,
+                                        index_type* P,
+                                        index_type* Q,
+                                        vector_type* /* rhs */)
   {
     int error_sum = 0;
 

--- a/resolve/LinSolverDirectCuSolverGLU.hpp
+++ b/resolve/LinSolverDirectCuSolverGLU.hpp
@@ -32,7 +32,12 @@ namespace ReSolve
       int refactorize();
       int solve(vector_type* rhs, vector_type* x);
 
-      int setup(matrix::Sparse* A, matrix::Sparse* L, matrix::Sparse* U, index_type* P, index_type* Q);
+      int setup(matrix::Sparse* A,
+                matrix::Sparse* L,
+                matrix::Sparse* U,
+                index_type*     P,
+                index_type*     Q,
+                vector_type* rhs = nullptr);
     
     private:
       void addFactors(matrix::Sparse* L, matrix::Sparse* U); //create L+U from sepeate L, U factors

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -17,7 +17,12 @@ namespace ReSolve
     mem_.deleteOnDevice(d_T_);
   }
 
-  int LinSolverDirectCuSolverRf::setup(matrix::Sparse* A, matrix::Sparse* L, matrix::Sparse* U, index_type* P, index_type* Q)
+  int LinSolverDirectCuSolverRf::setup(matrix::Sparse* A,
+                                       matrix::Sparse* L,
+                                       matrix::Sparse* U,
+                                       index_type* P,
+                                       index_type* Q,
+                                       vector_type* /* rhs */)
   {
     //remember - P and Q are generally CPU variables
     int error_sum = 0;

--- a/resolve/LinSolverDirectCuSolverRf.hpp
+++ b/resolve/LinSolverDirectCuSolverRf.hpp
@@ -26,7 +26,12 @@ namespace ReSolve
       LinSolverDirectCuSolverRf();
       ~LinSolverDirectCuSolverRf();
       
-      int setup(matrix::Sparse* A, matrix::Sparse* L, matrix::Sparse* U, index_type* P, index_type* Q);
+      int setup(matrix::Sparse* A,
+                matrix::Sparse* L,
+                matrix::Sparse* U,
+                index_type*     P,
+                index_type*     Q,
+                vector_type* rhs = nullptr);
 
       void setAlgorithms(cusolverRfFactorization_t fact_alg,  cusolverRfTriangularSolve_t solve_alg);
       

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -18,7 +18,12 @@ namespace ReSolve
     klu_free_numeric(&Numeric_, &Common_);
   }
 
-  int LinSolverDirectKLU::setup(matrix::Sparse* A)
+  int LinSolverDirectKLU::setup(matrix::Sparse* A,
+                                matrix::Sparse* /* L */,
+                                matrix::Sparse* /* U */,
+                                index_type*     /* P */,
+                                index_type*     /* Q */,    
+                                vector_type*  /* rhs */)
   {
     this->A_ = A;
     return 0;

--- a/resolve/LinSolverDirectKLU.hpp
+++ b/resolve/LinSolverDirectKLU.hpp
@@ -24,7 +24,13 @@ namespace ReSolve
     public:
       LinSolverDirectKLU();
       ~LinSolverDirectKLU();
-      int setup(matrix::Sparse* A);
+
+      int setup(matrix::Sparse* A,
+                matrix::Sparse* L = nullptr,
+                matrix::Sparse* U = nullptr,
+                index_type*     P = nullptr,
+                index_type*     Q = nullptr,
+                vector_type*  rhs = nullptr);
      
       void setupParameters(int ordering, double KLU_threshold, bool halt_if_singular);
 

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -24,7 +24,12 @@ namespace ReSolve
     delete U_csr_;
   }
 
-  int LinSolverDirectRocSolverRf::setup(matrix::Sparse* A, matrix::Sparse* L, matrix::Sparse* U, index_type* P, index_type* Q, vector_type* rhs)
+  int LinSolverDirectRocSolverRf::setup(matrix::Sparse* A,
+                                        matrix::Sparse* L,
+                                        matrix::Sparse* U,
+                                        index_type* P,
+                                        index_type* Q,
+                                        vector_type* rhs)
   {
     //remember - P and Q are generally CPU variables
     int error_sum = 0;
@@ -113,9 +118,6 @@ namespace ReSolve
                                                        &L_buffer_size);
       error_sum += status_rocsparse_;
 
-      printf("buffer size for L %d status %d \n", L_buffer_size, status_rocsparse_);
-      // hipMalloc((void**)&(L_buffer), L_buffer_size);
-
       mem_.allocateBufferOnDevice(&L_buffer_, L_buffer_size);
       status_rocsparse_ = rocsparse_dcsrsv_buffer_size(workspace_->getRocsparseHandle(), 
                                                        rocsparse_operation_none, 
@@ -128,9 +130,7 @@ namespace ReSolve
                                                        info_U_,
                                                        &U_buffer_size);
       error_sum += status_rocsparse_;
-      //      hipMalloc((void**)&(U_buffer), U_buffer_size);
       mem_.allocateBufferOnDevice(&U_buffer_, U_buffer_size);
-      printf("buffer size for U %d status %d \n", U_buffer_size, status_rocsparse_);
 
       status_rocsparse_ = rocsparse_dcsrsv_analysis(workspace_->getRocsparseHandle(), 
                                                     rocsparse_operation_none, 
@@ -389,22 +389,22 @@ printf("solve mode 1, splitting the factors again \n");
       mia[i] += mia[i - 1];
     }
 
-    std::vector<int> Mshifts(n, 0);
+    std::vector<int> Mshifts(static_cast<size_t>(n), 0);
     for(index_type i = 0; i < n; ++i) {
       // go through EACH COLUMN OF L first
       for(int j = Lp[i]; j < Lp[i + 1]; ++j) {
         row = Li[j];
         if(row != i) {
           // place (row, i) where it belongs!
-          mja[mia[row] + Mshifts[row]] = i;
-          Mshifts[row]++;
+          mja[mia[row] + Mshifts[static_cast<size_t>(row)]] = i;
+          Mshifts[static_cast<size_t>(row)]++;
         }
       }
       // each column of U next
       for(index_type j = Up[i]; j < Up[i + 1]; ++j) {
         row = Ui[j];
-        mja[mia[row] + Mshifts[row]] = i;
-        Mshifts[row]++;
+        mja[mia[row] + Mshifts[static_cast<size_t>(row)]] = i;
+        Mshifts[static_cast<size_t>(row)]++;
       }
     }
     //Mshifts.~vector(); 

--- a/resolve/LinSolverDirectRocSolverRf.hpp
+++ b/resolve/LinSolverDirectRocSolverRf.hpp
@@ -32,7 +32,12 @@ namespace ReSolve
       LinSolverDirectRocSolverRf(LinAlgWorkspaceHIP* workspace);
       ~LinSolverDirectRocSolverRf();
       
-      int setup(matrix::Sparse* A, matrix::Sparse* L, matrix::Sparse* U, index_type* P, index_type* Q, vector_type* rhs);
+      int setup(matrix::Sparse* A,
+                matrix::Sparse* L,
+                matrix::Sparse* U,
+                index_type*     P,
+                index_type*     Q,
+                vector_type*  rhs);
        
       int refactorize();
       int solve(vector_type* rhs, vector_type* x);


### PR DESCRIPTION
Implementing ROCm-based solver introduced several warnings due to type conversion and method shadowing. This PR fixes those warnings and does some minor code cleanup.