### PR TITLE
Update spack_cpu_build.yaml to not checkout in base image build step

### DIFF
--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -20,13 +20,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # Once we move submodule deps into spack, we can do some more builds
-          # Also need to change build script to use spack from base image
-          submodules: true
-
       # No GHCR base image with skopeo, so this will do...
       - name: "Set up skopeo"
         uses: warjiang/setup-skopeo@v0.1.3


### PR DESCRIPTION
In debugging https://github.com/LLNL/hiop/pull/695, I realised that the clone happens at multiple steps in the pipelines, and doesn't need to.

By not cloning when building the base image, we speed up the initial builds a little. We could also kick off the base image pipeline in a separate workflow, and it would surely complete in time for a full spack build (the spack job only needs it to upload to the remote registry.

There's a potential race condition with that if the spack pipeline fails quickly... so I don't see a need to do that.