### PR TITLE
Matrix norm

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,6 +49,9 @@ if(RESOLVE_USE_CUDA)
   add_executable(system_cuda.exe r_SysSolverCuda.cpp)
   target_link_libraries(system_cuda.exe PRIVATE ReSolve)
 
+  # Example in which factorization is redone if solution is bad
+  add_executable(klu_cusolverrf_check_redo.exe r_KLU_cusolverrf_redo_factorization.cpp)
+  target_link_libraries(klu_cusolverrf_check_redo.exe PRIVATE ReSolve)
 endif(RESOLVE_USE_CUDA)
 
 # Create HIP examples
@@ -82,7 +85,7 @@ endif(RESOLVE_USE_HIP)
 set(installable_executables klu_klu.exe klu_klu_standalone.exe system.exe)
 
 if(RESOLVE_USE_CUDA)
-  set(installable_executables ${installable_executables} klu_glu.exe klu_rf.exe klu_rf_fgmres.exe klu_glu_values_update.exe gmres_cusparse_rand.exe)        
+  set(installable_executables ${installable_executables} klu_glu.exe klu_rf.exe klu_rf_fgmres.exe klu_glu_values_update.exe gmres_cusparse_rand.exe klu_cusolverrf_check_redo.exe)        
 endif(RESOLVE_USE_CUDA)
 
 if(RESOLVE_USE_HIP)

--- a/examples/r_KLU_GLU.cpp
+++ b/examples/r_KLU_GLU.cpp
@@ -47,6 +47,7 @@ int main(int argc, char *argv[])
   vector_type* vec_rhs;
   vector_type* vec_x;
   vector_type* vec_r;
+  real_type norm_A, norm_x, norm_r;//used for INF norm
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
   ReSolve::LinSolverDirectCuSolverGLU* GLU = new ReSolve::LinSolverDirectCuSolverGLU(workspace_CUDA);
@@ -144,6 +145,15 @@ int main(int argc, char *argv[])
     matrix_handler->setValuesChanged(true, "cuda");
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", "cuda"); 
 
+    
+    matrix_handler->matrixInfNorm(A, &norm_A, "cuda"); 
+    norm_x = vector_handler->infNorm(vec_x, "cuda");
+    norm_r = vector_handler->infNorm(vec_r, "cuda");
+    std::cout << "\t Matrix inf  norm: " << std::scientific << std::setprecision(16) << norm_A<<"\n"
+      << "\t Residual inf norm: " << norm_r <<"\n"  
+      << "\t Solution inf norm: " << norm_x <<"\n"  
+      << "\t Norm of scaled residuals: "<< norm_r / (norm_A * norm_x) << "\n";
+    
     std::cout << "\t 2-Norm of the residual: " 
               << std::scientific << std::setprecision(16) 
               << sqrt(vector_handler->dot(vec_r, vec_r, "cuda"))/bnorm << "\n";

--- a/examples/r_KLU_KLU.cpp
+++ b/examples/r_KLU_KLU.cpp
@@ -46,7 +46,8 @@ int main(int argc, char *argv[])
   vector_type* vec_rhs;
   vector_type* vec_x;
   vector_type* vec_r;
-
+  real_type norm_A, norm_x, norm_r;//used for INF norm
+  
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
 
   for (int i = 0; i < numSystems; ++i)
@@ -116,6 +117,7 @@ int main(int argc, char *argv[])
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnzExpanded()<<std::endl;
     //Now call direct solver
     int status;
+
     if (i < 2){
       KLU->setup(A);
       status = KLU->analyze();
@@ -135,10 +137,17 @@ int main(int argc, char *argv[])
     matrix_handler->setValuesChanged(true, "cpu");
 
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", "cpu"); 
+    norm_r = vector_handler->infNorm(vec_r, "cpu");
 
-    std::cout << "\t 2-Norm of the residual: " 
+    std::cout << "\t2-Norm of the residual: " 
               << std::scientific << std::setprecision(16) 
               << sqrt(vector_handler->dot(vec_r, vec_r, "cpu")) << "\n";
+    matrix_handler->matrixInfNorm(A, &norm_A, "cpu"); 
+    norm_x = vector_handler->infNorm(vec_x, "cpu");
+    std::cout << "\tMatrix inf  norm: " << std::scientific << std::setprecision(16) << norm_A<<"\n"
+              << "\tResidual inf norm: " << norm_r <<"\n"  
+              << "\tSolution inf norm: " << norm_x <<"\n"  
+              << "\tNorm of scaled residuals: "<< norm_r / (norm_A * norm_x) << "\n";
   }
 
   //now DELETE

--- a/examples/r_KLU_rocsolverrf.cpp
+++ b/examples/r_KLU_rocsolverrf.cpp
@@ -49,6 +49,8 @@ int main(int argc, char *argv[] )
   vector_type* vec_x;
   vector_type* vec_r;
 
+  real_type norm_A, norm_x, norm_r;//used for INF norm
+  
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
   ReSolve::LinSolverDirectRocSolverRf* Rf = new ReSolve::LinSolverDirectRocSolverRf(workspace_HIP);
 
@@ -147,6 +149,14 @@ int main(int argc, char *argv[] )
     std::cout << "\t 2-Norm of the residual: " 
               << std::scientific << std::setprecision(16) 
               << sqrt(vector_handler->dot(vec_r, vec_r, "hip"))/bnorm << "\n";
+    
+    matrix_handler->matrixInfNorm(A, &norm_A, "hip"); 
+    norm_x = vector_handler->infNorm(vec_x, "hip");
+    norm_r = vector_handler->infNorm(vec_r, "hip");
+    std::cout << "\t Matrix inf  norm:  " << std::scientific << std::setprecision(16) << norm_A <<"\n"
+              << "\t Residual inf norm: " << norm_r <<"\n"  
+              << "\t Solution inf norm: " << norm_x <<"\n"  
+              << "\t Norm of scaled residuals: "<< norm_r / (norm_A * norm_x) << "\n";
 
   } // for (int i = 0; i < numSystems; ++i)
 

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -7,6 +7,7 @@ namespace ReSolve
   LinSolverDirectCuSolverRf::LinSolverDirectCuSolverRf()
   {
     cusolverRfCreate(&handle_cusolverrf_);
+    setup_completed_ = false;
   }
 
   LinSolverDirectCuSolverRf::~LinSolverDirectCuSolverRf()
@@ -25,11 +26,28 @@ namespace ReSolve
                                        vector_type* /* rhs */)
   {
     //remember - P and Q are generally CPU variables
+    // factorization data is stored in the handle. If function is called again, destroy the old handle to get rid of old data. 
+    if (setup_completed_) {
+      cusolverRfDestroy(handle_cusolverrf_);
+      cusolverRfCreate(&handle_cusolverrf_);
+    }
+
     int error_sum = 0;
     this->A_ = (matrix::Csr*) A;
     index_type n = A_->getNumRows();
-    mem_.allocateArrayOnDevice(&d_P_, n); 
-    mem_.allocateArrayOnDevice(&d_Q_, n);
+
+    if (d_P_ == nullptr){
+      mem_.allocateArrayOnDevice(&d_P_, n);
+    } 
+
+    if (d_Q_ == nullptr){
+      mem_.allocateArrayOnDevice(&d_Q_, n);
+    }
+
+    if (d_T_ != nullptr){
+      mem_.deleteOnDevice(d_T_);
+    }
+    
     mem_.allocateArrayOnDevice(&d_T_, n);
 
     mem_.copyArrayHostToDevice(d_P_, P, n);
@@ -68,6 +86,9 @@ namespace ReSolve
     const cusolverRfTriangularSolve_t solve_alg =
       CUSOLVERRF_TRIANGULAR_SOLVE_ALG1;  //  1- default, 2 or 3 // 1 causes error
     this->setAlgorithms(fact_alg, solve_alg);
+    
+    setup_completed_ = true;
+    
     return error_sum;
   }
 

--- a/resolve/LinSolverDirectCuSolverRf.hpp
+++ b/resolve/LinSolverDirectCuSolverRf.hpp
@@ -43,10 +43,11 @@ namespace ReSolve
       cusolverRfHandle_t handle_cusolverrf_;
       cusolverStatus_t status_cusolverrf_;
       
-      index_type* d_P_;
-      index_type* d_Q_;
-      real_type* d_T_;
-
+      index_type* d_P_{nullptr};
+      index_type* d_Q_{nullptr};
+      real_type* d_T_{nullptr};
+      bool setup_completed_{false};
+      
       MemoryHandler mem_; ///< Device memory manager object
   };
 }

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -55,10 +55,10 @@ namespace ReSolve
     if (Symbolic_ != nullptr) {
       klu_free_symbolic(&Symbolic_, &Common_);
     }
-
     Symbolic_ = klu_analyze(A_->getNumRows(), A_->getRowData(memory::HOST), A_->getColData(memory::HOST), &Common_) ;
 
     factors_extracted_ = false;
+    
     if (L_ != nullptr) {
       delete L_; 
       L_ = nullptr;

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -44,3 +44,8 @@ void FWHT_scaleByD(int n,
                    double* y);
 
 void FWHT(int M, int log2N, double* d_Data); 
+
+void vector_inf_norm(int n,  
+                     double* input,
+                     double * buffer, 
+                     double* result);

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -121,6 +121,7 @@ __global__ void massAxpy3_kernel(int N,
     i += (blockDim.x*gridDim.x);
   }
 }
+
 __global__ void matrixInfNormPart1(const int n, 
                                    const int nnz, 
                                    const int* a_ia,
@@ -130,7 +131,7 @@ __global__ void matrixInfNormPart1(const int n,
   // one thread per row, pass through rows
   // and sum
   // can be done through atomics
-  //\sum_{j=1}^m abs(a_{ij})
+  //\sum_{j=1}^m fabs(a_{ij})
 
   int idx = blockIdx.x*blockDim.x + threadIdx.x;
   while (idx < n) {
@@ -140,6 +141,76 @@ __global__ void matrixInfNormPart1(const int n,
     }
     result[idx] = sum;
     idx += (blockDim.x*gridDim.x);
+  }
+}
+
+__global__ void vectorInfNorm(const int n, 
+                              const double* input, 
+                              double* result)
+{
+
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+  volatile __shared__ double s_max[1024];
+  int t = threadIdx.x;
+  int bsize = blockDim.x;
+  double local_max = 0.0;
+  if (idx < n) {
+    local_max = fabs(input[idx]);
+  }
+
+  idx += (blockDim.x*gridDim.x);
+  
+  while (idx < n) {
+    local_max = fmax(fabs(input[idx]), local_max);
+    idx += (blockDim.x*gridDim.x);
+  }
+  s_max[t] = local_max;
+  __syncthreads();
+
+  // reduction
+
+  if (bsize >= 1024) {
+    if(t < 512) {
+      s_max[t] = fmax(s_max[t], s_max[t + 512]);
+    }
+    __syncthreads();
+  }
+  if (bsize >= 512) {
+    if(t < 256) {
+      s_max[t] = fmax(s_max[t], s_max[t + 256]);
+    }
+    __syncthreads();
+  }
+
+  if (bsize >= 256) {
+    if(t < 128) {
+      s_max[t] = fmax(s_max[t], s_max[t + 128]);
+    }
+    __syncthreads();
+  }
+
+  if (bsize >= 128) {
+    if(t < 64) {
+      s_max[t] = fmax(s_max[t], s_max[t + 64]);
+    }
+    __syncthreads();
+  }
+  //unroll for last warp
+  if (t < 64) {
+    s_max[t] = fmax(s_max[t], s_max[t + 64]);
+    s_max[t] = fmax(s_max[t], s_max[t + 32]);
+    s_max[t] = fmax(s_max[t], s_max[t + 16]);
+    s_max[t] = fmax(s_max[t], s_max[t + 8]);
+    s_max[t] = fmax(s_max[t], s_max[t + 4]);
+    s_max[t] = fmax(s_max[t], s_max[t + 2]);
+    s_max[t] = fmax(s_max[t], s_max[t + 1]);
+
+  }
+  if (t == 0) {
+    int bid = blockIdx.x;
+    int gid = gridDim.x;
+    result[blockIdx.x] = s_max[0];
   }
 }
 
@@ -362,6 +433,18 @@ void matrix_row_sums(int n,
                      double* result)
 {
   hipLaunchKernelGGL(matrixInfNormPart1, dim3(1000), dim3(1024), 0, 0, n, nnz, a_ia, a_val, result);
+}
+
+
+void vector_inf_norm(int n,  
+                     double* input,
+                     double* buffer, 
+                     double* result)
+{
+  hipLaunchKernelGGL(vectorInfNorm, dim3(1024), dim3(1024), 0, 0, n, input, buffer);
+  hipDeviceSynchronize();
+  hipLaunchKernelGGL(vectorInfNorm, dim3(1), dim3(1024), 0, 0, 1024, buffer, buffer);
+  hipMemcpy(result, buffer, sizeof(double) * 1, hipMemcpyDeviceToHost);
 }
 
 void permuteVectorP(int n, 

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -302,6 +302,20 @@ namespace ReSolve {
     }
   }
 
+  int MatrixHandler::matrixInfNorm(matrix::Sparse *A, real_type* norm, std::string memspace) {
+
+    if (memspace == "cuda" ) {
+      return cudaImpl_->matrixInfNorm(A, norm);
+    } else if (memspace == "cpu") {
+      return cpuImpl_->matrixInfNorm(A, norm);
+    } else if (memspace == "hip") {
+      return hipImpl_->matrixInfNorm(A, norm);
+    } else {
+        out::error() << "Support for device " << memspace << " not implemented (yet)" << std::endl;
+        return 1;
+    }
+
+  }
 
   int MatrixHandler::csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr, std::string memspace)
   {

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -63,7 +63,7 @@ namespace ReSolve {
                  const real_type* beta,
                  std::string matrix_type,
                  std::string memspace);
-      int Matrix1Norm(matrix::Sparse *A, real_type* norm);
+      int matrixInfNorm(matrix::Sparse *A, real_type* norm, std::string memspace);
       void setValuesChanged(bool toWhat, std::string memspace); 
     
     private: 

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -79,9 +79,27 @@ namespace ReSolve {
     }
   }
 
-  int MatrixHandlerCpu::Matrix1Norm(matrix::Sparse* /* A */, real_type* /* norm */)
+  int MatrixHandlerCpu::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
-    return -1;
+    real_type sum, nrm;
+    index_type i, j;
+
+    for (i = 0; i < A->getNumRows(); ++i) {
+      sum = 0.0; 
+      for (j  = A->getRowData(memory::HOST)[i]; j < A->getRowData(memory::HOST)[i+1]; ++j) {
+        sum += std::abs(A->getValues(memory::HOST)[j]);
+      }
+      if (i == 0) {
+        nrm = sum;
+      } else {
+        if (sum > nrm)
+        {
+          nrm = sum;
+        } 
+      }
+    }
+    *norm = nrm;
+    return 0;
   }
 
   /**

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -43,7 +43,7 @@ namespace ReSolve {
                  const real_type* alpha,
                  const real_type* beta,
                  std::string matrix_type);
-      virtual int Matrix1Norm(matrix::Sparse *A, real_type* norm);
+      virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm);
       void setValuesChanged(bool isValuesChanged); 
     
     private: 

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -41,7 +41,7 @@ namespace ReSolve {
                  const real_type* alpha,
                  const real_type* beta,
                  std::string matrix_type);
-      virtual int Matrix1Norm(matrix::Sparse *A, real_type* norm);
+      virtual int matrixInfNorm(matrix::Sparse* A, real_type* norm);
       void setValuesChanged(bool isValuesChanged); 
     
     private: 

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -6,6 +6,7 @@
 #include <resolve/matrix/Csc.hpp>
 #include <resolve/matrix/Csr.hpp>
 #include <resolve/workspace/LinAlgWorkspaceHIP.hpp>
+#include <resolve/hip/hipKernels.h>
 #include "MatrixHandlerHip.hpp"
 
 namespace ReSolve {
@@ -103,9 +104,41 @@ namespace ReSolve {
     }
   }
 
-  int MatrixHandlerHip::Matrix1Norm(matrix::Sparse* /* A */, real_type* /* norm */)
+  int MatrixHandlerHip::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
-    return -1;
+    // we assume A is in CSR format
+    real_type* d_r = workspace_->getDr();
+    index_type d_r_size = workspace_->getDrSize();
+    
+    if (d_r_size != A->getNumRows()) {
+      if (d_r_size != 0) {
+        mem_.deleteOnDevice(d_r);
+      }
+      mem_.allocateArrayOnDevice(&d_r, A->getNumRows());
+      workspace_->setDrSize(A->getNumRows());
+      workspace_->setDr(d_r);
+    }
+    
+    if (workspace_->getNormBufferState() == false) { // not allocated  
+      real_type* buffer;
+      mem_.allocateArrayOnDevice(&buffer, 1024);
+      workspace_->setNormBuffer(buffer);
+      workspace_->setNormBufferState(true);
+    }
+
+    mem_.deviceSynchronize();
+    matrix_row_sums(A->getNumRows(),
+                    A->getNnzExpanded(),
+                    A->getRowData(memory::DEVICE),
+                    A->getValues(memory::DEVICE),
+                    d_r);
+    mem_.deviceSynchronize();
+
+    vector_inf_norm(A->getNumRows(),  
+                    d_r, 
+                    workspace_->getNormBuffer(),
+                    norm);
+    return 0;
   }
 
   int MatrixHandlerHip::csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr)

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -44,7 +44,7 @@ namespace ReSolve {
                          const real_type* beta,
                          std::string matrix_type);
       
-      virtual int Matrix1Norm(matrix::Sparse *A, real_type* norm);
+      virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm);
       
       void setValuesChanged(bool isValuesChanged); 
     

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -42,7 +42,7 @@ namespace ReSolve {
                          const real_type* alpha,
                          const real_type* beta,
                          std::string matrix_type) = 0;
-      virtual int Matrix1Norm(matrix::Sparse* A, real_type* norm) = 0;
+      virtual int matrixInfNorm(matrix::Sparse* A, real_type* norm) = 0;
 
       virtual void setValuesChanged(bool isValuesChanged) = 0;    
   };

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -111,7 +111,7 @@ namespace ReSolve {
    * 
    * @param[in] alpha The constant
    * @param[in,out] x The vector
-   * @param memspace string containg memspace (cpu or cuda or hip)
+   * @param memspace[in] string containg memspace (cpu or cuda or hip)
    * 
    */
   void VectorHandler::scal(const real_type* alpha, vector::Vector* x, std::string memspace)
@@ -129,6 +129,30 @@ namespace ReSolve {
     }
   }
 
+  /** 
+   * @brief compute infinity norm of a vector (i.e., find an entry with largest absolute value)
+   * 
+   * @param[in] The vector
+   * @param memspace[in] string containg memspace (cpu or cuda or hip)
+   *
+   * @return infinity norm (real number) of _x_
+   * 
+   */
+  real_type VectorHandler::infNorm(vector::Vector* x, std::string memspace)
+  {
+    if (memspace == "cuda" ) {
+      return cudaImpl_->infNorm(x);
+    } else if (memspace == "hip") { 
+      return hipImpl_->infNorm(x);
+    } else {
+      if (memspace == "cpu") {
+        return cpuImpl_->infNorm(x);
+      } else {      
+        out::error() << "Not implemented (yet)" << std::endl;
+        return -1.0; // note inf norm cannot be negative!
+      }  
+    }
+  }
   /** 
    * @brief axpy i.e, y = alpha*x+y where alpha is a constant
    * 

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -133,7 +133,7 @@ namespace ReSolve {
    * @brief compute infinity norm of a vector (i.e., find an entry with largest absolute value)
    * 
    * @param[in] The vector
-   * @param memspace[in] string containg memspace (cpu or cuda or hip)
+   * @param[in] memspace string containg memspace (cpu or cuda or hip)
    *
    * @return infinity norm (real number) of _x_
    * 

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -54,7 +54,14 @@ namespace ReSolve { //namespace vector {
                 vector::Vector* y,
                 vector::Vector* x,
                 std::string memspace);
+
+      /** infNorm:
+       * Returns infinity norm of a vector (i.e., entry with max abs value)
+       */ 
+      real_type infNorm(vector::Vector* x, std::string memspace);
+   
     private:
+      
       VectorHandlerImpl*  cpuImpl_{nullptr};
       VectorHandlerImpl* cudaImpl_{nullptr};
       VectorHandlerImpl*  hipImpl_{nullptr};

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include <resolve/utilities/logger/Logger.hpp>
 #include <resolve/cuda/cudaKernels.h>
 #include <resolve/vector/Vector.hpp>
@@ -40,7 +38,6 @@ namespace ReSolve {
    * 
    * @param[in] x The first vector
    * @param[in] y The second vector
-   * @param[in] memspace String containg memspace (cpu or cuda)
    * 
    * @return dot product (real number) of _x_ and _y_
    */
@@ -67,7 +64,6 @@ namespace ReSolve {
    * 
    * @param[in] alpha The constant
    * @param[in,out] x The vector
-   * @param memspace string containg memspace (cpu or cuda)
    * 
    */
   void VectorHandlerCpu::scal(const real_type* alpha, vector::Vector* x)
@@ -78,6 +74,28 @@ namespace ReSolve {
       x_data[i] *= (*alpha);
     }
   }
+  
+  /** 
+   * @brief compute infinity norm of a vector (i.e., find an entry with largest absolute value)
+   * 
+   * @param[in] The vector
+   *
+   * @return infinity norm (real number) of _x_
+   * 
+   */
+  real_type VectorHandlerCpu::infNorm(vector::Vector* x)
+  {
+    real_type* x_data = x->getData(memory::HOST);
+    real_type  vecmax = std::abs(x_data[0]);
+    real_type v;
+    for (int i = 1; i < x->getSize(); ++i){
+     v = std::abs(x_data[i]);
+     if (v > vecmax){
+      vecmax = v;
+     }
+    }
+    return vecmax;
+  }
 
   /** 
    * @brief axpy i.e, y = alpha*x+y where alpha is a constant
@@ -85,7 +103,6 @@ namespace ReSolve {
    * @param[in] alpha The constant
    * @param[in] x The first vector
    * @param[in,out] y The second vector (result is return in y)
-   * @param[in]  memspace String containg memspace (cpu or cuda)
    * 
    */
   void VectorHandlerCpu::axpy(const  real_type* alpha, vector::Vector* x, vector::Vector* y)
@@ -110,7 +127,6 @@ namespace ReSolve {
    * @param[in] V Multivector containing the matrix, organized columnwise
    * @param[in] y Vector, k x 1 if N and n x 1 if T
    * @param[in,out] x Vector, n x 1 if N and k x 1 if T
-   * @param[in] memspace  cpu or cuda (for now)
    *
    * @pre   V is stored colum-wise, _n_ > 0, _k_ > 0
    * 
@@ -134,7 +150,6 @@ namespace ReSolve {
    * @param[in] alpha vector size k x 1
    * @param[in] x (multi)vector size size x k
    * @param[in,out] y vector size size x 1 (this is where the result is stored)
-   * @param[in] memspace string containg memspace (cpu or cuda)
    *
    * @pre   _k_ > 0, _size_ > 0, _size_ = x->getSize()
    *
@@ -153,7 +168,6 @@ namespace ReSolve {
    * @param[in] k Number of vectors in V
    * @param[in] x Multivector; 2 vectors size n x 1 each
    * @param[out] res Multivector; 2 vectors size k x 1 each (result is returned in res)
-   * @param[in] memspace String containg memspace (cpu or cuda)
    *
    * @pre   _size_ > 0, _k_ > 0, size = x->getSize(), _res_ needs to be allocated
    *

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -28,6 +28,9 @@ namespace ReSolve { //namespace vector {
 
       //scal = alpha * x
       virtual void scal(const real_type* alpha, vector::Vector* x);
+      
+      //vector infinity norm
+      virtual real_type infNorm(vector::Vector* x);
 
       //mass axpy: x*alpha + y where x is [n x k] and alpha is [k x 1]; x is stored columnwise
       virtual void massAxpy(index_type size, vector::Vector* alpha, index_type k, vector::Vector* x, vector::Vector* y);

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -6,6 +6,7 @@
 #include <resolve/workspace/LinAlgWorkspace.hpp>
 #include <resolve/vector/VectorHandlerImpl.hpp>
 #include "VectorHandlerCuda.hpp"
+#include <resolve/cusolver_defs.hpp> // needed for inf nrm
 
 namespace ReSolve {
   using out = io::Logger;
@@ -40,7 +41,6 @@ namespace ReSolve {
    * 
    * @param[in] x The first vector
    * @param[in] y The second vector
-   * @param[in] memspace String containg memspace (cpu or cuda)
    * 
    * @return dot product (real number) of _x_ and _y_
    */
@@ -60,7 +60,6 @@ namespace ReSolve {
    * 
    * @param[in] alpha The constant
    * @param[in,out] x The vector
-   * @param memspace string containg memspace (cpu or cuda)
    * 
    */
   void VectorHandlerCuda::scal(const real_type* alpha, vector::Vector* x)
@@ -74,12 +73,37 @@ namespace ReSolve {
   }
 
   /** 
+   * @brief compute infinity norm of a vector (i.e., find an entry with largest absolute value)
+   * 
+   * @param[in] The vector
+   *
+   * @return infinity norm (real number) of _x_
+   * 
+   */
+  real_type VectorHandlerCuda::infNorm(vector::Vector* x)
+  {
+
+    if (workspace_->getNormBufferState() == false) { // not allocated  
+      real_type* buffer;
+      mem_.allocateArrayOnDevice(&buffer, 1024);
+      workspace_->setNormBuffer(buffer);
+      workspace_->setNormBufferState(true);
+    }
+    real_type norm;
+    int status = cusolverSpDnrminf(workspace_->getCusolverSpHandle(),
+                                   x->getSize(),
+                                   x->getData(memory::DEVICE),
+                                   &norm,
+                                   workspace_->getNormBuffer()  /* at least 8192 bytes */);
+    return norm;
+  }
+  
+  /** 
    * @brief axpy i.e, y = alpha*x+y where alpha is a constant
    * 
    * @param[in] alpha The constant
    * @param[in] x The first vector
    * @param[in,out] y The second vector (result is return in y)
-   * @param[in]  memspace String containg memspace (cpu or cuda)
    * 
    */
   void VectorHandlerCuda::axpy(const  real_type* alpha, vector::Vector* x, vector::Vector* y)
@@ -108,7 +132,6 @@ namespace ReSolve {
    * @param[in] V Multivector containing the matrix, organized columnwise
    * @param[in] y Vector, k x 1 if N and n x 1 if T
    * @param[in,out] x Vector, n x 1 if N and k x 1 if T
-   * @param[in] memspace  cpu or cuda (for now)
    *
    * @pre   V is stored colum-wise, _n_ > 0, _k_ > 0
    * 
@@ -162,7 +185,6 @@ namespace ReSolve {
    * @param[in] alpha vector size k x 1
    * @param[in] x (multi)vector size size x k
    * @param[in,out] y vector size size x 1 (this is where the result is stored)
-   * @param[in] memspace string containg memspace (cpu or cuda)
    *
    * @pre   _k_ > 0, _size_ > 0, _size_ = x->getSize()
    *
@@ -202,7 +224,6 @@ namespace ReSolve {
    * @param[in] k Number of vectors in V
    * @param[in] x Multivector; 2 vectors size n x 1 each
    * @param[out] res Multivector; 2 vectors size k x 1 each (result is returned in res)
-   * @param[in] memspace String containg memspace (cpu or cuda)
    *
    * @pre   _size_ > 0, _k_ > 0, size = x->getSize(), _res_ needs to be allocated
    *

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -90,11 +90,15 @@ namespace ReSolve {
       workspace_->setNormBufferState(true);
     }
     real_type norm;
+    // TODO: Shouldn't the return type be cusolverStatus_t ?
     int status = cusolverSpDnrminf(workspace_->getCusolverSpHandle(),
                                    x->getSize(),
                                    x->getData(memory::DEVICE),
                                    &norm,
                                    workspace_->getNormBuffer()  /* at least 8192 bytes */);
+    if (status) {
+      out::error() << "cusolverSpDnrminf failed with error code " << status << "\n";
+    }
     return norm;
   }
   

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -28,6 +28,9 @@ namespace ReSolve { //namespace vector {
 
       //scal = alpha * x
       virtual void scal(const real_type* alpha, vector::Vector* x);
+      
+      //vector infinity norm
+      virtual real_type infNorm(vector::Vector* x);
 
       //mass axpy: x*alpha + y where x is [n x k] and alpha is [k x 1]; x is stored columnwise
       virtual void massAxpy(index_type size, vector::Vector* alpha, index_type k, vector::Vector* x, vector::Vector* y);
@@ -51,6 +54,7 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* y,
                         vector::Vector* x);
     private:
+      MemoryHandler mem_; ///< Device memory manager object
       LinAlgWorkspaceCUDA* workspace_;
   };
 

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -40,7 +40,6 @@ namespace ReSolve {
    * 
    * @param[in] x The first vector
    * @param[in] y The second vector
-   * @param[in] memspace String containg memspace (cpu or hip)
    * 
    * @return dot product (real number) of _x_ and _y_
    */
@@ -61,7 +60,6 @@ namespace ReSolve {
    * 
    * @param[in] alpha The constant
    * @param[in,out] x The vector
-   * @param memspace string containg memspace (cpu or hip)
    * 
    */
   void VectorHandlerHip::scal(const real_type* alpha, vector::Vector* x)
@@ -76,12 +74,36 @@ namespace ReSolve {
   }
 
   /** 
+   * @brief compute infinity norm of a vector (i.e., find an entry with largest absolute value)
+   * 
+   * @param[in] The vector
+   *
+   * @return infinity norm (real number) of _x_
+   * 
+   */
+  real_type VectorHandlerHip::infNorm(vector::Vector* x)
+  {
+
+    if (workspace_->getNormBufferState() == false) { // not allocated  
+      real_type* buffer;
+      mem_.allocateArrayOnDevice(&buffer, 1024);
+      workspace_->setNormBuffer(buffer);
+      workspace_->setNormBufferState(true);
+    }
+    real_type norm;
+    vector_inf_norm(x->getSize(),  
+                    x->getData(memory::DEVICE), 
+                    workspace_->getNormBuffer(),
+                    &norm);
+    return norm;
+  }
+
+  /** 
    * @brief axpy i.e, y = alpha*x+y where alpha is a constant
    * 
    * @param[in] alpha The constant
    * @param[in] x The first vector
    * @param[in,out] y The second vector (result is return in y)
-   * @param[in]  memspace String containg memspace (cpu or hip)
    * 
    */
   void VectorHandlerHip::axpy(const  real_type* alpha, vector::Vector* x, vector::Vector* y)
@@ -111,7 +133,6 @@ namespace ReSolve {
    * @param[in] V Multivector containing the matrix, organized columnwise
    * @param[in] y Vector, k x 1 if N and n x 1 if T
    * @param[in,out] x Vector, n x 1 if N and k x 1 if T
-   * @param[in] memspace  cpu or hip (for now)
    *
    * @pre   V is stored colum-wise, _n_ > 0, _k_ > 0
    * 
@@ -166,7 +187,6 @@ namespace ReSolve {
    * @param[in] alpha vector size k x 1
    * @param[in] x (multi)vector size size x k
    * @param[in,out] y vector size size x 1 (this is where the result is stored)
-   * @param[in] memspace string containg memspace (cpu or hip)
    *
    * @pre   _k_ > 0, _size_ > 0, _size_ = x->getSize()
    *
@@ -208,7 +228,6 @@ namespace ReSolve {
    * @param[in] k Number of vectors in V
    * @param[in] x Multivector; 2 vectors size n x 1 each
    * @param[out] res Multivector; 2 vectors size k x 1 each (result is returned in res)
-   * @param[in] memspace String containg memspace (cpu or hip)
    *
    * @pre   _size_ > 0, _k_ > 0, size = x->getSize(), _res_ needs to be allocated
    *

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -28,6 +28,9 @@ namespace ReSolve { //namespace vector {
 
       //scal = alpha * x
       virtual void scal(const real_type* alpha, vector::Vector* x);
+      
+      //vector infinity norm
+      virtual real_type infNorm(vector::Vector* x);
 
       //mass axpy: x*alpha + y where x is [n x k] and alpha is [k x 1]; x is stored columnwise
       virtual void massAxpy(index_type size, vector::Vector* alpha, index_type k, vector::Vector* x, vector::Vector* y);
@@ -52,6 +55,7 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* x);
     private:
       LinAlgWorkspaceHIP* workspace_;
+      MemoryHandler mem_; ///< Device memory manager object
   };
 
 } //} // namespace ReSolve::vector

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -30,6 +30,9 @@ namespace ReSolve
 
       //scal = alpha * x
       virtual void scal(const real_type* alpha, vector::Vector* x) = 0;
+      
+      //infNorm = ||x||_\infty
+      virtual real_type infNorm(vector::Vector* x) = 0;
 
       //mass axpy: x*alpha + y where x is [n x k] and alpha is [k x 1]; x is stored columnwise
       virtual void massAxpy(index_type size, vector::Vector* alpha, index_type k, vector::Vector* x, vector::Vector* y) = 0;

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -9,14 +9,17 @@ namespace ReSolve
     handle_cublas_     = nullptr;
     buffer_spmv_       = nullptr;
     buffer_1norm_      = nullptr;    
-
+    d_r_               = nullptr;
+    d_r_size_          = 0; 
     matvec_setup_done_ = false;
+    norm_buffer_ready_ = false;
   }
 
   LinAlgWorkspaceCUDA::~LinAlgWorkspaceCUDA()
   {
     if (buffer_spmv_ != nullptr)  mem_.deleteOnDevice(buffer_spmv_);
-    if (buffer_1norm_ != nullptr) mem_.deleteOnDevice(buffer_1norm_);
+    if (d_r_size_ != 0)  mem_.deleteOnDevice(d_r_);
+    if (norm_buffer_ready_) mem_.deleteOnDevice(buffer_1norm_);
     cusparseDestroy(handle_cusparse_);
     cusolverSpDestroy(handle_cusolversp_);
     cublasDestroy(handle_cublas_);
@@ -32,6 +35,11 @@ namespace ReSolve
   {
     return buffer_1norm_;
   }
+  
+  bool  LinAlgWorkspaceCUDA::getNormBufferState()
+  {
+    return norm_buffer_ready_;
+  }
 
   void LinAlgWorkspaceCUDA::setSpmvBuffer(void* buffer)
   {
@@ -42,6 +50,11 @@ namespace ReSolve
   {
     buffer_1norm_ =  buffer;
   }
+  
+  void LinAlgWorkspaceCUDA::setNormBufferState(bool r)
+  {
+    norm_buffer_ready_ = r;;
+  }
 
   cusparseHandle_t LinAlgWorkspaceCUDA::getCusparseHandle()
   {
@@ -51,6 +64,16 @@ namespace ReSolve
   void LinAlgWorkspaceCUDA::setCusparseHandle(cusparseHandle_t handle)
   {
     handle_cusparse_ = handle;
+  }
+
+  void LinAlgWorkspaceCUDA::setDrSize(index_type new_sz)
+  {
+    d_r_size_ = new_sz;
+  }
+  
+  void LinAlgWorkspaceCUDA::setDr(double* new_dr)
+  {
+    d_r_ = new_dr;
   }
 
   cublasHandle_t LinAlgWorkspaceCUDA::getCublasHandle()
@@ -93,6 +116,15 @@ namespace ReSolve
     return vec_y_;
   }
 
+  index_type  LinAlgWorkspaceCUDA::getDrSize()
+  {
+    return d_r_size_;
+  }
+
+  real_type*  LinAlgWorkspaceCUDA::getDr()
+  {
+    return d_r_;
+  }
   bool LinAlgWorkspaceCUDA::matvecSetup()
   {
     return matvec_setup_done_;

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <resolve/Common.hpp>
+
 #include "cublas_v2.h"
 #include "cusparse.h"
 #include "cusolverSp.h"
@@ -27,11 +29,18 @@ namespace ReSolve
       cusparseSpMatDescr_t getSpmvMatrixDescriptor();
       cusparseDnVecDescr_t getVecX();
       cusparseDnVecDescr_t  getVecY();
+      index_type getDrSize();
+      real_type* getDr();
+      bool getNormBufferState();
+
 
       void setCublasHandle(cublasHandle_t handle);
       void setCusolverSpHandle( cusolverSpHandle_t handle);
       void setCusparseHandle(cusparseHandle_t handle);
       void setSpmvMatrixDescriptor(cusparseSpMatDescr_t mat);
+      void setDrSize(index_type new_sz);
+      void setDr(real_type* new_dr);
+      void setNormBufferState(bool r);
 
       void initializeHandles();
 
@@ -48,14 +57,19 @@ namespace ReSolve
       cusparseSpMatDescr_t mat_A_; 
 
       //vector descriptors
-      cusparseDnVecDescr_t vec_x_, vec_y_;
+      cusparseDnVecDescr_t vec_x_;
+      cusparseDnVecDescr_t vec_y_;
 
       //buffers
-      void* buffer_spmv_;
-      void* buffer_1norm_;
+      void* buffer_spmv_{nullptr};
+      void* buffer_1norm_{nullptr};
 
-      bool matvec_setup_done_; //check if setup is done for matvec i.e. if buffer is allocated, csr structure is set etc.
-
+      bool matvec_setup_done_{false}; //check if setup is done for matvec i.e. if buffer is allocated, csr structure is set etc.
+      
+      real_type* d_r_{nullptr}; // needed for one-norm
+      index_type d_r_size_{0};
+      bool norm_buffer_ready_{false};// to track if allocated 
+    
       MemoryHandler mem_;
   };
 

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -8,6 +8,10 @@ namespace ReSolve
     handle_rocblas_     = nullptr;
 
     matvec_setup_done_ = false;
+    d_r_               = nullptr;
+    d_r_size_          = 0; 
+    norm_buffer_       = nullptr;
+    norm_buffer_ready_ = false;
   }
 
   LinAlgWorkspaceHIP::~LinAlgWorkspaceHIP()
@@ -15,6 +19,8 @@ namespace ReSolve
     rocsparse_destroy_handle(handle_rocsparse_);
     rocblas_destroy_handle(handle_rocblas_);
     rocsparse_destroy_mat_descr(mat_A_);
+    if (d_r_size_ != 0)  mem_.deleteOnDevice(d_r_);
+    if (norm_buffer_ready_ == true)  mem_.deleteOnDevice(norm_buffer_);
   }
 
   rocsparse_handle LinAlgWorkspaceHIP::getRocsparseHandle()
@@ -57,6 +63,26 @@ namespace ReSolve
     info_A_ = info;
   }
 
+  void LinAlgWorkspaceHIP::setDrSize(index_type new_sz)
+  {
+    d_r_size_ = new_sz;
+  }
+  
+  void LinAlgWorkspaceHIP::setDr(double* new_dr)
+  {
+    d_r_ = new_dr;
+  }
+  
+  void LinAlgWorkspaceHIP::setNormBuffer(double* nb)
+  {
+    norm_buffer_ = nb;
+  }
+  
+  void LinAlgWorkspaceHIP::setNormBufferState(bool r)
+  {
+    norm_buffer_ready_ = r;;
+  }
+  
   bool LinAlgWorkspaceHIP::matvecSetup()
   {
     return matvec_setup_done_;
@@ -71,5 +97,25 @@ namespace ReSolve
   {
     rocsparse_create_handle(&handle_rocsparse_);
     rocblas_create_handle(&handle_rocblas_);
+  }
+  
+  index_type  LinAlgWorkspaceHIP::getDrSize()
+  {
+    return d_r_size_;
+  }
+
+  real_type*  LinAlgWorkspaceHIP::getDr()
+  {
+    return d_r_;
+  }
+  
+  bool  LinAlgWorkspaceHIP::getNormBufferState()
+  {
+    return norm_buffer_ready_;
+  }
+  
+  real_type*  LinAlgWorkspaceHIP::getNormBuffer()
+  {
+    return norm_buffer_;
   }
 } // namespace ReSolve

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <resolve/Common.hpp>
+
 #include <rocsparse/rocsparse.h>
 #include <rocblas/rocblas.h>
 #include <hip/hip_runtime.h>
@@ -18,6 +20,10 @@ namespace ReSolve
       rocsparse_handle getRocsparseHandle();      
       rocsparse_mat_descr getSpmvMatrixDescriptor();
       rocsparse_mat_info getSpmvMatrixInfo();
+      index_type getDrSize();
+      real_type* getDr();
+      real_type* getNormBuffer();
+      bool getNormBufferState();
 
       void setRocblasHandle(rocblas_handle handle);
       void setRocsparseHandle(rocsparse_handle handle);
@@ -28,6 +34,12 @@ namespace ReSolve
 
       bool matvecSetup();
       void matvecSetupDone();
+      
+      void setDrSize(index_type new_sz);
+      void setDr(real_type* new_dr);
+      void setNormBuffer(real_type* nb);
+      void setNormBufferState(bool r);
+      
 
     private:
       //handles
@@ -41,12 +53,16 @@ namespace ReSolve
 
       //buffers
       // there is no buffer needed in matvec
-      bool matvec_setup_done_; //check if setup is done for matvec (note: no buffer but there is analysis)
+      bool matvec_setup_done_{false}; //check if setup is done for matvec (note: no buffer but there is analysis)
 
       //info - but we need info
-      rocsparse_mat_info  info_A_;
-
-      // MemoryHandler mem_; ///< Memory handler not needed for now
+      rocsparse_mat_info info_A_;
+      
+      real_type* d_r_{nullptr}; // needed for inf-norm
+      real_type* norm_buffer_{nullptr}; // needed for inf-norm
+      index_type d_r_size_{0};
+      bool norm_buffer_ready_{false};// to track if allocated 
+      MemoryHandler mem_; ///< Memory handler not needed for now
   };
 
 } // namespace ReSolve

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -31,11 +31,19 @@ public:
     return status.report(__func__);
   }
 
-  TestOutcome matrixOneNorm()
+  TestOutcome matrixInfNorm(index_type N)
   {
     TestStatus status;
-    status.skipTest();
+
+    ReSolve::MatrixHandler* handler = createMatrixHandler();
+
+    matrix::Csr* A = createCsrMatrix(N, memspace_);
+    real_type norm;
+    handler->matrixInfNorm(A, &norm, memspace_);
+    status *= (norm == 30.0); 
     
+    delete handler;
+    delete A;
     return status.report(__func__);
   }
 

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -14,7 +14,7 @@ int main(int, char**)
     ReSolve::tests::MatrixHandlerTests test("cpu");
       
     result += test.matrixHandlerConstructor();
-    result += test.matrixOneNorm();
+    result += test.matrixInfNorm(10000);
     result += test.matVec(50);
 
     std::cout << "\n";
@@ -26,7 +26,7 @@ int main(int, char**)
     ReSolve::tests::MatrixHandlerTests test("cuda");
 
     result += test.matrixHandlerConstructor();
-    result += test.matrixOneNorm();
+    result += test.matrixInfNorm(1000000);
     result += test.matVec(50);
 
     std::cout << "\n";
@@ -39,7 +39,7 @@ int main(int, char**)
     ReSolve::tests::MatrixHandlerTests test("hip");
 
     result += test.matrixHandlerConstructor();
-    result += test.matrixOneNorm();
+    result += test.matrixInfNorm(1000000);
     result += test.matVec(50);
 
     std::cout << "\n";

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -20,8 +20,8 @@ namespace ReSolve {
     {
       public:       
         VectorHandlerTests(std::string memspace) : memspace_(memspace) 
-        {
-        }
+      {
+      }
 
         virtual ~VectorHandlerTests()
         {
@@ -31,6 +31,40 @@ namespace ReSolve {
         {
           TestStatus status;
           status.skipTest();
+
+          return status.report(__func__);
+        }
+
+        TestOutcome infNorm(index_type N)
+        {
+          TestStatus status;
+          ReSolve::memory::MemorySpace ms;
+
+          if (memspace_ == "cpu")
+            ms = memory::HOST;
+          else
+            ms = memory::DEVICE;
+
+          ReSolve::VectorHandler* handler = createVectorHandler();
+
+          vector::Vector* x = new vector::Vector(N);
+
+          real_type* data = new real_type[N];
+          for (int i = 0; i < N; ++i) {
+            data[i] = 0.1 * (real_type) i;
+          }
+          x->update(data, memory::HOST, ms);
+
+          real_type ans = handler->infNorm(x, memspace_);
+          bool st = true;
+          if (ans != (real_type) (N - 1) * 0.1) {
+            st = false;
+            printf("the wrong answer is %f expecting %f \n", ans, (real_type) N);
+          } 
+          status *= st;
+
+          delete handler;
+          delete x;
 
           return status.report(__func__);
         }
@@ -147,7 +181,7 @@ namespace ReSolve {
             ms = memory::DEVICE;
 
           ReSolve::VectorHandler* handler = createVectorHandler();
-          
+
           vector::Vector* x =  new vector::Vector(N, K);
           vector::Vector* y =  new vector::Vector(N);
           vector::Vector* alpha = new vector::Vector(K);;
@@ -172,7 +206,7 @@ namespace ReSolve {
 
           handler->massAxpy(N, alpha, K, x, y, memspace_);
           status *= verifyAnswer(y, 2.0 - res, memspace_);
-         
+
           delete handler;
           delete x;
           delete y;
@@ -192,18 +226,18 @@ namespace ReSolve {
             ms = memory::DEVICE;
 
           ReSolve::VectorHandler* handler = createVectorHandler();
-          
+
           vector::Vector* x =  new vector::Vector(N, K);
           vector::Vector* y =  new vector::Vector(N, 2);
           vector::Vector* res = new vector::Vector(K, 2);
           x->allocate(ms);
           y->allocate(ms);
           res->allocate(ms);
-          
+
           x->setToConst(1.0, ms);
           y->setToConst(-1.0, ms);
           handler->massDot2Vec(N, x, K, y, res, memspace_);
-          
+
           status *= verifyAnswer(res, (-1.0) * (real_type) N, memspace_);
 
           delete handler;
@@ -231,7 +265,7 @@ namespace ReSolve {
           // for the test with TRANSPOSE
           vector::Vector* yT = new vector::Vector(N);
           vector::Vector* xT = new vector::Vector(K);
-          
+
           V->allocate(ms);
           yN->allocate(ms);
           xN->allocate(ms);
@@ -243,7 +277,7 @@ namespace ReSolve {
           xN->setToConst(.5, ms);
           yT->setToConst(-1.0, ms);
           xT->setToConst(.5, ms);
-          
+
           real_type alpha = -1.0;
           real_type beta = 1.0;
           handler->gemv("N", N, K, &alpha, &beta, V, yN, xN, memspace_);

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -15,6 +15,7 @@ int main(int, char**)
     result += test.dot(50);
     result += test.axpy(50);
     result += test.scal(50);
+    result += test.infNorm(50);
 
     std::cout << "\n";
   }
@@ -32,6 +33,7 @@ int main(int, char**)
     result += test.massAxpy(1000, 30);
     result += test.massDot(100, 10);
     result += test.massDot(1000, 30);
+    result += test.infNorm(1000);
 
     std::cout << "\n";
   }
@@ -50,6 +52,7 @@ int main(int, char**)
     result += test.massAxpy(1000, 300);
     result += test.massDot(100, 10);
     result += test.massDot(1000, 30);
+    result += test.infNorm(1000);
 
     std::cout << "\n";
   }


### PR DESCRIPTION
Matrix inf norm commonly appears in error evaluation formulae (i.e. NSR, etc). I added Cuda, CPU and HIP versions. It is not a part of standard BLAS.

Matrix Inf norm is max of the sum of rows (with abs value).
This is done as 3 kernels:
1) Sum rows, store in `d_r` (buffer).
2) Reduce `d_r` to another buffer (blockwise).
3) Second pass of reduction - reduce to a variable.
It is pretty straightforward to do on CPU.

There is a `cusolverSp` function that does 2+3 (which I am using). The rest I implemented myself. 
Should be easy to add unit test (?) Can add before merging. 