### PR TITLE
Base class direct solver should not delete L and U factors

### DIFF
--- a/resolve/LinSolver.cpp
+++ b/resolve/LinSolver.cpp
@@ -33,15 +33,14 @@ namespace ReSolve
     U_ = nullptr;
     P_ = nullptr;
     Q_ = nullptr;
-    factors_extracted_ = false;
+    std::cout << "LinSolverDirect constructor\n";
+    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   LinSolverDirect::~LinSolverDirect()
   {
-    delete L_;
-    delete U_;
-    delete [] P_;
-    delete [] Q_;
+    std::cout << "LinSolverDirect destructor\n";
+    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   int LinSolverDirect::setup(matrix::Sparse* A,
@@ -65,13 +64,11 @@ namespace ReSolve
 
   int LinSolverDirect::factorize()
   {
-    factors_extracted_ = false;
     return 1;
   }
 
   int LinSolverDirect::refactorize()
   {
-    factors_extracted_ = false;
     return 1;
   }
 

--- a/resolve/LinSolver.cpp
+++ b/resolve/LinSolver.cpp
@@ -33,14 +33,10 @@ namespace ReSolve
     U_ = nullptr;
     P_ = nullptr;
     Q_ = nullptr;
-    std::cout << "LinSolverDirect constructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   LinSolverDirect::~LinSolverDirect()
   {
-    std::cout << "LinSolverDirect destructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   int LinSolverDirect::setup(matrix::Sparse* A,

--- a/resolve/LinSolver.hpp
+++ b/resolve/LinSolver.hpp
@@ -76,7 +76,6 @@ namespace ReSolve
       matrix::Sparse* U_{nullptr};
       index_type* P_{nullptr};
       index_type* Q_{nullptr};
-      bool factors_extracted_;
 
       int ordering_{1}; // 0 = AMD, 1 = COLAMD, 2 = user provided P, Q
       real_type pivot_threshold_tol_{0.1};

--- a/resolve/LinSolverDirectCpuILU0.cpp
+++ b/resolve/LinSolverDirectCpuILU0.cpp
@@ -19,8 +19,6 @@ namespace ReSolve
   LinSolverDirectCpuILU0::LinSolverDirectCpuILU0(LinAlgWorkspaceCpu* /* workspace */)
     // : workspace_(workspace)
   {
-    std::cout << "LinSolverDirectCpuILU0 constructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   /**
@@ -30,9 +28,6 @@ namespace ReSolve
    */
   LinSolverDirectCpuILU0::~LinSolverDirectCpuILU0()
   {
-    std::cout << "LinSolverDirectCpuILU0 destructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
-    std::cout << "Deleting factors ...\n";
     if (owns_factors_) {
       delete L_;
       delete U_;

--- a/resolve/LinSolverDirectCpuILU0.cpp
+++ b/resolve/LinSolverDirectCpuILU0.cpp
@@ -19,6 +19,8 @@ namespace ReSolve
   LinSolverDirectCpuILU0::LinSolverDirectCpuILU0(LinAlgWorkspaceCpu* /* workspace */)
     // : workspace_(workspace)
   {
+    std::cout << "LinSolverDirectCpuILU0 constructor\n";
+    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   /**
@@ -28,9 +30,14 @@ namespace ReSolve
    */
   LinSolverDirectCpuILU0::~LinSolverDirectCpuILU0()
   {
-    if (false) { //(owns_factors_) {
+    std::cout << "LinSolverDirectCpuILU0 destructor\n";
+    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
+    std::cout << "Deleting factors ...\n";
+    if (owns_factors_) {
       delete L_;
       delete U_;
+      L_ = nullptr;
+      U_ = nullptr;
     }
     delete [] diagU_;
     delete [] idxmap_;

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -30,14 +30,10 @@ namespace ReSolve
                    << "\tordering         = " << Common_.ordering         << "\n"
                    << "\tpivot threshold  = " << Common_.tol              << "\n"
                    << "\thalt if singular = " << Common_.halt_if_singular << "\n";
-    std::cout << "LinSolverDirectKLU constructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   } 
 
   LinSolverDirectKLU::~LinSolverDirectKLU()
   {
-    std::cout << "LinSolverDirectKLU destructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
     if (factors_extracted_) {
       delete L_;
       delete U_;

--- a/resolve/LinSolverDirectKLU.hpp
+++ b/resolve/LinSolverDirectKLU.hpp
@@ -50,6 +50,7 @@ namespace ReSolve
       virtual real_type getMatrixConditionNumber() override;
 
     private:
+      bool factors_extracted_{false};
       klu_common Common_; //settings
       klu_symbolic* Symbolic_{nullptr};
       klu_numeric* Numeric_{nullptr}; 

--- a/resolve/LinSolverDirectSerialILU0.cpp
+++ b/resolve/LinSolverDirectSerialILU0.cpp
@@ -115,8 +115,8 @@ namespace ReSolve
     // TODO: What is the purpose of nnzL and nnzU if they are not used after this?
     // allocate L and U
 
-    L_ = new matrix::Csr(n, n, nnz, false, true);
-    U_ = new matrix::Csr(n, n, nnz, false, true);
+    L_ = new matrix::Csr(n, n, nnzL, false, true);
+    U_ = new matrix::Csr(n, n, nnzU, false, true);
     owns_factors_ = true;
 
     L_->allocateMatrixData(ReSolve::memory::HOST);  

--- a/resolve/LinSolverDirectSerialILU0.cpp
+++ b/resolve/LinSolverDirectSerialILU0.cpp
@@ -10,10 +10,20 @@ namespace ReSolve
   LinSolverDirectSerialILU0::LinSolverDirectSerialILU0(LinAlgWorkspaceCpu* workspace)
   {
     workspace_ = workspace;
+    std::cout << "LinSolverDirectSerialILU0 constructor\n";
+    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   LinSolverDirectSerialILU0::~LinSolverDirectSerialILU0()
   {
+    std::cout << "LinSolverDirectSerialILU0 destructor\n";
+    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
+    if (owns_factors_) {
+      delete L_;
+      delete U_;
+      L_ = nullptr;
+      U_ = nullptr;
+    }
     delete [] h_aux1_;
     delete [] h_ILU_vals_;
   }
@@ -109,8 +119,9 @@ namespace ReSolve
     // TODO: What is the purpose of nnzL and nnzU if they are not used after this?
     // allocate L and U
 
-    L_ = new matrix::Csr(n, n, nnz, false, true);  
-    U_ = new matrix::Csr(n, n, nnz, false, true);  
+    L_ = new matrix::Csr(n, n, nnz, false, true);
+    U_ = new matrix::Csr(n, n, nnz, false, true);
+    owns_factors_ = true;
 
     L_->allocateMatrixData(ReSolve::memory::HOST);  
     U_->allocateMatrixData(ReSolve::memory::HOST);  
@@ -159,9 +170,9 @@ namespace ReSolve
           kL++;
         }
       }  
-    //update row pointers
-    L_->getRowData(ReSolve::memory::HOST)[i + 1] = L_->getRowData(ReSolve::memory::HOST)[i] + kL; 
-    U_->getRowData(ReSolve::memory::HOST)[i + 1] = U_->getRowData(ReSolve::memory::HOST)[i] + kU; 
+      //update row pointers
+      L_->getRowData(ReSolve::memory::HOST)[i + 1] = L_->getRowData(ReSolve::memory::HOST)[i] + kL; 
+      U_->getRowData(ReSolve::memory::HOST)[i + 1] = U_->getRowData(ReSolve::memory::HOST)[i] + kU; 
     }
    
     return zero_pivot;
@@ -175,7 +186,7 @@ namespace ReSolve
   int LinSolverDirectSerialILU0::solve(vector_type* rhs)
   {
     int error_sum = 0;
-printf("solve t 1\n");
+    // printf("solve t 1\n");
     // h_aux1 = L^{-1} rhs
     for (index_type i = 0; i < L_->getNumRows(); ++i) {
       h_aux1_[i] = rhs->getData(ReSolve::memory::HOST)[i];
@@ -205,7 +216,7 @@ printf("solve t 1\n");
     //printf("solve t 2i, L has %d rows, U has %d rows \n", L_->getNumRows(), U_->getNumRows());
     int error_sum = 0;
     // h_aux1 = L^{-1} rhs
-//for (int ii=0; ii<10; ++ii) printf("y[%d] = %16.16f \n ", ii,   rhs->getData(ReSolve::memory::HOST)[ii]); 
+      //for (int ii=0; ii<10; ++ii) printf("y[%d] = %16.16f \n ", ii,   rhs->getData(ReSolve::memory::HOST)[ii]); 
     for (index_type i = 0; i < L_->getNumRows(); ++i) {
       h_aux1_[i] = rhs->getData(ReSolve::memory::HOST)[i];
       for (index_type j = L_->getRowData(ReSolve::memory::HOST)[i]; j < L_->getRowData(ReSolve::memory::HOST)[i + 1] - 1; ++j) {
@@ -215,7 +226,7 @@ printf("solve t 1\n");
       h_aux1_[i] /= L_->getValues(ReSolve::memory::HOST)[L_->getRowData(ReSolve::memory::HOST)[i + 1] - 1];
     }
 
-//for (int ii=0; ii<10; ++ii) printf("(L)^{-1}y[%d] = %16.16f \n ", ii,  h_aux1_[ii]); 
+    //for (int ii=0; ii<10; ++ii) printf("(L)^{-1}y[%d] = %16.16f \n ", ii,  h_aux1_[ii]); 
     // x = U^{-1} h_aux1
 
     for (index_type i = U_->getNumRows() - 1; i >= 0; --i) {
@@ -226,7 +237,7 @@ printf("solve t 1\n");
       }
       x->getData(ReSolve::memory::HOST)[i] /= U_->getValues(ReSolve::memory::HOST)[U_->getRowData(ReSolve::memory::HOST)[i]]; //divide by the diagonal entry
     }
-//for (int ii=0; ii<10; ++ii) printf("(LU)^{-1}y[%d] = %16.16f \n ", ii,  x->getData(ReSolve::memory::HOST)[ii]); 
+    //for (int ii=0; ii<10; ++ii) printf("(LU)^{-1}y[%d] = %16.16f \n ", ii,  x->getData(ReSolve::memory::HOST)[ii]); 
    return error_sum;
   }
-}// namespace resolve
+} // namespace resolve

--- a/resolve/LinSolverDirectSerialILU0.cpp
+++ b/resolve/LinSolverDirectSerialILU0.cpp
@@ -10,14 +10,10 @@ namespace ReSolve
   LinSolverDirectSerialILU0::LinSolverDirectSerialILU0(LinAlgWorkspaceCpu* workspace)
   {
     workspace_ = workspace;
-    std::cout << "LinSolverDirectSerialILU0 constructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
   }
 
   LinSolverDirectSerialILU0::~LinSolverDirectSerialILU0()
   {
-    std::cout << "LinSolverDirectSerialILU0 destructor\n";
-    std::cout << "L_ = " << L_ << ", P_ = " << P_ << "\n";
     if (owns_factors_) {
       delete L_;
       delete U_;

--- a/resolve/LinSolverDirectSerialILU0.hpp
+++ b/resolve/LinSolverDirectSerialILU0.hpp
@@ -42,10 +42,12 @@ namespace ReSolve
     private:
 
       MemoryHandler mem_; ///< Device memory manager object
-      LinAlgWorkspaceCpu* workspace_; 
+      LinAlgWorkspaceCpu* workspace_{nullptr}; 
+      bool owns_factors_{false};    ///< If the class owns L and U factors
 
-      real_type* h_aux1_;
-      // since ILU OVERWRITES THE MATRIX values, we need a buffer to keep the values of ILU decomposition. 
-      real_type* h_ILU_vals_;
+      real_type* h_aux1_{nullptr};
+      // since ILU OVERWRITES THE MATRIX values, we need a buffer to keep 
+      // the values of ILU decomposition. 
+      real_type* h_ILU_vals_{nullptr};
   };
 }// namespace

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#include <resolve/Common.hpp>
-#include <resolve/MemoryUtils.hpp>
 
 namespace ReSolve
 { 

--- a/tests/unit/TestBase.hpp
+++ b/tests/unit/TestBase.hpp
@@ -91,7 +91,7 @@ public:
         std::cout << "--- " << ORANGE << "FAIL" << CLEAR << " (EXPECTED)" << ": Test " << funcname << "\n";
         break;
       case UNEXPECTED_PASS:
-        std::cout << "--- " << YELLOW << "PASS" << CLEAR << "(UNEXPECTED)" << ": Test " << funcname << "\n";
+        std::cout << "--- " << BLUE << "PASS" << CLEAR << " (UNEXPECTED)" << ": Test " << funcname << "\n";
         break;
       default:
         std::cout << "--- " << RED << "FAIL" << CLEAR << "Unrecognized test result " << outcome_ 


### PR DESCRIPTION
Base class `LinSolverDirect` deletes member factors `L_` and `U_`, as well as permutation vectors `P_` and `Q_`, but it does not allocate them. It is better if the (derived) class that allocates these objects also assumes responsibility of deleting them.

Closes #139 
