### PR TITLE
Fix warnings in integrate-lusol branch

### DIFF
--- a/resolve/LinSolverDirectLUSOL.cpp
+++ b/resolve/LinSolverDirectLUSOL.cpp
@@ -252,7 +252,7 @@ namespace ReSolve
     return inform;
   }
 
-  int LinSolverDirectLUSOL::solve(vector_type* x)
+  int LinSolverDirectLUSOL::solve(vector_type* /* x */)
   {
     log::error() << "LinSolverDirect::solve(vector_type*) called on "
                     "LinSolverDirectLUSOL which is unimplemented!\n";
@@ -287,19 +287,19 @@ namespace ReSolve
     return nullptr;
   }
 
-  void LinSolverDirectLUSOL::setPivotThreshold(real_type _)
+  void LinSolverDirectLUSOL::setPivotThreshold(real_type /* _ */)
   {
     log::error() << "LinSolverDirect::setPivotThreshold(real_type) called on "
                     "LinSolverDirectLUSOL on which it is irrelevant!\n";
   }
 
-  void LinSolverDirectLUSOL::setOrdering(int _)
+  void LinSolverDirectLUSOL::setOrdering(int /* _ */)
   {
     log::error() << "LinSolverDirect::setOrdering(int) called on "
                     "LinSolverDirectLUSOL on which it is irrelevant!\n";
   }
 
-  void LinSolverDirectLUSOL::setHaltIfSingular(bool _)
+  void LinSolverDirectLUSOL::setHaltIfSingular(bool /* _ */)
   {
     log::error() << "LinSolverDirect::setHaltIfSingular(bool) called on "
                     "LinSolverDirectLUSOL on which it is irrelevant!\n";

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -124,7 +124,8 @@ namespace ReSolve
         matrix::Coo* createMatrix()
         {
           // NOTE: these are hardcoded for now
-          matrix::Coo* A = new matrix::Coo(9, 9, valsA_.size(), true, true);
+          index_type size = static_cast<index_type>(valsA_.size());
+          matrix::Coo* A = new matrix::Coo(9, 9, size, true, true);
           A->updateData(rowsA_.data(),
                         colsA_.data(),
                         valsA_.data(),


### PR DESCRIPTION
Quick fix for warnings appearing in builds of `integrate-lusol` branch on Frontier and Summit with `-Wall -Wconversion -Wextra` flags.