### PR TITLE
Check if LUSOL workspace has been allocated before

### DIFF
--- a/resolve/LinSolverDirectLUSOL.hpp
+++ b/resolve/LinSolverDirectLUSOL.hpp
@@ -2,6 +2,7 @@
 
 #include <resolve/Common.hpp>
 #include <resolve/LinSolver.hpp>
+#include <resolve/MemoryUtils.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -51,6 +52,13 @@ namespace ReSolve
       virtual real_type getMatrixConditionNumber() override;
 
     private:
+      int allocateSolverData();
+      int freeSolverData();
+
+      bool is_solver_data_allocated_{false};
+
+      MemoryHandler mem_;
+
       //NOTE: a_, indc_, and indr_ may need to be passed along to the GPU at some
       //      point in the future, so they are manually managed
 

--- a/resolve/MemoryUtils.hpp
+++ b/resolve/MemoryUtils.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <resolve/resolve_defs.hpp>
-#include <cstdlib>
+#include <cstring> // <- declares `memcpy`
 
 namespace ReSolve
 {


### PR DESCRIPTION
Some bandaid solutions for LUSOL:
- On repeated analysis, check if LUSOL workspace has been allocated before. If so, nuke it and allocate the new one. This is a brute-force solution to prevent memory leaks and should be refined.
- Created `allocateSolverData` and `freeSolverData` private methods.
- Use memory manager to initialize array.
- Changed logger alias to `out`.

