### PR TITLE
Remove memory leaks in matrix and vector unit tests

### DIFF
--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -23,7 +23,9 @@ namespace ReSolve
     cusparseDestroy(handle_cusparse_);
     cusolverSpDestroy(handle_cusolversp_);
     cublasDestroy(handle_cublas_);
-    cusparseDestroySpMat(mat_A_);
+    if (matvec_setup_done_) {
+      cusparseDestroySpMat(mat_A_);
+    }
   }
 
   void* LinAlgWorkspaceCUDA::getSpmvBuffer()
@@ -53,7 +55,7 @@ namespace ReSolve
   
   void LinAlgWorkspaceCUDA::setNormBufferState(bool r)
   {
-    norm_buffer_ready_ = r;;
+    norm_buffer_ready_ = r;
   }
 
   cusparseHandle_t LinAlgWorkspaceCUDA::getCusparseHandle()

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -18,7 +18,9 @@ namespace ReSolve
   {
     rocsparse_destroy_handle(handle_rocsparse_);
     rocblas_destroy_handle(handle_rocblas_);
-    rocsparse_destroy_mat_descr(mat_A_);
+    if (matvec_setup_done_) {
+      rocsparse_destroy_mat_descr(mat_A_);
+    }
     if (d_r_size_ != 0)  mem_.deleteOnDevice(d_r_);
     if (norm_buffer_ready_ == true)  mem_.deleteOnDevice(norm_buffer_);
   }

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -22,10 +22,8 @@ public:
   {
     if (handler_.getIsCudaEnabled() || handler_.getIsHipEnabled()) {
       memspace_ = memory::DEVICE;
-      std::cout << "Memory space set to device: " << memspace_ << "\n";
     } else {
       memspace_ = memory::HOST;
-      std::cout << "Memory space set to host: " << memspace_ << "\n";
     }
   }
 

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -11,8 +11,12 @@ int main(int, char**)
 
   {
     std::cout << "Running tests on CPU:\n";
-    ReSolve::tests::MatrixHandlerTests test("cpu");
-      
+
+    ReSolve::LinAlgWorkspaceCpu workspace;
+    workspace.initializeHandles();
+    ReSolve::MatrixHandler handler(&workspace);
+
+    ReSolve::tests::MatrixHandlerTests test(handler);
     result += test.matrixHandlerConstructor();
     result += test.matrixInfNorm(10000);
     result += test.matVec(50);
@@ -23,8 +27,11 @@ int main(int, char**)
 #ifdef RESOLVE_USE_CUDA
   {
     std::cout << "Running tests with CUDA backend:\n";
-    ReSolve::tests::MatrixHandlerTests test("cuda");
+    ReSolve::LinAlgWorkspaceCUDA workspace;
+    workspace.initializeHandles();
+    ReSolve::MatrixHandler handler(&workspace);
 
+    ReSolve::tests::MatrixHandlerTests test(handler);
     result += test.matrixHandlerConstructor();
     result += test.matrixInfNorm(1000000);
     result += test.matVec(50);
@@ -36,8 +43,11 @@ int main(int, char**)
 #ifdef RESOLVE_USE_HIP
   {
     std::cout << "Running tests with HIP backend:\n";
-    ReSolve::tests::MatrixHandlerTests test("hip");
+    ReSolve::LinAlgWorkspaceHIP workspace;
+    workspace.initializeHandles();
+    ReSolve::MatrixHandler handler(&workspace);
 
+    ReSolve::tests::MatrixHandlerTests test(handler);
     result += test.matrixHandlerConstructor();
     result += test.matrixInfNorm(1000000);
     result += test.matVec(50);

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -72,8 +72,10 @@ namespace ReSolve
           real_type* H = new real_type[9]; // In this case, Hessenberg matrix is NOT 3 x 2 ???
           real_type* aux_data = nullptr; // needed for setup
 
-          V->allocate(memory::DEVICE);
-          V->allocate(memory::HOST);
+          V->allocate(ms);
+          if (ms == memory::DEVICE) {
+            V->allocate(memory::HOST);
+          }
 
           ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(handler_, var);
           GS->setup(N, 3);

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -18,7 +18,7 @@ namespace ReSolve
     class GramSchmidtTests : TestBase
     {
       public:       
-        GramSchmidtTests(ReSolve::VectorHandler* handler) : handler_(handler) 
+        GramSchmidtTests(ReSolve::VectorHandler& handler) : handler_(handler) 
         {
         }
 
@@ -63,25 +63,25 @@ namespace ReSolve
           }
 
           ReSolve::memory::MemorySpace ms;
-          if (handler_->getIsCudaEnabled() || handler_->getIsHipEnabled())
+          if (handler_.getIsCudaEnabled() || handler_.getIsHipEnabled())
             ms = memory::DEVICE;
           else
             ms = memory::HOST;
 
-          vector::Vector* V = new vector::Vector(N, 3); // we will be using a space of 3 vectors
+          vector::Vector V(N, 3); // we will be using a space of 3 vectors
           real_type* H = new real_type[9]; // In this case, Hessenberg matrix is NOT 3 x 2 ???
           real_type* aux_data = nullptr; // needed for setup
 
-          V->allocate(ms);
+          V.allocate(ms);
           if (ms == memory::DEVICE) {
-            V->allocate(memory::HOST);
+            V.allocate(memory::HOST);
           }
 
-          ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(handler_, var);
-          GS->setup(N, 3);
+          ReSolve::GramSchmidt GS(&handler_, var);
+          GS.setup(N, 3);
           
           //fill 2nd and 3rd vector with values
-          aux_data = V->getVectorData(1, memory::HOST);
+          aux_data = V.getVectorData(1, memory::HOST);
           for (int i = 0; i < N; ++i) {
             if ( i % 2 == 0) {         
               aux_data[i] = constants::ONE;
@@ -89,7 +89,7 @@ namespace ReSolve
               aux_data[i] = var1;
             }
           }
-          aux_data = V->getVectorData(2, memory::HOST);
+          aux_data = V.getVectorData(2, memory::HOST);
           for (int i = 0; i < N; ++i) {
             if ( i % 3 > 0) {         
               aux_data[i] = constants::ZERO;
@@ -97,66 +97,64 @@ namespace ReSolve
               aux_data[i] = var2;
             }
           }
-          V->setDataUpdated(memory::HOST); 
-          V->copyData(memory::HOST, ms);
+          V.setDataUpdated(memory::HOST); 
+          V.copyData(memory::HOST, ms);
 
           //set the first vector to all 1s, normalize 
-          V->setToConst(0, 1.0, ms);
-          real_type nrm = handler_->dot(V, V, ms);
+          V.setToConst(0, 1.0, ms);
+          real_type nrm = handler_.dot(&V, &V, ms);
           nrm = sqrt(nrm);
           nrm = 1.0 / nrm;
-          handler_->scal(&nrm, V, ms);
+          handler_.scal(&nrm, &V, ms);
 
-          GS->orthogonalize(N, V, H, 0); 
-          GS->orthogonalize(N, V, H, 1); 
+          GS.orthogonalize(N, &V, H, 0); 
+          GS.orthogonalize(N, &V, H, 1); 
           status *= verifyAnswer(V, 3);
 
           delete [] H;
-          delete V; 
-          delete GS;
           
           return status.report(testname.c_str());
         }    
 
       private:
-        ReSolve::VectorHandler* handler_{nullptr};
+        ReSolve::VectorHandler& handler_;
 
         // x is a multivector containing K vectors 
-        bool verifyAnswer(vector::Vector* x, index_type K)
+        bool verifyAnswer(vector::Vector& x, index_type K)
         {
           ReSolve::memory::MemorySpace ms;
-          if (handler_->getIsCudaEnabled() || handler_->getIsHipEnabled())
+          if (handler_.getIsCudaEnabled() || handler_.getIsHipEnabled())
             ms = memory::DEVICE;
           else
             ms = memory::HOST;
 
-          vector::Vector* a = new vector::Vector(x->getSize()); 
-          vector::Vector* b = new vector::Vector(x->getSize());
+          vector::Vector a(x.getSize()); 
+          vector::Vector b(x.getSize());
 
           real_type ip; 
           bool status = true;
 
           for (index_type i = 0; i < K; ++i) {
             for (index_type j = 0; j < K; ++j) {
-              a->update(x->getVectorData(i, ms), ms, memory::HOST);
-              b->update(x->getVectorData(j, ms), ms, memory::HOST);
-              ip = handler_->dot(a, b, memory::HOST);
+              a.update(x.getVectorData(i, ms), ms, memory::HOST);
+              b.update(x.getVectorData(j, ms), ms, memory::HOST);
+              ip = handler_.dot(&a, &b, memory::HOST);
               if ( (i != j) && !isEqual(ip, 0.0)) {
                 status = false;
                 std::cout << "Vectors " << i << " and " << j << " are not orthogonal!"
-                  << " Inner product computed: " << ip << ", expected: " << 0.0 << "\n";
+                          << " Inner product computed: " << ip << ", expected: " << 0.0 << "\n";
                 break; 
               }
               if ( (i == j) && !isEqual(sqrt(ip), 1.0)) {           
                 status = false;
                 std::cout << std::setprecision(16);
-                std::cout << "Vector " << i << " has norm: " << sqrt(ip) << " expected: "<< 1.0 <<"\n";
+                std::cout << "Vector " << i << " has norm: " << sqrt(ip)
+                          << " expected: " << 1.0 << "\n";
                 break; 
               }
             }
           }
-          delete a;
-          delete b;
+
           return status;
         }
    }; // class

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -23,10 +23,8 @@ namespace ReSolve {
         {
           if (handler_.getIsCudaEnabled() || handler_.getIsHipEnabled()) {
             memspace_ = memory::DEVICE;
-            std::cout << "Memory space set to device: " << memspace_ << "\n";
           } else {
             memspace_ = memory::HOST;
-            std::cout << "Memory space set to host: " << memspace_ << "\n";
           }
         }
 

--- a/tests/unit/vector/runGramSchmidtTests.cpp
+++ b/tests/unit/vector/runGramSchmidtTests.cpp
@@ -7,13 +7,12 @@ int main(int, char**)
 {
   ReSolve::tests::TestingResults result; 
 
-#ifdef RESOLVE_USE_CUDA
   {
-    std::cout << "Running tests with CUDA backend:\n";
+    std::cout << "Running tests on the CPU:\n";
 
-    ReSolve::LinAlgWorkspaceCUDA* workspace = new ReSolve::LinAlgWorkspaceCUDA();
-    workspace->initializeHandles();
-    ReSolve::VectorHandler* handler = new ReSolve::VectorHandler(workspace);
+    ReSolve::LinAlgWorkspaceCpu workspace;
+    workspace.initializeHandles();
+    ReSolve::VectorHandler handler(&workspace);
 
     ReSolve::tests::GramSchmidtTests test(handler);
     result += test.GramSchmidtConstructor();
@@ -23,9 +22,24 @@ int main(int, char**)
     result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_pm);
     result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs1);
     std::cout << "\n";
+  }
 
-    delete handler;
-    delete workspace;
+#ifdef RESOLVE_USE_CUDA
+  {
+    std::cout << "Running tests with CUDA backend:\n";
+
+    ReSolve::LinAlgWorkspaceCUDA workspace;
+    workspace.initializeHandles();
+    ReSolve::VectorHandler handler(&workspace);
+
+    ReSolve::tests::GramSchmidtTests test(handler);
+    result += test.GramSchmidtConstructor();
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs2);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_two_sync);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_pm);
+    result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs1);
+    std::cout << "\n";
   }
 #endif
 
@@ -33,9 +47,9 @@ int main(int, char**)
   {
     std::cout << "Running tests with HIP backend:\n";
 
-    ReSolve::LinAlgWorkspaceHIP* workspace = new ReSolve::LinAlgWorkspaceHIP();
-    workspace->initializeHandles();
-    ReSolve::VectorHandler* handler = new ReSolve::VectorHandler(workspace);
+    ReSolve::LinAlgWorkspaceHIP workspace;
+    workspace.initializeHandles();
+    ReSolve::VectorHandler handler(&workspace);
 
     ReSolve::tests::GramSchmidtTests test(handler);
     result += test.GramSchmidtConstructor();
@@ -45,30 +59,8 @@ int main(int, char**)
     result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_pm);
     result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs1);
     std::cout << "\n";
-
-    delete handler;
-    delete workspace;
   }
 #endif
 
-  {
-    std::cout << "Running tests on the CPU:\n";
-
-    ReSolve::LinAlgWorkspaceCpu* workspace = new ReSolve::LinAlgWorkspaceCpu();
-    workspace->initializeHandles();
-    ReSolve::VectorHandler* handler = new ReSolve::VectorHandler(workspace);
-
-    ReSolve::tests::GramSchmidtTests test(handler);
-    result += test.GramSchmidtConstructor();
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs2);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_two_sync);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::mgs_pm);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::cgs1);
-    std::cout << "\n";
-
-    delete handler;
-    delete workspace;
-  }
   return result.summary();
 }

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -9,8 +9,12 @@ int main(int, char**)
 
   {
     std::cout << "Running tests on CPU:\n";
-    ReSolve::tests::VectorHandlerTests test("cpu");
-      
+
+    ReSolve::LinAlgWorkspaceCpu workspace;
+    workspace.initializeHandles();
+    ReSolve::VectorHandler handler(&workspace);
+
+    ReSolve::tests::VectorHandlerTests test(handler);
     result += test.vectorHandlerConstructor();
     result += test.dot(50);
     result += test.axpy(50);
@@ -26,8 +30,12 @@ int main(int, char**)
 #ifdef RESOLVE_USE_CUDA
   {
     std::cout << "Running tests with CUDA backend:\n";
-    ReSolve::tests::VectorHandlerTests test("cuda");
 
+    ReSolve::LinAlgWorkspaceCUDA workspace;
+    workspace.initializeHandles();
+    ReSolve::VectorHandler handler(&workspace);
+
+    ReSolve::tests::VectorHandlerTests test(handler);
     result += test.dot(5000);
     result += test.axpy(5000);
     result += test.scal(5000);
@@ -45,8 +53,12 @@ int main(int, char**)
 #ifdef RESOLVE_USE_HIP
   {
     std::cout << "Running tests with HIP backend:\n";
-    ReSolve::tests::VectorHandlerTests test("hip");
 
+    ReSolve::LinAlgWorkspaceHIP workspace;
+    workspace.initializeHandles();
+    ReSolve::VectorHandler handler(&workspace);
+
+    ReSolve::tests::VectorHandlerTests test(handler);
     result += test.dot(5000);
     result += test.axpy(5000);
     result += test.scal(5000);
@@ -60,5 +72,6 @@ int main(int, char**)
     std::cout << "\n";
   }
 #endif
+
   return result.summary();
 }


### PR DESCRIPTION
Updated tests to use latest features of workspace classes. In this PR:
- Ensure that the workspace in unit tests is deleted after it is not used anymore.
- Fixed double deletion bugs in HIP and CUDA workspaces.
- Use correct comparison between floating point numbers (no `==`).
- Memory space is now inferred from matrix/vector handlers.
