### PR TITLE
Matrix handler now checks in the background if the matrix is CSR.

### DIFF
--- a/examples/r_KLU_GLU.cpp
+++ b/examples/r_KLU_GLU.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
     vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     real_type bnorm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
     
     matrix_handler->matrixInfNorm(A, &norm_A, ReSolve::memory::DEVICE); 

--- a/examples/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/r_KLU_GLU_matrix_values_update.cpp
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 
 
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
       std::cout << "\t 2-Norm of the residual: " 
                 << std::scientific << std::setprecision(16) 

--- a/examples/r_KLU_KLU.cpp
+++ b/examples/r_KLU_KLU.cpp
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::HOST); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
     norm_r = vector_handler->infNorm(vec_r, ReSolve::memory::HOST);
 
     std::cout << "\t2-Norm of the residual: " 

--- a/examples/r_KLU_KLU_standalone.cpp
+++ b/examples/r_KLU_KLU_standalone.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 
-  matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::HOST); 
+  matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
 
   std::cout << "\t 2-Norm of the residual: " 
             << std::scientific << std::setprecision(16) 

--- a/examples/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_cusolverrf_redo_factorization.cpp
@@ -155,7 +155,7 @@ int main(int argc, char *argv[] )
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
     res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     b_nrm   = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
     std::cout << "\t2-Norm of the residual: " 
@@ -180,7 +180,7 @@ int main(int argc, char *argv[] )
 
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
       res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
       std::cout <<"\t New residual norm: "

--- a/examples/r_KLU_rf.cpp
+++ b/examples/r_KLU_rf.cpp
@@ -148,7 +148,7 @@ int main(int argc, char *argv[] )
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
     std::cout << "\t 2-Norm of the residual: " 
               << std::scientific << std::setprecision(16) 

--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
     
       matrix_handler->matrixInfNorm(A, &norm_A, ReSolve::memory::DEVICE); 
       norm_x = vector_handler->infNorm(vec_x, ReSolve::memory::DEVICE);
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
       FGMRES->resetMatrix(A);
       FGMRES->setupPreconditioner("LU", Rf);
       
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
       matrix_handler->matrixInfNorm(A, &norm_A, ReSolve::memory::DEVICE); 
       norm_x = vector_handler->infNorm(vec_x, ReSolve::memory::DEVICE);

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
       std::cout << "\t 2-Norm of the residual : " 
                 << std::scientific << std::setprecision(16) 
                 << sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE))/norm_b << "\n";
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
       FGMRES->resetMatrix(A);
       
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
       std::cout << "\t 2-Norm of the residual (before IR): " 
                 << std::scientific << std::setprecision(16) 

--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
       std::cout << "\t2-Norm of the residual: "
         << std::scientific << std::setprecision(16) 
         << sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE))/norm_b << "\n";
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
       FGMRES->resetMatrix(A);
       FGMRES->setupPreconditioner("LU", Rf);
 
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
       real_type rnrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
       std::cout << "\t 2-Norm of the residual (before IR): " 
         << std::scientific << std::setprecision(16) 

--- a/examples/r_KLU_rocsolverrf.cpp
+++ b/examples/r_KLU_rocsolverrf.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[] )
     vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     real_type bnorm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
     std::cout << "\t 2-Norm of the residual: " 
               << std::scientific << std::setprecision(16) 

--- a/examples/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[] )
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
     res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     b_nrm = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
     std::cout << "\t 2-Norm of the residual: " 
@@ -163,7 +163,7 @@ int main(int argc, char *argv[] )
 
          matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-         matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+         matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
          res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
          
          std::cout<<"\t New residual norm: "

--- a/examples/r_SysSolver.cpp
+++ b/examples/r_SysSolver.cpp
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::HOST); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
 
     std::cout << "\t 2-Norm of the residual: " 
               << std::scientific << std::setprecision(16) 

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -124,7 +124,7 @@ namespace ReSolve
     vec_V_->setToZero(memspace_);
 
     rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
-    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, "csr", memspace_); 
+    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
     rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
@@ -189,7 +189,7 @@ namespace ReSolve
 
         vec_v->setData( vec_V_->getVectorData(i + 1, memspace_), memspace_);
 
-        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO,"csr", memspace_); 
+        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_); 
 
         // orthogonalize V[i+1], form a column of h_H_
 
@@ -274,7 +274,7 @@ namespace ReSolve
       }
 
       rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
-      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE,"csr", memspace_); 
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
       rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
       // rnorm = ||V_1||
       rnorm = std::sqrt(rnorm);

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -154,7 +154,7 @@ namespace ReSolve
     vec_V_->setToZero(memspace_);
 
     rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
-    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, "csr", memspace_); 
+    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
 
     vec_v->setData(vec_V_->getVectorData(0, memspace_), memspace_);
     vec_s->setData(vec_S_->getVectorData(0, memspace_), memspace_);
@@ -228,7 +228,7 @@ namespace ReSolve
         // V_{i+1}=A*Z_i
         vec_v->setData(vec_V_->getVectorData(i + 1, memspace_), memspace_);
 
-        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, "csr", memspace_); 
+        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_); 
 
         // orthogonalize V[i+1], form a column of h_H_
         // this is where it differs from normal solver GS
@@ -337,7 +337,7 @@ namespace ReSolve
       }
 
       rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
-      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE,"csr", memspace_); 
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
       if (outer_flag) {
 
         sketching_handler_->reset();

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -682,7 +682,7 @@ namespace ReSolve
       return -1.0;
     }
     matrixHandler_->setValuesChanged(true, ms);
-    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUSONE, "csr", ms);
+    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUSONE, ms);
     resnorm = std::sqrt(vectorHandler_->dot(resVector_, resVector_, ms));
     return resnorm/norm_b;
   }
@@ -711,7 +711,7 @@ namespace ReSolve
       return -1.0;
     }
     matrixHandler_->setValuesChanged(true, ms);
-    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUSONE, "csr", ms);
+    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUSONE, ms);
     resnorm = vectorHandler_->infNorm(resVector_, ms);
     norm_x  = vectorHandler_->infNorm(x, ms);
     matrixHandler_->matrixInfNorm(A_, &norm_A, ms);

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -17,6 +17,7 @@ namespace ReSolve
 
   matrix::Coo::Coo(index_type n, index_type m, index_type nnz) : Sparse(n, m, nnz)
   {
+    sparse_format_ = TRIPLET;
   }
   
   matrix::Coo::Coo(index_type n, 
@@ -43,7 +44,6 @@ namespace ReSolve
                    memory::MemorySpace memspaceDst)
     : Sparse(n, m, nnz, symmetric, expanded)
   {
-    using namespace memory;
     sparse_format_ = TRIPLET;
 
     int control = -1;

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -12,6 +12,7 @@ namespace ReSolve
 
   matrix::Coo::Coo()
   {
+    sparse_format_ = TRIPLET;
   }
 
   matrix::Coo::Coo(index_type n, index_type m, index_type nnz) : Sparse(n, m, nnz)
@@ -24,6 +25,7 @@ namespace ReSolve
                    bool symmetric,
                    bool expanded) : Sparse(n, m, nnz, symmetric, expanded)
   {
+    sparse_format_ = TRIPLET;
   }
   
   /**
@@ -42,6 +44,8 @@ namespace ReSolve
     : Sparse(n, m, nnz, symmetric, expanded)
   {
     using namespace memory;
+    sparse_format_ = TRIPLET;
+
     int control = -1;
     if ((memspaceSrc == memory::HOST)   && (memspaceDst == memory::HOST))  { control = 0;}
     if ((memspaceSrc == memory::HOST)   && (memspaceDst == memory::DEVICE)){ control = 1;}

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -10,6 +10,7 @@ namespace ReSolve
 
   matrix::Csc::Csc()
   {
+    sparse_format_ = COMPRESSED_SPARSE_COLUMN;
   }
 
   matrix::Csc::Csc(index_type n, index_type m, index_type nnz) : Sparse(n, m, nnz)
@@ -22,6 +23,7 @@ namespace ReSolve
                        bool symmetric,
                        bool expanded) : Sparse(n, m, nnz, symmetric, expanded)
   {
+    sparse_format_ = COMPRESSED_SPARSE_COLUMN;
   }
 
   matrix::Csc::~Csc()

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -13,10 +13,12 @@ namespace ReSolve
 
   matrix::Csr::Csr()
   {
+    sparse_format_ = COMPRESSED_SPARSE_ROW;
   }
 
   matrix::Csr::Csr(index_type n, index_type m, index_type nnz) : Sparse(n, m, nnz)
   {
+    sparse_format_ = COMPRESSED_SPARSE_ROW;
   }
   
   matrix::Csr::Csr(index_type n, 
@@ -25,6 +27,7 @@ namespace ReSolve
                    bool symmetric,
                    bool expanded) : Sparse(n, m, nnz, symmetric, expanded)
   {
+    sparse_format_ = COMPRESSED_SPARSE_ROW;
   }
 
   /**
@@ -54,6 +57,8 @@ namespace ReSolve
     : Sparse(n, m, nnz, symmetric, expanded)
   {
     using namespace memory;
+    sparse_format_ = COMPRESSED_SPARSE_ROW;
+
     int control = -1;
     if ((memspaceSrc == memory::HOST)   && (memspaceDst == memory::HOST))  { control = 0;}
     if ((memspaceSrc == memory::HOST)   && (memspaceDst == memory::DEVICE)){ control = 1;}

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -56,7 +56,6 @@ namespace ReSolve
                    memory::MemorySpace memspaceDst)
     : Sparse(n, m, nnz, symmetric, expanded)
   {
-    using namespace memory;
     sparse_format_ = COMPRESSED_SPARSE_ROW;
 
     int control = -1;

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -116,7 +116,6 @@ namespace ReSolve {
    * @param[out] vec_result - Vector where the result is stored
    * @param[in]  alpha - scalar parameter
    * @param[in]  beta  - scalar parameter
-   * @param[in]  matrixFormat - Only CSR format is supported at this time
    * @param[in]  memspace     - Device where the product is computed
    * @return result := alpha * A * x + beta * result
    */
@@ -125,16 +124,15 @@ namespace ReSolve {
                             vector_type* vec_result, 
                             const real_type* alpha, 
                             const real_type* beta,
-                            std::string matrixFormat, 
                             memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->matvec(A, vec_x, vec_result, alpha, beta, matrixFormat);
+        return cpuImpl_->matvec(A, vec_x, vec_result, alpha, beta);
         break;
       case DEVICE:
-        return devImpl_->matvec(A, vec_x, vec_result, alpha, beta, matrixFormat);
+        return devImpl_->matvec(A, vec_x, vec_result, alpha, beta);
         break;
     }
     return 1;

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -60,7 +60,6 @@ namespace ReSolve {
                  vector_type* vec_result,
                  const real_type* alpha,
                  const real_type* beta,
-                 std::string matrix_type,
                  memory::MemorySpace memspace);
       int matrixInfNorm(matrix::Sparse *A, real_type* norm, memory::MemorySpace memspace);
       void setValuesChanged(bool toWhat, memory::MemorySpace memspace); 

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -33,6 +33,20 @@ namespace ReSolve {
 
   /**
    * @brief result := alpha * A * x + beta * result
+   * 
+   * @param[in]     A - matrix
+   * @param[in]     vec_x - vector multiplied by A
+   * @param[in,out] vec_result - resulting vector
+   * @param[in]     alpha - matrix-vector multiplication factor
+   * @param[in]     beta - sum into result factor
+   * @return int    error code, 0 if successful
+   * 
+   * @pre Matrix `A` is in CSR format.
+   * 
+   * @note If we decide to implement this function for different matrix
+   * format, the check for CSR matrix will be replaced with a switch
+   * statement to select implementation for recognized input matrix
+   * format.
    */
   int MatrixHandlerCpu::matvec(matrix::Sparse* A, 
                                vector_type* vec_x, 
@@ -42,10 +56,8 @@ namespace ReSolve {
   {
     using namespace constants;
 
-    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
-      out::error() << "Matrix has to be in CSR format for matrix-vector product.\n";
-      return 1;
-    }
+    assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+           "Matrix has to be in CSR format for matrix-vector product.\n");
 
     index_type* ia = A->getRowData(memory::HOST);
     index_type* ja = A->getColData(memory::HOST);
@@ -76,12 +88,24 @@ namespace ReSolve {
     return 0;
   }
 
+  /**
+   * @brief Matrix infinity norm
+   * 
+   * @param[in]  A - matrix
+   * @param[out] norm - matrix norm
+   * @return int error code, 0 if successful
+   * 
+   * @pre Matrix `A` is in CSR format.
+   * 
+   * @note If we decide to implement this function for different matrix
+   * format, the check for CSR matrix will be replaced with a switch
+   * statement to select implementation for recognized input matrix
+   * format.
+   */
   int MatrixHandlerCpu::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
-    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
-      out::error() << "Matrix has to be in CSR format for norm computation.\n";
-      return 1;
-    }
+    assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+           "Matrix has to be in CSR format for matrix-vector product.\n");
 
     real_type sum, nrm;
     index_type i, j;

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -34,53 +34,55 @@ namespace ReSolve {
   /**
    * @brief result := alpha * A * x + beta * result
    */
-  int MatrixHandlerCpu::matvec(matrix::Sparse* Ageneric, 
+  int MatrixHandlerCpu::matvec(matrix::Sparse* A, 
                                vector_type* vec_x, 
                                vector_type* vec_result, 
                                const real_type* alpha, 
-                               const real_type* beta,
-                               std::string matrixFormat) 
+                               const real_type* beta) 
   {
     using namespace constants;
-    // int error_sum = 0;
-    if (matrixFormat == "csr") {
-      matrix::Csr* A = (matrix::Csr*) Ageneric;
-      index_type* ia = A->getRowData(memory::HOST);
-      index_type* ja = A->getColData(memory::HOST);
-      real_type*   a = A->getValues( memory::HOST);
 
-      real_type* x_data      = vec_x->getData(memory::HOST);
-      real_type* result_data = vec_result->getData(memory::HOST);
-      real_type sum;
-      real_type y;
-      real_type t;
-      real_type c;
-
-      //Kahan algorithm for stability; Kahan-Babushka version didnt make a difference   
-      for (int i = 0; i < A->getNumRows(); ++i) {
-        sum = 0.0;
-        c = 0.0;
-        for (int j = ia[i]; j < ia[i+1]; ++j) { 
-          y =  ( a[j] * x_data[ja[j]]) - c;
-          t = sum + y;
-          c = (t - sum) - y;
-          sum = t;
-          //  sum += ( a[j] * x_data[ja[j]]);
-        }
-        sum *= (*alpha);
-        result_data[i] = result_data[i]*(*beta) + sum;
-      } 
-      vec_result->setDataUpdated(memory::HOST);
-      return 0;
-    } else {
-      out::error() << "MatVec not implemented (yet) for " 
-                   << matrixFormat << " matrix format." << std::endl;
+    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
+      out::error() << "Matrix has to be in CSR format for matrix-vector product.\n";
       return 1;
     }
+
+    index_type* ia = A->getRowData(memory::HOST);
+    index_type* ja = A->getColData(memory::HOST);
+    real_type*   a = A->getValues( memory::HOST);
+
+    real_type* x_data      = vec_x->getData(memory::HOST);
+    real_type* result_data = vec_result->getData(memory::HOST);
+    real_type sum;
+    real_type y;
+    real_type t;
+    real_type c;
+
+    //Kahan algorithm for stability; Kahan-Babushka version didnt make a difference   
+    for (int i = 0; i < A->getNumRows(); ++i) {
+      sum = 0.0;
+      c = 0.0;
+      for (int j = ia[i]; j < ia[i+1]; ++j) { 
+        y =  ( a[j] * x_data[ja[j]]) - c;
+        t = sum + y;
+        c = (t - sum) - y;
+        sum = t;
+        //  sum += ( a[j] * x_data[ja[j]]);
+      }
+      sum *= (*alpha);
+      result_data[i] = result_data[i]*(*beta) + sum;
+    } 
+    vec_result->setDataUpdated(memory::HOST);
+    return 0;
   }
 
   int MatrixHandlerCpu::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
+    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
+      out::error() << "Matrix has to be in CSR format for norm computation.\n";
+      return 1;
+    }
+
     real_type sum, nrm;
     index_type i, j;
 
@@ -92,8 +94,7 @@ namespace ReSolve {
       if (i == 0) {
         nrm = sum;
       } else {
-        if (sum > nrm)
-        {
+        if (sum > nrm) {
           nrm = sum;
         } 
       }

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -41,8 +41,7 @@ namespace ReSolve {
                  vector_type* vec_x,
                  vector_type* vec_result,
                  const real_type* alpha,
-                 const real_type* beta,
-                 std::string matrix_type);
+                 const real_type* beta);
       virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm);
       void setValuesChanged(bool isValuesChanged); 
     

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -29,17 +29,20 @@ namespace ReSolve {
   }
 
 
-  int MatrixHandlerCuda::matvec(matrix::Sparse* Ageneric, 
+  int MatrixHandlerCuda::matvec(matrix::Sparse* A, 
                                 vector_type* vec_x, 
                                 vector_type* vec_result, 
                                 const real_type* alpha, 
-                                const real_type* beta,
-                                std::string matrixFormat) 
+                                const real_type* beta) 
   {
     using namespace constants;
+
+    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
+      out::error() << "Matrix has to be in CSR format for matrix-vector product.\n";
+      return 1;
+    }
+
     int error_sum = 0;
-    if (matrixFormat == "csr") {
-      matrix::Csr* A = dynamic_cast<matrix::Csr*>(Ageneric);
       //result = alpha *A*x + beta * result
       cusparseStatus_t status;
       cusparseDnVecDescr_t vecx = workspace_->getVecX();
@@ -111,15 +114,15 @@ namespace ReSolve {
       cusparseDestroyDnVec(vecx);
       cusparseDestroyDnVec(vecAx);
       return error_sum;
-    } else {
-      out::error() << "MatVec not implemented (yet) for " 
-        << matrixFormat << " matrix format." << std::endl;
-      return 1;
-    }
   }
 
   int MatrixHandlerCuda::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
+    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
+      out::error() << "Matrix has to be in CSR format for norm computation.\n";
+      return 1;
+    }
+
     if (workspace_->getNormBufferState() == false) { // not allocated  
       real_type* buffer;
       mem_.allocateArrayOnDevice(&buffer, 1024);

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -29,6 +29,23 @@ namespace ReSolve {
   }
 
 
+  /**
+   * @brief result := alpha * A * x + beta * result
+   * 
+   * @param[in]     A - matrix
+   * @param[in]     vec_x - vector multiplied by A
+   * @param[in,out] vec_result - resulting vector
+   * @param[in]     alpha - matrix-vector multiplication factor
+   * @param[in]     beta - sum into result factor
+   * @return int    error code, 0 if successful
+   * 
+   * @pre Matrix `A` is in CSR format.
+   * 
+   * @note If we decide to implement this function for different matrix
+   * format, the check for CSR matrix will be replaced with a switch
+   * statement to select implementation for recognized input matrix
+   * format.
+   */
   int MatrixHandlerCuda::matvec(matrix::Sparse* A, 
                                 vector_type* vec_x, 
                                 vector_type* vec_result, 
@@ -37,91 +54,101 @@ namespace ReSolve {
   {
     using namespace constants;
 
-    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
-      out::error() << "Matrix has to be in CSR format for matrix-vector product.\n";
-      return 1;
-    }
+    assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+           "Matrix has to be in CSR format for matrix-vector product.\n");
 
     int error_sum = 0;
-      //result = alpha *A*x + beta * result
-      cusparseStatus_t status;
-      cusparseDnVecDescr_t vecx = workspace_->getVecX();
-      cusparseCreateDnVec(&vecx, A->getNumRows(), vec_x->getData(memory::DEVICE), CUDA_R_64F);
+    //result = alpha *A*x + beta * result
+    cusparseStatus_t status;
+    cusparseDnVecDescr_t vecx = workspace_->getVecX();
+    cusparseCreateDnVec(&vecx, A->getNumRows(), vec_x->getData(memory::DEVICE), CUDA_R_64F);
 
 
-      cusparseDnVecDescr_t vecAx = workspace_->getVecY();
-      cusparseCreateDnVec(&vecAx, A->getNumRows(), vec_result->getData(memory::DEVICE), CUDA_R_64F);
+    cusparseDnVecDescr_t vecAx = workspace_->getVecY();
+    cusparseCreateDnVec(&vecAx, A->getNumRows(), vec_result->getData(memory::DEVICE), CUDA_R_64F);
 
-      cusparseSpMatDescr_t matA = workspace_->getSpmvMatrixDescriptor();
+    cusparseSpMatDescr_t matA = workspace_->getSpmvMatrixDescriptor();
 
-      void* buffer_spmv = workspace_->getSpmvBuffer();
-      cusparseHandle_t handle_cusparse = workspace_->getCusparseHandle();
-      if (values_changed_) {
-        status = cusparseCreateCsr(&matA, 
-                                   A->getNumRows(),
-                                   A->getNumColumns(),
-                                   A->getNnz(),
-                                   A->getRowData(memory::DEVICE),
-                                   A->getColData(memory::DEVICE),
-                                   A->getValues( memory::DEVICE), 
-                                   CUSPARSE_INDEX_32I, 
-                                   CUSPARSE_INDEX_32I,
-                                   CUSPARSE_INDEX_BASE_ZERO,
-                                   CUDA_R_64F);
-        error_sum += status;
-        values_changed_ = false;
-      }
-      if (!workspace_->matvecSetup()) {
-        //setup first, allocate, etc.
-        size_t bufferSize = 0;
+    void* buffer_spmv = workspace_->getSpmvBuffer();
+    cusparseHandle_t handle_cusparse = workspace_->getCusparseHandle();
+    if (values_changed_) {
+      status = cusparseCreateCsr(&matA, 
+                                 A->getNumRows(),
+                                 A->getNumColumns(),
+                                 A->getNnz(),
+                                 A->getRowData(memory::DEVICE),
+                                 A->getColData(memory::DEVICE),
+                                 A->getValues( memory::DEVICE), 
+                                 CUSPARSE_INDEX_32I, 
+                                 CUSPARSE_INDEX_32I,
+                                 CUSPARSE_INDEX_BASE_ZERO,
+                                 CUDA_R_64F);
+      error_sum += status;
+      values_changed_ = false;
+    }
+    if (!workspace_->matvecSetup()) {
+      //setup first, allocate, etc.
+      size_t bufferSize = 0;
 
-        status = cusparseSpMV_bufferSize(handle_cusparse, 
-                                         CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                         &MINUSONE,
-                                         matA,
-                                         vecx,
-                                         &ONE,
-                                         vecAx,
-                                         CUDA_R_64F,
-                                         CUSPARSE_SPMV_CSR_ALG2, 
-                                         &bufferSize);
-        error_sum += status;
-        mem_.deviceSynchronize();
-        mem_.allocateBufferOnDevice(&buffer_spmv, bufferSize);
-        workspace_->setSpmvMatrixDescriptor(matA);
-        workspace_->setSpmvBuffer(buffer_spmv);
-
-        workspace_->matvecSetupDone();
-      } 
-
-      status = cusparseSpMV(handle_cusparse,
-                            CUSPARSE_OPERATION_NON_TRANSPOSE,       
-                            alpha, 
-                            matA, 
-                            vecx, 
-                            beta, 
-                            vecAx, 
-                            CUDA_R_64F,
-                            CUSPARSE_SPMV_CSR_ALG2, 
-                            buffer_spmv);
+      status = cusparseSpMV_bufferSize(handle_cusparse, 
+                                       CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                       &MINUSONE,
+                                       matA,
+                                       vecx,
+                                       &ONE,
+                                       vecAx,
+                                       CUDA_R_64F,
+                                       CUSPARSE_SPMV_CSR_ALG2, 
+                                       &bufferSize);
       error_sum += status;
       mem_.deviceSynchronize();
-      if (status)
-        out::error() << "Matvec status: "   << status                    << ". "
-                     << "Last error code: " << mem_.getLastDeviceError() << ".\n";
-      vec_result->setDataUpdated(memory::DEVICE);
+      mem_.allocateBufferOnDevice(&buffer_spmv, bufferSize);
+      workspace_->setSpmvMatrixDescriptor(matA);
+      workspace_->setSpmvBuffer(buffer_spmv);
 
-      cusparseDestroyDnVec(vecx);
-      cusparseDestroyDnVec(vecAx);
-      return error_sum;
+      workspace_->matvecSetupDone();
+    } 
+
+    status = cusparseSpMV(handle_cusparse,
+                          CUSPARSE_OPERATION_NON_TRANSPOSE,       
+                          alpha, 
+                          matA, 
+                          vecx, 
+                          beta, 
+                          vecAx, 
+                          CUDA_R_64F,
+                          CUSPARSE_SPMV_CSR_ALG2, 
+                          buffer_spmv);
+    error_sum += status;
+    mem_.deviceSynchronize();
+    if (status)
+      out::error() << "Matvec status: "   << status                    << ". "
+                   << "Last error code: " << mem_.getLastDeviceError() << ".\n";
+    vec_result->setDataUpdated(memory::DEVICE);
+
+    cusparseDestroyDnVec(vecx);
+    cusparseDestroyDnVec(vecAx);
+    return error_sum;
   }
 
+  /**
+   * @brief Matrix infinity norm
+   * 
+   * @param[in]  A - matrix
+   * @param[out] norm - matrix norm
+   * @return int error code, 0 if successful
+   * 
+   * @pre Matrix `A` is in CSR format.
+   * 
+   * @note If we decide to implement this function for different matrix
+   * format, the check for CSR matrix will be replaced with a switch
+   * statement to select implementation for recognized input matrix
+   * format.
+   */
   int MatrixHandlerCuda::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
-    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
-      out::error() << "Matrix has to be in CSR format for norm computation.\n";
-      return 1;
-    }
+    assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+           "Matrix has to be in CSR format for matrix-vector product.\n");
 
     if (workspace_->getNormBufferState() == false) { // not allocated  
       real_type* buffer;

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -39,8 +39,7 @@ namespace ReSolve {
                  vector_type* vec_x,
                  vector_type* vec_result,
                  const real_type* alpha,
-                 const real_type* beta,
-                 std::string matrix_type);
+                 const real_type* beta);
       virtual int matrixInfNorm(matrix::Sparse* A, real_type* norm);
       void setValuesChanged(bool isValuesChanged); 
     

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -28,17 +28,20 @@ namespace ReSolve {
   }
 
 
-  int MatrixHandlerHip::matvec(matrix::Sparse* Ageneric, 
+  int MatrixHandlerHip::matvec(matrix::Sparse* A, 
                                vector_type* vec_x, 
                                vector_type* vec_result, 
                                const real_type* alpha, 
-                               const real_type* beta,
-                               std::string matrixFormat) 
+                               const real_type* beta) 
   {
     using namespace constants;
+
+    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
+      out::error() << "Matrix has to be in CSR format for matrix-vector product.\n";
+      return 1;
+    }
+
     int error_sum = 0;
-    if (matrixFormat == "csr") {
-      matrix::Csr* A = dynamic_cast<matrix::Csr*>(Ageneric);
       //result = alpha *A*x + beta * result
       rocsparse_status status;
 
@@ -96,16 +99,15 @@ namespace ReSolve {
       vec_result->setDataUpdated(memory::DEVICE);
 
       return error_sum;
-    } else {
-      out::error() << "MatVec not implemented (yet) for " 
-                   << matrixFormat << " matrix format." << std::endl;
-      return 1;
-    }
   }
 
   int MatrixHandlerHip::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
-    // we assume A is in CSR format
+    if (A->getSparseFormat() != matrix::Sparse::COMPRESSED_SPARSE_ROW) {
+      out::error() << "Matrix has to be in CSR format for norm computation.\n";
+      return 1;
+    }
+
     real_type* d_r = workspace_->getDr();
     index_type d_r_size = workspace_->getDrSize();
     

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -41,8 +41,7 @@ namespace ReSolve {
                          vector_type* vec_x,
                          vector_type* vec_result,
                          const real_type* alpha,
-                         const real_type* beta,
-                         std::string matrix_type);
+                         const real_type* beta);
       
       virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm);
       

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -38,8 +38,7 @@ namespace ReSolve {
                          vector_type* vec_x,
                          vector_type* vec_result,
                          const real_type* alpha,
-                         const real_type* beta,
-                         std::string matrix_type) = 0;
+                         const real_type* beta) = 0;
       virtual int matrixInfNorm(matrix::Sparse* A, real_type* norm) = 0;
 
       virtual void setValuesChanged(bool isValuesChanged) = 0;    

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -135,6 +135,11 @@ namespace ReSolve {
     return this->nnz_;
   }
 
+  matrix::Sparse::SparseFormat matrix::Sparse::getSparseFormat() const
+  {
+    return sparse_format_;
+  }
+
   /**
    * @brief check if matrix is symmetric.
    *

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -25,7 +25,7 @@ namespace ReSolve { namespace matrix {
   {
     public:
       /// Supported sparse matrix formats
-      enum SparseFormat{TRIPLET, COMPRESSED_SPARSE_ROW, COMPRESSED_SPARSE_COLUMN};
+      enum SparseFormat{NONE, TRIPLET, COMPRESSED_SPARSE_ROW, COMPRESSED_SPARSE_COLUMN};
 
     public:
       //basic constructor
@@ -76,7 +76,7 @@ namespace ReSolve { namespace matrix {
       virtual int setNewValues(real_type* new_vals, memory::MemorySpace memspace);
     
     protected:
-      SparseFormat sparse_format_{COMPRESSED_SPARSE_ROW}; ///< Matrix format
+      SparseFormat sparse_format_{NONE}; ///< Matrix format
       index_type n_{0}; ///< number of rows
       index_type m_{0}; ///< number of columns
       index_type nnz_{0}; ///< number of non-zeros

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -8,15 +8,25 @@
 #include <resolve/MemoryUtils.hpp>
 
 namespace ReSolve { namespace matrix {
+
   /**
-   * @brief This class implements basic sparse matrix interface. (Almost) all sparse matrix formats store information about matrix rows and columns (as integers) and data (as real numbers).
-   *        This class is virtualand implements only what is common for all basic formats.
-   *        Note that regardless of how row/column information is stored, all values need to be stored, so all utilities needed for values are implemented in this class.
+   * @brief This class implements basic sparse matrix interface. 
+   * 
+   * Most of sparse matrix formats store information about matrix rows and
+   * columns as integers and nonzero element values as real numbers.
+   * This class is virtual and implements only what is common for all basic
+   * formats. Note that regardless of how row/column information is stored,
+   * all nonzero matrix values need to be stored, so all utilities needed for
+   * the values are implemented in this class.
    *
    * @author Kasia Swirydowicz <kasia.swirydowicz@pnnl.gov>
    */
   class Sparse 
   {
+    public:
+      /// Supported sparse matrix formats
+      enum SparseFormat{TRIPLET, COMPRESSED_SPARSE_ROW, COMPRESSED_SPARSE_COLUMN};
+
     public:
       //basic constructor
       Sparse();
@@ -32,6 +42,7 @@ namespace ReSolve { namespace matrix {
       index_type getNumRows();
       index_type getNumColumns();
       index_type getNnz();
+      SparseFormat getSparseFormat() const;
 
       bool symmetric(); 
       bool expanded();
@@ -65,7 +76,7 @@ namespace ReSolve { namespace matrix {
       virtual int setNewValues(real_type* new_vals, memory::MemorySpace memspace);
     
     protected:
-      //size
+      SparseFormat sparse_format_{COMPRESSED_SPARSE_ROW}; ///< Matrix format
       index_type n_{0}; ///< number of rows
       index_type m_{0}; ///< number of columns
       index_type nnz_{0}; ///< number of non-zeros

--- a/tests/functionality/testKLU.cpp
+++ b/tests/functionality/testKLU.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 
   // real_type normXmatrix1 = sqrt(vector_handler->dot(vec_test, vec_test, ReSolve::memory::HOST));
   matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr",ReSolve::memory::HOST); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
   error_sum += status;
   
   real_type normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
@@ -118,14 +118,14 @@ int main(int argc, char *argv[])
  
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
   //evaluate the residual ON THE CPU using COMPUTED solution
  
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
  
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::HOST); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
   error_sum += status;
 
   real_type normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
  
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::HOST); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
   

--- a/tests/functionality/testKLU_GLU.cpp
+++ b/tests/functionality/testKLU_GLU.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
   vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr",ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   
   real_type normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
  
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
   vec_x->update(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
   error_sum += status;
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
   //evaluate the residual ON THE CPU using COMPUTED solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
  
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
    matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -204,7 +204,7 @@ int main(int argc, char *argv[])
  
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   

--- a/tests/functionality/testKLU_Rf.cpp
+++ b/tests/functionality/testKLU_Rf.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
   vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr",ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   
   real_type normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -121,14 +121,14 @@ int main(int argc, char *argv[])
  
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
  
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
  
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   

--- a/tests/functionality/testKLU_Rf_FGMRES.cpp
+++ b/tests/functionality/testKLU_Rf_FGMRES.cpp
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
   //evaluate the residual ||b-Ax||
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr",ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -144,14 +144,14 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
 
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
   //evaluate final residual
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   std::cout<<"Results (second matrix): "<<std::endl<<std::endl;

--- a/tests/functionality/testKLU_RocSolver.cpp
+++ b/tests/functionality/testKLU_RocSolver.cpp
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
 
   // real_type normXmatrix1 = sqrt(vector_handler->dot(vec_test, vec_test, ReSolve::memory::DEVICE));
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr",ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -144,14 +144,14 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   //evaluate the residual ON THE CPU using COMPUTED solution
 
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
 
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 

--- a/tests/functionality/testKLU_RocSolver_FGMRES.cpp
+++ b/tests/functionality/testKLU_RocSolver_FGMRES.cpp
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
   //evaluate the residual ||b-Ax||
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr",ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -144,14 +144,14 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
 
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -226,7 +226,7 @@ int main(int argc, char *argv[])
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
   //evaluate final residual
-  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
 
   real_type normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -242,7 +242,7 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   std::cout<<"Results (second matrix): "<<std::endl<<std::endl;

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -119,7 +119,6 @@ int main(int argc, char* argv[])
                                      &vec_r,
                                      &ONE,
                                      &MINUSONE,
-                                     "csr",
                                      ReSolve::memory::HOST);
 
   // Compute vector norms
@@ -139,7 +138,6 @@ int main(int argc, char* argv[])
                                      &vec_r,
                                      &ONE,
                                      &MINUSONE,
-                                     "csr",
                                      ReSolve::memory::HOST);
   real_type exactSol_normRmatrix = sqrt(vector_handler.dot(&vec_r, &vec_r, ReSolve::memory::HOST));
 
@@ -220,7 +218,6 @@ int main(int argc, char* argv[])
                                      &vec_r,
                                      &ONE,
                                      &MINUSONE,
-                                     "csr",
                                      ReSolve::memory::HOST);
 
   // Compute vector norms
@@ -241,7 +238,6 @@ int main(int argc, char* argv[])
                                      &vec_r,
                                      &ONE,
                                      &MINUSONE,
-                                     "csr",
                                      ReSolve::memory::HOST);
   // Compute residual error norm                                     
   exactSol_normRmatrix = sqrt(vector_handler.dot(&vec_r, &vec_r, ReSolve::memory::HOST));

--- a/tests/functionality/testSysGLU.cpp
+++ b/tests/functionality/testSysGLU.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
   // Compute residual on device
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   
   // Compute residual norm
@@ -164,14 +164,14 @@ int main(int argc, char *argv[])
  
   // Compute residual norm ON THE GPU using REFERENCE solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   // Compute residual norm ON THE CPU using COMPUTED solution
   vec_x->update(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
   real_type normRmatrix1CPU = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::HOST));
 
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
   // Compute residual norm for the second system
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   
@@ -261,7 +261,7 @@ int main(int argc, char *argv[])
  
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
   // Evaluate the residual norm ||b-Ax|| on the device
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr",ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
@@ -182,13 +182,13 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE,"csr", ReSolve::memory::HOST);
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
   real_type normRmatrix1CPU = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::HOST));
 
@@ -247,7 +247,7 @@ int main(int argc, char *argv[])
   // Compute residual norm for the second system
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
 
   //compute the residual using exact solution
   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, "csr", ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -70,7 +70,7 @@ public:
     real_type alpha = 2.0/30.0;
     real_type beta  = 2.0;
     handler_.setValuesChanged(true, memspace_);
-    handler_.matvec(A, &x, &y, &alpha, &beta, "csr", memspace_);
+    handler_.matvec(A, &x, &y, &alpha, &beta, memspace_);
 
     status *= verifyAnswer(y, 4.0);
 


### PR DESCRIPTION
Since only CSR format is supported by the `MatrixHandler` methods for matrix-vector product and matrix norm, these methods will now check if the matrix is CSR and, if not, return an error. When (if) `MatrixHandler` supports other sparse formats, we can add switch to those methods to perform computations specific to the (supported) input matrix  format.

This PR:
- Removes input argument from `matvec` method specifying the matrix format.
- Adds member variable with matrix format ID to `matrix::Sparse` class. Each derived class (`Csr`, `Csc`, etc.) sets this ID at construction. This allows `matvec` and `matrixNorm` to check matrix format "under the hood".
- Resolves #180.
- Updates examples and tests with new `MatrixHandler::matvec` interface.

