### PR TITLE
Use memspace as parameter consistently in FGMRES classes.

### DIFF
--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -110,212 +110,212 @@ namespace ReSolve
     return 0;
   }
 
-  //this always happen on the GPU
   int GramSchmidt::orthogonalize(index_type n, vector::Vector* V, real_type* H, index_type i, memory::MemorySpace memspace)
   {
     using namespace constants;
 
-    if (memspace == memory::DEVICE) {
-
-      double t;
-      double s;
-
-      switch (variant_){
-        case mgs: 
-
-          vec_w_->setData(V->getVectorData(i + 1, memory::DEVICE), memory::DEVICE);
-          for(int j = 0; j <= i; ++j) {
-            t = 0.0;
-            vec_v_->setData( V->getVectorData(j, memory::DEVICE), memory::DEVICE);
-            t = vector_handler_->dot(vec_v_, vec_w_, memspace);  
-            H[ idxmap(i, j, num_vecs_ + 1) ] = t; 
-            t *= -1.0;
-            vector_handler_->axpy(&t, vec_v_, vec_w_, memspace);  
-          }
-          t = 0.0;
-          t = vector_handler_->dot(vec_w_, vec_w_, memspace);
-          //set the last entry in Hessenberg matrix
-          t = sqrt(t);
-          H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t; 
-          if(fabs(t) > EPSILON) {
-            t = 1.0/t;
-            vector_handler_->scal(&t, vec_w_, memspace);  
-          } else {
-            assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
-            return -1;
-          }
-          break;
-        case cgs2:
-
-          vec_v_->setData(V->getVectorData(i + 1, memory::DEVICE), memory::DEVICE);
-          vector_handler_->gemv('T', n, i + 1, &ONE, &ZERO, V,  vec_v_, vec_Hcolumn_, memspace);
-          // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
-          vector_handler_->gemv('N', n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace );  
-          mem_.deviceSynchronize();
-          
-          // copy H_col to aux, we will need it later
-          vec_Hcolumn_->setDataUpdated(memory::DEVICE);
-          vec_Hcolumn_->setCurrentSize(i + 1);
-          vec_Hcolumn_->deepCopyVectorData(h_aux_, 0, memory::HOST);
-          mem_.deviceSynchronize();
-
-          //Hcol = V(:,1:i)^T*V(:,i+1);
-          vector_handler_->gemv('T', n, i + 1, &ONE, &ZERO, V,  vec_v_, vec_Hcolumn_, memspace);
-          mem_.deviceSynchronize();
-
-          // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
-          vector_handler_->gemv('N', n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace );  
-          mem_.deviceSynchronize();
-
-          // copy H_col to H
-          vec_Hcolumn_->setDataUpdated(memory::DEVICE);
-          vec_Hcolumn_->deepCopyVectorData(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
-          mem_.deviceSynchronize();
-
-          // add both pieces together (unstable otherwise, careful here!!)
-          t = 0.0;
-          for(int j = 0; j <= i; ++j) {
-            H[ idxmap(i, j, num_vecs_ + 1)] += h_aux_[j];
-          }
-
-          t = vector_handler_->dot(vec_v_, vec_v_, memspace);  
-          //set the last entry in Hessenberg matrix
-          t = sqrt(t);
-          H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t; 
-
-          if(fabs(t) > EPSILON) {
-            t = 1.0/t;
-            vector_handler_->scal(&t, vec_v_, memspace);  
-          } else {
-            assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
-            return -1;
-          }
-          return 0;
-          break;
-        case mgs_two_synch:
-          // V[1:i]^T[V[i] w]
-          vec_v_->setData(V->getVectorData(i, memory::DEVICE), memory::DEVICE);
-          vec_w_->setData(V->getVectorData(i + 1, memory::DEVICE), memory::DEVICE);
-          vec_rv_->setCurrentSize(i + 1);
-
-          vector_handler_->massDot2Vec(n, V, i, vec_v_, vec_rv_, memspace);
-          vec_rv_->setDataUpdated(memory::DEVICE);
-          vec_rv_->copyData(memory::DEVICE, memory::HOST);
-
-          vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
-          h_rv_ = vec_rv_->getVectorData(1, memory::HOST);
-
-          for(int j=0; j<=i; ++j) {
-            H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
-          }
-          // triangular solve
-          for(int j = 0; j <= i; ++j) {
-            H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv_[j];
-            s = 0.0;
-            for(int k = 0; k < j; ++k) {
-              s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * H[ idxmap(i, k, num_vecs_ + 1) ];
-            } // for k
-            H[ idxmap(i, j, num_vecs_ + 1) ] -= s; 
-          }   // for j
-          vec_Hcolumn_->setCurrentSize(i + 1);
-          vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memory::DEVICE); 
-          vector_handler_->massAxpy(n, vec_Hcolumn_, i, V, vec_w_, memspace);
-
-          // normalize (second synch)
-          t = vector_handler_->dot(vec_w_, vec_w_, memspace);  
-          //set the last entry in Hessenberg matrix
-          t = sqrt(t);
-          H[ idxmap(i, i + 1, num_vecs_ + 1)] = t;    
-          if(fabs(t) > EPSILON) {
-            t = 1.0 / t;
-            vector_handler_->scal(&t, vec_w_, memspace);  
-          } else {
-            assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
-            return -1;
-          }
-          return 0;
-          break;
-        case mgs_pm:
-          vec_v_->setData(V->getVectorData(i, memory::DEVICE), memory::DEVICE);
-          vec_w_->setData(V->getVectorData(i + 1, memory::DEVICE), memory::DEVICE);
-          vec_rv_->setCurrentSize(i + 1);
-
-          vector_handler_->massDot2Vec(n, V, i, vec_v_, vec_rv_, memspace);
-          vec_rv_->setDataUpdated(memory::DEVICE);
-          vec_rv_->copyData(memory::DEVICE, memory::HOST);
-
-          vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
-          h_rv_ = vec_rv_->getVectorData(1, memory::HOST);
-
-          for(int j = 0; j <= i; ++j) {
-            H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
-          }
-
-          //triangular solve
-          for(int j = 0; j <= i; ++j) {
-            H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv_[j];
-            s = 0.0;
-            for(int k = 0; k < j; ++k) {
-              s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * H[ idxmap(i, k, num_vecs_ + 1) ];
-            } // for k
-            H[ idxmap(i, j, num_vecs_ + 1) ] -= s;
-          }   // for j
-
-          // now compute h_rv = L^T h_H
-          double h;
-          for(int j = 0; j <= i; ++j) {
-            // go through COLUMN OF L
-            h_rv_[j] = 0.0;
-            for(int k = j + 1; k <= i; ++k) {
-              h = h_L_[ idxmap(k, j, num_vecs_ + 1)];
-              h_rv_[j] += H[ idxmap(i, k, num_vecs_ + 1) ] * h;
-            }
-          }
-
-          // and do one more tri solve with L^T: h_aux = (I-L)^{-1}h_rv
-          for(int j = 0; j <= i; ++j) {
-            h_aux_[j] = h_rv_[j];
-            s = 0.0;
-            for(int k = 0; k < j; ++k) {
-              s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * h_aux_[k];
-            } // for k
-            h_aux_[j] -= s;
-          }   // for j
-
-          // and now subtract that from h_H
-          for(int j=0; j<=i; ++j) {
-            H[ idxmap(i, j, num_vecs_ + 1) ] -= h_aux_[j];
-          }
-
-          vec_Hcolumn_->setCurrentSize(i + 1);
-          vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memory::DEVICE); 
-
-          vector_handler_->massAxpy(n, vec_Hcolumn_, i, V,  vec_w_, memspace);
-          // normalize (second synch)
-          t = vector_handler_->dot(vec_w_, vec_w_, memspace);  
-          //set the last entry in Hessenberg matrix
-          t = sqrt(t);
-          H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;    
-          if(fabs(t) > EPSILON) {
-            t = 1.0 / t;
-            vector_handler_->scal(&t, vec_w_, memspace);  
-          } else {
-            assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
-            return -1;
-          }
-          return 0;
-          break;
-
-        default:
-          assert(0 && "Iterative refinement failed, wrong orthogonalization.\n");
-          return -1;
-          break;
-
-      }//switch
-    } else {
-      out::error() << "Not implemented (yet)" << std::endl;
-      return -1;
+    if (memspace != memory::DEVICE) {
+      out::error() << "Support for Gram-Scmidt on CPU not implemented!\n";
+      return 1;
     }
+
+    double t;
+    double s;
+
+    switch (variant_) {
+      case mgs: 
+        vec_w_->setData(V->getVectorData(i + 1, memspace), memspace);
+        for(int j = 0; j <= i; ++j) {
+          t = 0.0;
+          vec_v_->setData( V->getVectorData(j, memspace), memspace);
+          t = vector_handler_->dot(vec_v_, vec_w_, memspace);  
+          H[ idxmap(i, j, num_vecs_ + 1) ] = t; 
+          t *= -1.0;
+          vector_handler_->axpy(&t, vec_v_, vec_w_, memspace);  
+        }
+        t = 0.0;
+        t = vector_handler_->dot(vec_w_, vec_w_, memspace);
+        //set the last entry in Hessenberg matrix
+        t = sqrt(t);
+        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t; 
+        if(fabs(t) > EPSILON) {
+          t = 1.0/t;
+          vector_handler_->scal(&t, vec_w_, memspace);  
+        } else {
+          assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
+          return -1;
+        }
+        break;
+
+      case cgs2:
+        vec_v_->setData(V->getVectorData(i + 1, memspace), memspace);
+        vector_handler_->gemv('T', n, i + 1, &ONE, &ZERO, V,  vec_v_, vec_Hcolumn_, memspace);
+        // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
+        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace );  
+        mem_.deviceSynchronize();
+        
+        // copy H_col to aux, we will need it later
+        vec_Hcolumn_->setDataUpdated(memspace);
+        vec_Hcolumn_->setCurrentSize(i + 1);
+        vec_Hcolumn_->deepCopyVectorData(h_aux_, 0, memory::HOST);
+        mem_.deviceSynchronize();
+
+        //Hcol = V(:,1:i)^T*V(:,i+1);
+        vector_handler_->gemv('T', n, i + 1, &ONE, &ZERO, V,  vec_v_, vec_Hcolumn_, memspace);
+        mem_.deviceSynchronize();
+
+        // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
+        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace );  
+        mem_.deviceSynchronize();
+
+        // copy H_col to H
+        vec_Hcolumn_->setDataUpdated(memspace);
+        vec_Hcolumn_->deepCopyVectorData(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+        mem_.deviceSynchronize();
+
+        // add both pieces together (unstable otherwise, careful here!!)
+        t = 0.0;
+        for(int j = 0; j <= i; ++j) {
+          H[ idxmap(i, j, num_vecs_ + 1)] += h_aux_[j];
+        }
+
+        t = vector_handler_->dot(vec_v_, vec_v_, memspace);  
+        //set the last entry in Hessenberg matrix
+        t = sqrt(t);
+        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t; 
+
+        if(fabs(t) > EPSILON) {
+          t = 1.0/t;
+          vector_handler_->scal(&t, vec_v_, memspace);  
+        } else {
+          assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
+          return -1;
+        }
+        return 0;
+        break;
+
+      case mgs_two_synch:
+        // V[1:i]^T[V[i] w]
+        vec_v_->setData(V->getVectorData(i, memspace), memspace);
+        vec_w_->setData(V->getVectorData(i + 1, memspace), memspace);
+        vec_rv_->setCurrentSize(i + 1);
+
+        vector_handler_->massDot2Vec(n, V, i, vec_v_, vec_rv_, memspace);
+        vec_rv_->setDataUpdated(memspace);
+        vec_rv_->copyData(memspace, memory::HOST);
+
+        vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+        h_rv_ = vec_rv_->getVectorData(1, memory::HOST);
+
+        for(int j=0; j<=i; ++j) {
+          H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
+        }
+        // triangular solve
+        for(int j = 0; j <= i; ++j) {
+          H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv_[j];
+          s = 0.0;
+          for(int k = 0; k < j; ++k) {
+            s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * H[ idxmap(i, k, num_vecs_ + 1) ];
+          } // for k
+          H[ idxmap(i, j, num_vecs_ + 1) ] -= s; 
+        }   // for j
+        vec_Hcolumn_->setCurrentSize(i + 1);
+        vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace); 
+        vector_handler_->massAxpy(n, vec_Hcolumn_, i, V, vec_w_, memspace);
+
+        // normalize (second synch)
+        t = vector_handler_->dot(vec_w_, vec_w_, memspace);  
+        //set the last entry in Hessenberg matrix
+        t = sqrt(t);
+        H[ idxmap(i, i + 1, num_vecs_ + 1)] = t;    
+        if(fabs(t) > EPSILON) {
+          t = 1.0 / t;
+          vector_handler_->scal(&t, vec_w_, memspace);  
+        } else {
+          assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
+          return -1;
+        }
+        return 0;
+        break;
+
+      case mgs_pm:
+        vec_v_->setData(V->getVectorData(i, memspace), memspace);
+        vec_w_->setData(V->getVectorData(i + 1, memspace), memspace);
+        vec_rv_->setCurrentSize(i + 1);
+
+        vector_handler_->massDot2Vec(n, V, i, vec_v_, vec_rv_, memspace);
+        vec_rv_->setDataUpdated(memspace);
+        vec_rv_->copyData(memspace, memory::HOST);
+
+        vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+        h_rv_ = vec_rv_->getVectorData(1, memory::HOST);
+
+        for(int j = 0; j <= i; ++j) {
+          H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
+        }
+
+        //triangular solve
+        for(int j = 0; j <= i; ++j) {
+          H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv_[j];
+          s = 0.0;
+          for(int k = 0; k < j; ++k) {
+            s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * H[ idxmap(i, k, num_vecs_ + 1) ];
+          } // for k
+          H[ idxmap(i, j, num_vecs_ + 1) ] -= s;
+        }   // for j
+
+        // now compute h_rv = L^T h_H
+        double h;
+        for(int j = 0; j <= i; ++j) {
+          // go through COLUMN OF L
+          h_rv_[j] = 0.0;
+          for(int k = j + 1; k <= i; ++k) {
+            h = h_L_[ idxmap(k, j, num_vecs_ + 1)];
+            h_rv_[j] += H[ idxmap(i, k, num_vecs_ + 1) ] * h;
+          }
+        }
+
+        // and do one more tri solve with L^T: h_aux = (I-L)^{-1}h_rv
+        for(int j = 0; j <= i; ++j) {
+          h_aux_[j] = h_rv_[j];
+          s = 0.0;
+          for(int k = 0; k < j; ++k) {
+            s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * h_aux_[k];
+          } // for k
+          h_aux_[j] -= s;
+        }   // for j
+
+        // and now subtract that from h_H
+        for(int j=0; j<=i; ++j) {
+          H[ idxmap(i, j, num_vecs_ + 1) ] -= h_aux_[j];
+        }
+
+        vec_Hcolumn_->setCurrentSize(i + 1);
+        vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace); 
+
+        vector_handler_->massAxpy(n, vec_Hcolumn_, i, V,  vec_w_, memspace);
+        // normalize (second synch)
+        t = vector_handler_->dot(vec_w_, vec_w_, memspace);  
+        //set the last entry in Hessenberg matrix
+        t = sqrt(t);
+        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;    
+        if(fabs(t) > EPSILON) {
+          t = 1.0 / t;
+          vector_handler_->scal(&t, vec_w_, memspace);  
+        } else {
+          assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
+          return -1;
+        }
+        return 0;
+        break;
+
+      default:
+        assert(0 && "Iterative refinement failed, wrong orthogonalization.\n");
+        return -1;
+        break;
+    } //switch
+
     return 0;
-  }//orthogonalize
-}
+  } // int orthogonalize()
+
+} // namespace ReSolve

--- a/resolve/LinSolverDirectRocSparseILU0.hpp
+++ b/resolve/LinSolverDirectRocSparseILU0.hpp
@@ -36,19 +36,19 @@ namespace ReSolve
                 matrix::Sparse* U = nullptr,
                 index_type*     P = nullptr,
                 index_type*     Q = nullptr,
-                vector_type* rhs  = nullptr);
+                vector_type* rhs  = nullptr) override;
       // if values of A change, but the nnz pattern does not, redo the analysis only (reuse buffers though)
       int reset(matrix::Sparse* A);
        
-      int solve(vector_type* rhs, vector_type* x);
-      int solve(vector_type* rhs);// the solutuon is returned IN RHS (rhs is overwritten)
+      int solve(vector_type* rhs, vector_type* x) override;
+      int solve(vector_type* rhs) override; // the solutuon is returned IN RHS (rhs is overwritten)
     
 
     private:
       rocsparse_status status_rocsparse_;
 
       MemoryHandler mem_; ///< Device memory manager object
-      LinAlgWorkspaceHIP* workspace_; 
+      LinAlgWorkspaceHIP* workspace_{nullptr};
 
       rocsparse_mat_descr descr_A_{nullptr};
       rocsparse_mat_descr descr_L_{nullptr};
@@ -56,10 +56,10 @@ namespace ReSolve
 
       rocsparse_mat_info  info_A_{nullptr};
       
-      void* buffer_; 
+      void* buffer_{nullptr};
       
-      real_type* d_aux1_;
+      real_type* d_aux1_{nullptr};
       // since ILU OVERWRITES THE MATRIX values, we need a buffer to keep the values of ILU decomposition. 
-      real_type* d_ILU_vals_;
+      real_type* d_ILU_vals_{nullptr};
   };
 }// namespace

--- a/resolve/LinSolverIterativeFGMRES.hpp
+++ b/resolve/LinSolverIterativeFGMRES.hpp
@@ -7,53 +7,57 @@
 
 namespace ReSolve 
 {
-
+  /**
+   * @brief (F)GMRES solver
+   * 
+   * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
+   * 
+   * @note MatrixHandler and VectorHandler objects are inherited from
+   * LinSolver base class.
+   */
   class LinSolverIterativeFGMRES : public LinSolverIterative
   {
     using vector_type = vector::Vector;
 
     public:
-    LinSolverIterativeFGMRES(std::string memspace = "cuda");
-    LinSolverIterativeFGMRES( MatrixHandler* matrix_handler,
+      LinSolverIterativeFGMRES(std::string memspace = "cuda");
+      LinSolverIterativeFGMRES(MatrixHandler* matrix_handler,
                               VectorHandler* vector_handler,
                               GramSchmidt*   gs,
                               std::string memspace = "cuda");
-    LinSolverIterativeFGMRES(index_type restart,
-                             real_type  tol,
-                             index_type maxit,
-                             index_type conv_cond,
-                             MatrixHandler* matrix_handler,
-                             VectorHandler* vector_handler,
-                             GramSchmidt*   gs,
-                             std::string memspace = "cuda");
-    ~LinSolverIterativeFGMRES();
+      LinSolverIterativeFGMRES(index_type restart,
+                              real_type  tol,
+                              index_type maxit,
+                              index_type conv_cond,
+                              MatrixHandler* matrix_handler,
+                              VectorHandler* vector_handler,
+                              GramSchmidt*   gs,
+                              std::string memspace = "cuda");
+      ~LinSolverIterativeFGMRES();
 
-    int solve(vector_type* rhs, vector_type* x);
-    int setup(matrix::Sparse* A);
-    int resetMatrix(matrix::Sparse* new_A); 
-    int setupPreconditioner(std::string name, LinSolverDirect* LU_solver);
-
+      int solve(vector_type* rhs, vector_type* x) override;
+      int setup(matrix::Sparse* A) override;
+      int resetMatrix(matrix::Sparse* new_A) override; 
+      int setupPreconditioner(std::string name, LinSolverDirect* LU_solver) override;
 
     private:
-    //remember matrix handler and vector handler are inherited.
+      memory::MemorySpace memspace_;
 
-    memory::MemorySpace memspace_;
+      std::string orth_option_;
+      vector_type* d_V_{nullptr};
+      vector_type* d_Z_{nullptr};
 
-    std::string orth_option_;
-    vector_type* d_V_{nullptr};
-    vector_type* d_Z_{nullptr};
-
-    real_type* h_H_{nullptr};
-    real_type* h_c_{nullptr};
-    real_type* h_s_{nullptr};
-    real_type* h_rs_{nullptr};
+      real_type* h_H_{nullptr};
+      real_type* h_c_{nullptr};
+      real_type* h_s_{nullptr};
+      real_type* h_rs_{nullptr};
 
 
-    GramSchmidt* GS_;     
-    void precV(vector_type* rhs, vector_type* x); //multiply the vector by preconditioner
-    LinSolverDirect* LU_solver_;
-    index_type n_;// for simplicity
+      GramSchmidt* GS_;     
+      void precV(vector_type* rhs, vector_type* x); //multiply the vector by preconditioner
+      LinSolverDirect* LU_solver_;
+      index_type n_;// for simplicity
 
-    MemoryHandler mem_; ///< Device memory manager object
+      MemoryHandler mem_; ///< Device memory manager object
   };
 }

--- a/resolve/LinSolverIterativeRandFGMRES.hpp
+++ b/resolve/LinSolverIterativeRandFGMRES.hpp
@@ -11,6 +11,8 @@ namespace ReSolve
   /**
    * @brief Randomized (F)GMRES
    * 
+   * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
+   * 
    * @note MatrixHandler and VectorHandler objects are inherited from
    * LinSolver base class.
    * 
@@ -21,8 +23,8 @@ namespace ReSolve
       using vector_type = vector::Vector;
 
     public:
-      enum SketchingMethod { cs = 0, // count sketch 
-                            fwht = 1}; // fast Walsh-Hadamard transform
+      enum SketchingMethod { cs = 0,    // count sketch 
+                             fwht = 1}; // fast Walsh-Hadamard transform
     
       LinSolverIterativeRandFGMRES(std::string memspace = "cuda");
 
@@ -44,35 +46,15 @@ namespace ReSolve
 
       ~LinSolverIterativeRandFGMRES();
 
-      int solve(vector_type* rhs, vector_type* x);
-      int setup(matrix::Sparse* A);
-      int resetMatrix(matrix::Sparse* new_A); 
-      int setupPreconditioner(std::string name, LinSolverDirect* LU_solver);
+      int solve(vector_type* rhs, vector_type* x) override;
+      int setup(matrix::Sparse* A) override;
+      int resetMatrix(matrix::Sparse* new_A) override; 
+      int setupPreconditioner(std::string name, LinSolverDirect* LU_solver) override;
 
-      real_type getTol();
-      index_type getMaxit();
-      index_type getRestart();
-      index_type getConvCond();
-      bool getFlexible();
-      // std::string getRandSketchingMethod();
       index_type getKrand();
-
-      void setTol(real_type new_tol);
-      void setMaxit(index_type new_maxit);
-      void setRestart(index_type new_restart);
-      void setConvCond(index_type new_conv_cond);
-      void setFlexible(bool new_flexible);
-      // void setRandSketchingMethod(std::string rand_method);
 
     private:
       memory::MemorySpace memspace_;
-
-      real_type tol_;
-      index_type maxit_;
-      index_type restart_;
-      std::string orth_option_;
-      index_type conv_cond_;
-      bool flexible_{true}; ///< if can be run as "normal" GMRES if needed, set flexible_ to `false`. Default is `true`, of course.
 
       vector_type* d_V_{nullptr};
       vector_type* d_Z_{nullptr};


### PR DESCRIPTION
FGMRES classes are now device agnostic. All is left to do is to make minor tweaks to Gram-Schmidt class, so we can run iterative solvers without GPUs.