### PR TITLE
Unit tests for Gram-Schmidt methods on CPU backend

### DIFF
--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -197,13 +197,14 @@ namespace ReSolve
         vec_w_->setData(V->getVectorData(i + 1, memspace), memspace);
         vec_rv_->setCurrentSize(i + 1);
 
-        vector_handler_->massDot2Vec(n, V, i, vec_v_, vec_rv_, memspace);
+        // vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace);
+        vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace);
         vec_rv_->setDataUpdated(memspace);
         vec_rv_->copyData(memspace, memory::HOST);
 
         vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv_ = vec_rv_->getVectorData(1, memory::HOST);
-
+        
         for(int j=0; j<=i; ++j) {
           H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
         }
@@ -218,7 +219,7 @@ namespace ReSolve
         }   // for j
         vec_Hcolumn_->setCurrentSize(i + 1);
         vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace); 
-        vector_handler_->massAxpy(n, vec_Hcolumn_, i, V, vec_w_, memspace);
+        vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V, vec_w_, memspace);
 
         // normalize (second synch)
         t = vector_handler_->dot(vec_w_, vec_w_, memspace);  
@@ -228,6 +229,11 @@ namespace ReSolve
         if(fabs(t) > EPSILON) {
           t = 1.0 / t;
           vector_handler_->scal(&t, vec_w_, memspace);  
+          for (int ii=0; ii<=i; ++ii)
+          {
+            vec_v_->setData(V->getVectorData(ii, memspace), memspace);
+            vec_w_->setData(V->getVectorData(i + 1, memspace), memspace);
+          }        
         } else {
           assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
           return -1;
@@ -240,7 +246,7 @@ namespace ReSolve
         vec_w_->setData(V->getVectorData(i + 1, memspace), memspace);
         vec_rv_->setCurrentSize(i + 1);
 
-        vector_handler_->massDot2Vec(n, V, i, vec_v_, vec_rv_, memspace);
+        vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace);
         vec_rv_->setDataUpdated(memspace);
         vec_rv_->copyData(memspace, memory::HOST);
 
@@ -290,7 +296,7 @@ namespace ReSolve
         vec_Hcolumn_->setCurrentSize(i + 1);
         vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace); 
 
-        vector_handler_->massAxpy(n, vec_Hcolumn_, i, V,  vec_w_, memspace);
+        vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V,  vec_w_, memspace);
         // normalize (second synch)
         t = vector_handler_->dot(vec_w_, vec_w_, memspace);  
         //set the last entry in Hessenberg matrix

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -407,7 +407,7 @@ namespace ReSolve {
                                       const real_type* mvec, 
                                       real_type* result)
   {
-    kernels::MassIPTwoVec<<<i + 1, 1024>>>(vec1, vec2, mvec, result, i + 1, n);
+    kernels::MassIPTwoVec<<<i, 1024>>>(vec1, vec2, mvec, result, i, n);
   }
 
   /**
@@ -421,7 +421,7 @@ namespace ReSolve {
    */
   void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha)
   {
-    kernels::massAxpy3<<<(n + 384 - 1) / 384, 384>>>(n, i + 1, x, y, alpha);
+    kernels::massAxpy3<<<(n + 384 - 1) / 384, 384>>>(n, i, x, y, alpha);
   }
 
   /**

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -524,7 +524,7 @@ namespace ReSolve {
                                       real_type* result)
   {
     hipLaunchKernelGGL(kernels::MassIPTwoVec_kernel,
-                       dim3(i + 1),
+                       dim3(i),
                        dim3(1024),
                        0,
                        0,
@@ -532,7 +532,7 @@ namespace ReSolve {
                        vec2,
                        mvec,
                        result,
-                       i + 1,
+                       i,
                        n);
   }
 

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -206,12 +206,12 @@ namespace ReSolve {
                   CUBLAS_OP_N,
                   size,       // m
                   1,          // n
-                  k + 1,      // k
+                  k,      // k
                   &MINUSONE, // alpha
                   x->getData(memory::DEVICE), // A
                   size,       // lda
                   alpha->getData(memory::DEVICE), // B
-                  k + 1,      // ldb
+                  k,      // ldb
                   &ONE,
                   y->getData(memory::DEVICE),          // c
                   size);      // ldc     
@@ -243,7 +243,7 @@ namespace ReSolve {
       cublasDgemm(handle_cublas,
                   CUBLAS_OP_T,
                   CUBLAS_OP_N,
-                  k + 1,   //m
+                  k,   //m
                   2,       //n
                   size,    //k
                   &ONE,   //alpha
@@ -253,7 +253,7 @@ namespace ReSolve {
                   size,    //ldb
                   &ZERO,
                   res->getData(memory::DEVICE),     //c
-                  k + 1);  //ldc 
+                  k);  //ldc 
     }
   }
 

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -26,18 +26,10 @@ namespace ReSolve {
         TestOutcome GramSchmidtConstructor()
         {
           TestStatus status;
-          // status.skipTest();
-
-          // GramSchmidt gs1;
-          // status *= (gs1.getVariant() == GramSchmidt::mgs);
-          // status *= (gs1.getL() == nullptr);
-          // status *= !gs1.isSetupComplete();
 
           VectorHandler vh;
           GramSchmidt gs2(&vh, GramSchmidt::mgs_pm);
           status *= (gs2.getVariant() == GramSchmidt::mgs_pm);
-          // status *= (gs1.getL() == nullptr);
-          // status *= !gs1.isSetupComplete();
 
           return status.report(__func__);
         }
@@ -167,7 +159,6 @@ namespace ReSolve {
               a->update(x->getVectorData(i, ms), ms, memory::HOST);
               b->update(x->getVectorData(j, ms), ms, memory::HOST);
               ip = handler->dot(a, b, memory::HOST);
-              
               if ( (i != j) && (abs(ip) > 1e-14)) {
                 status = false;
                 std::cout << "Vectors " << i << " and " << j << " are not orthogonal!"

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -133,6 +133,12 @@ namespace ReSolve {
             workspace->initializeHandles();
             return new VectorHandler(workspace);
 #endif
+#ifdef RESOLVE_USE_HIP
+          } else if (memspace_ == "hip") {
+            LinAlgWorkspaceHIP* workspace = new LinAlgWorkspaceHIP();
+            workspace->initializeHandles();
+            return new VectorHandler(workspace);
+#endif
           } else {
             std::cout << "ReSolve not built with support for memory space " << memspace_ << "\n";
           }

--- a/tests/unit/vector/runGramSchmidtTests.cpp
+++ b/tests/unit/vector/runGramSchmidtTests.cpp
@@ -21,8 +21,22 @@ int main(int, char**)
   }
 #endif
 
+#ifdef RESOLVE_USE_HIP
   {
-    std::cout << "Running tests on CPU!:\n";
+    std::cout << "Running tests with HIP backend:\n";
+    ReSolve::tests::GramSchmidtTests test("hip");
+
+    result += test.GramSchmidtConstructor();
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs2);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_two_synch);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_pm);
+    std::cout << "\n";
+  }
+#endif
+
+  {
+    std::cout << "Running tests on the CPU:\n";
     ReSolve::tests::GramSchmidtTests test("cpu");
 
     result += test.GramSchmidtConstructor();

--- a/tests/unit/vector/runGramSchmidtTests.cpp
+++ b/tests/unit/vector/runGramSchmidtTests.cpp
@@ -21,5 +21,16 @@ int main(int, char**)
   }
 #endif
 
+  {
+    std::cout << "Running tests on CPU!:\n";
+    ReSolve::tests::GramSchmidtTests test("cpu");
+
+    result += test.GramSchmidtConstructor();
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs2);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_two_synch);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_pm);
+    std::cout << "\n";
+  }
   return result.summary();
 }


### PR DESCRIPTION
- Add Gram-Schmidt unit tests on CPU backend
- Adjust indexing in `massAxpy` and `massDot2Vec` kernel calls.