### PR TITLE
Update spack_cpu_build.yaml to build ~klu+lusol

### DIFF
--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -82,6 +82,7 @@ jobs:
         # Minimal Build(s) - GHCR mirror speeds these up a lot!
         spack_spec:
           - resolve@develop~klu~lusol
+          - resolve@develop~klu+lusol
           - resolve@develop+klu~lusol
           - resolve@develop+klu+lusol
 


### PR DESCRIPTION
Targeting #164 since there is more testing in that PR.

We could also merge into develop first, but merging into #164 just in cases tests fail...

cc @superwhiskers and @pelesh 