### PR TITLE
Only build spack base image if necessary

### DIFF
--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -7,7 +7,7 @@ env:
   # Our repo name contains upper case characters, so we can't use ${{ github.repository }}
   IMAGE_NAME: resolve
   USERNAME: resolve-bot
-  BASE_VERSION: ubuntu-22.04-fortran
+  BASE_VERSION: ubuntu-22.04-fortran-v0.1.0
 
 # Until we remove the need to clone submodules to build, this should on be in PRs
 on: [pull_request]
@@ -15,7 +15,7 @@ on: [pull_request]
 jobs:
   base_image_build:
     name: Build base image
-    runs-on: ubuntu-22.04-v0.1.0
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # No GHCR base image with skopeo, so this will do...
       - name: "Set up skopeo"
-        uses: warjiang/setup-skopeo@latest
+        uses: warjiang/setup-skopeo@v0.1.3
         with:
           version: latest
 

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -32,15 +32,6 @@ jobs:
     permissions:
       packages: read
     steps:
-      # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-      # This isn't necessary for skopeo, but spack will need this to push later...
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       # Use skopeo to check for image for convenience
       - name: Check for existing base images
         run: |
@@ -57,7 +48,6 @@ jobs:
           echo "IMAGE_EXISTS=false" >> $GITHUB_ENV
 
   base_image_build:
-    if: ${{ env.IMAGE_EXISTS == false }}
     runs-on: ubuntu-22.04
     permissions:
       packages: write
@@ -66,8 +56,17 @@ jobs:
     name: Build Custom Base Image
 
     steps:
+      # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Need to build custom base image with gfortran
       - name: Create Dockerfile heredoc
+        if: ${{ env.IMAGE_EXISTS == 'false' }}
         run: |
           cat << EOF > Dockerfile
           FROM ubuntu:22.04
@@ -86,6 +85,7 @@ jobs:
           EOF
 
       - name: Extract metadata (tags, labels) for Docker
+        if: ${{ env.IMAGE_EXISTS == 'false' }}
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -93,6 +93,7 @@ jobs:
           labels: org.opencontainers.image.version=${{ env.BASE_VERSION }}
 
       - name: Build and push Docker base image
+        if: ${{ env.IMAGE_EXISTS == 'false' }}
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -15,7 +15,7 @@ on: [pull_request]
 jobs:
   base_image_build:
     name: Build base image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-v0.1.0
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -13,11 +13,12 @@ env:
 on: [pull_request]
 
 jobs:
-  checkout_code:
-    name: Checkout code
+  base_image_build:
+    name: Build base image
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,13 +27,6 @@ jobs:
           # Also need to change build script to use spack from base image
           submodules: true
 
-  check_for_image:
-    needs: checkout_code
-    name: Check for image
-    runs-on: ubuntu-22.04
-    permissions:
-      packages: read
-    steps:
       # No GHCR base image with skopeo, so this will do...
       - name: "Set up skopeo"
         uses: warjiang/setup-skopeo@v0.1.3
@@ -46,7 +40,6 @@ jobs:
           CONTAINER_TAG=${{ env.BASE_VERSION }}
           OCI_URL="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BASE_VERSION }}"
           echo Checking for CONTAINER_TAG $CONTAINER_TAG
-          mkdir -p /etc/gitlab-runner/certs
           skopeo inspect \
               docker://$OCI_URL \
               --raw \
@@ -54,16 +47,6 @@ jobs:
             > /dev/null && echo "Image already exists. Please bump version." && exit 0
           echo "IMAGE_EXISTS=false" >> $GITHUB_ENV
 
-  base_image_build:
-    needs: check_for_image
-    runs-on: ubuntu-22.04
-    permissions:
-      packages: write
-      contents: read
-
-    name: Build Custom Base Image
-
-    steps:
       # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -27,11 +27,18 @@ jobs:
           submodules: true
 
   check_for_image:
+    needs: checkout_code
     name: Check for image
-    runs-on: docker.io/kfox1111/misc:skopeo
+    runs-on: ubuntu-22.04
     permissions:
       packages: read
     steps:
+      # No GHCR base image with skopeo, so this will do...
+      - name: "Set up skopeo"
+        uses: warjiang/setup-skopeo@latest
+        with:
+          version: latest
+
       # Use skopeo to check for image for convenience
       - name: Check for existing base images
         run: |
@@ -48,6 +55,7 @@ jobs:
           echo "IMAGE_EXISTS=false" >> $GITHUB_ENV
 
   base_image_build:
+    needs: check_for_image
     runs-on: ubuntu-22.04
     permissions:
       packages: write

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -13,13 +13,11 @@ env:
 on: [pull_request]
 
 jobs:
-  base_image_build:
+  checkout_code:
+    name: Checkout code
     runs-on: ubuntu-22.04
     permissions:
-      packages: write
       contents: read
-
-    name: Build Custom Base Image
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,6 +26,46 @@ jobs:
           # Also need to change build script to use spack from base image
           submodules: true
 
+  check_for_image:
+    name: Check for image
+    runs-on: docker.io/kfox1111/misc:skopeo
+    permissions:
+      packages: read
+    steps:
+      # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+      # This isn't necessary for skopeo, but spack will need this to push later...
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Use skopeo to check for image for convenience
+      - name: Check for existing base images
+        run: |
+          set -e
+          CONTAINER_TAG=${{ env.BASE_VERSION }}
+          OCI_URL="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BASE_VERSION }}"
+          echo Checking for CONTAINER_TAG $CONTAINER_TAG
+          mkdir -p /etc/gitlab-runner/certs
+          skopeo inspect \
+              docker://$OCI_URL \
+              --raw \
+              --creds "${{ env.USERNAME }}:${{ secrets.GITHUB_TOKEN }}" \
+            > /dev/null && echo "Image already exists. Please bump version." && exit 0
+          echo "IMAGE_EXISTS=false" >> $GITHUB_ENV
+
+  base_image_build:
+    if: ${{ env.IMAGE_EXISTS == false }}
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: read
+
+    name: Build Custom Base Image
+
+    steps:
       # Need to build custom base image with gfortran
       - name: Create Dockerfile heredoc
         run: |
@@ -46,14 +84,6 @@ jobs:
                 libstdc++6 \
               && rm -rf /var/lib/apt/lists/*
           EOF
-
-      # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
Closes #171 partially. There is still some work to be done to verify that we need to re-build things with a spack lock / package hash, but that can be made into another issue. We also always force push at the end...