### PR TITLE
Add make test_install to github tests.

### DIFF
--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -135,8 +135,11 @@ jobs:
       - name: Install package
         run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh
 
-      - name: Test Installation
+      - name: Test Build
         run: cd $(spack -e . location --build-dir resolve@develop) && ctest -VV
+
+      - name: Test Installation
+        run: cd $(spack -e . location --build-dir resolve@develop) && make test_install
 
       # Push with force to override existing binaries...
       - name: Push to binaries to buildcache


### PR DESCRIPTION
Running `ctest` triggers testing the build. Running `make test_install` starts installation tests. The latter will verify if all runtime paths are set correctly.