### PR TITLE
Fix warnings in rand-gmres-dev2 branch

### DIFF
--- a/examples/r_randGMRES.cpp
+++ b/examples/r_randGMRES.cpp
@@ -19,7 +19,6 @@ using namespace ReSolve::constants;
 int main(int argc, char *argv[])
 {
   // Use the same data types as those you specified in ReSolve build.
-  using index_type = ReSolve::index_type;
   using real_type  = ReSolve::real_type;
   using vector_type = ReSolve::vector::Vector;
 

--- a/examples/r_randGMRES_CUDA.cpp
+++ b/examples/r_randGMRES_CUDA.cpp
@@ -19,7 +19,6 @@ using namespace ReSolve::constants;
 int main(int argc, char *argv[])
 {
   // Use the same data types as those you specified in ReSolve build.
-  using index_type = ReSolve::index_type;
   using real_type  = ReSolve::real_type;
   using vector_type = ReSolve::vector::Vector;
 

--- a/resolve/LinSolverDirectRocSparseILU0.cpp
+++ b/resolve/LinSolverDirectRocSparseILU0.cpp
@@ -89,8 +89,6 @@ namespace ReSolve
                                                      &buffer_size_U);
     error_sum += status_rocsparse_;
 
-    size_t buffer_size = std::max(buffer_size_A, std::max(buffer_size_L, buffer_size_U));
-
     // Now analysis
     status_rocsparse_ = rocsparse_dcsrilu0_analysis(workspace_->getRocsparseHandle(), 
                                                     n, 

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -118,15 +118,14 @@ namespace ReSolve
     switch(rand_method_) {
       case cs:
         if(ceil(restart_ * log(n_)) < k_rand_) {
-          //k_rand_ = ceil(restart_ * log(n_));
-          k_rand_ = ceil(restart_ * log(n_));
+          k_rand_ = static_cast<index_type>(std::ceil(restart_ * std::log(static_cast<real_type>(n_))));
         }
         rand_manager_ = new RandSketchingCountSketch();
         //set k and n 
         break;
       case fwht:
         if ( ceil(2.0 * restart_ * log(n_) / log(restart_)) < k_rand_) {
-          k_rand_ = ceil(2.0 * restart_ * log(n_) / log(restart_));
+          k_rand_ = static_cast<index_type>(std::ceil(2.0 * restart_ * std::log(n_) / std::log(restart_)));
         }
         rand_manager_ = new RandSketchingFWHT();
         break;
@@ -134,7 +133,7 @@ namespace ReSolve
         io::Logger::warning() << "Wrong sketching method, setting to default (CountSketch)\n"; 
         rand_method_ = cs;
         if(ceil(restart_ * log(n_)) < k_rand_) {
-          k_rand_ = ceil(restart_ * log(n_));
+          k_rand_ = static_cast<index_type>(std::ceil(restart_ * std::log(n_)));
         }
         rand_manager_ = new RandSketchingCountSketch();
         break;
@@ -194,7 +193,7 @@ namespace ReSolve
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
     rnorm = vector_handler_->dot(vec_s, vec_s, memspace_);
-    double rnorm_true = vector_handler_->dot(vec_v, vec_v, memspace_);
+    // double rnorm_true = vector_handler_->dot(vec_v, vec_v, memspace_);
     //rnorm = ||V_1||
     rnorm = sqrt(rnorm);
     bnorm = sqrt(bnorm);

--- a/resolve/RandSketchingCountSketch.cpp
+++ b/resolve/RandSketchingCountSketch.cpp
@@ -51,8 +51,7 @@ namespace ReSolve
   {
     k_rand_ = k;
     n_ = n;
-    srand(time(NULL)); 
-   // srand(1234); 
+    srand(static_cast<unsigned>(time(nullptr)));
     //allocate labeling scheme vector and move to GPU
 
     h_labels_ = new int[n_];


### PR DESCRIPTION
Fix warnings due to type conversions from floating point to integer types. Added a guard in case integer type precision is exceeded.