### PR TITLE
Fix memory leak in `GramSchmidt` class; setup now in GMRES

### DIFF
--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -155,7 +155,6 @@ int main(int argc, char *argv[])
         index_type* Q = KLU->getQOrdering();
         Rf->setup(A, L, U, P, Q);
         std::cout<<"about to set FGMRES" <<std::endl;
-        GS->setup(A->getNumRows(), FGMRES->getRestart()); 
         FGMRES->setup(A); 
       }
     } else {

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -151,7 +151,6 @@ int main(int argc, char *argv[])
         std::cout<<"about to set FGMRES" <<std::endl;
         FGMRES->setRestart(1000); 
         FGMRES->setMaxit(2000);
-        GS->setup(A->getNumRows(), FGMRES->getRestart()); 
         FGMRES->setup(A);
       }
     } else {

--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -156,7 +156,6 @@ int main(int argc, char *argv[])
         Rf->setup(A, L, U, P, Q, vec_rhs);
         Rf->refactorize();
         std::cout<<"about to set FGMRES" <<std::endl;
-        GS->setup(A->getNumRows(), FGMRES->getRestart()); 
         FGMRES->setup(A); 
       }
       RESOLVE_RANGE_POP("KLU");

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -164,9 +164,9 @@ namespace ReSolve
           vector_handler_->scal(&t, vec_w_, memspace_);  
         } else {
           assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
-          return -1;
+          return 1;
         }
-        break;
+        return 0;
 
       case cgs2:
         vec_v_->setData(V->getVectorData(i + 1, memspace_), memspace_);
@@ -210,10 +210,9 @@ namespace ReSolve
           vector_handler_->scal(&t, vec_v_, memspace_);  
         } else {
           assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
-          return -1;
+          return 1;
         }
         return 0;
-        break;
 
       case mgs_two_sync:
         // V[1:i]^T[V[i] w]
@@ -260,11 +259,10 @@ namespace ReSolve
           }        
         } else {
           assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
-          return -1;
+          return 1;
         }
         h_rv = nullptr;
         return 0;
-        break;
 
       case mgs_pm:
         vec_v_->setData(V->getVectorData(i, memspace_), memspace_);
@@ -332,11 +330,10 @@ namespace ReSolve
           vector_handler_->scal(&t, vec_w_, memspace_);  
         } else {
           assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
-          return -1;
+          return 1;
         }
         h_rv = nullptr;
         return 0;
-        break;
 
       case cgs1:
         vec_v_->setData(V->getVectorData(i + 1, memspace_), memspace_);
@@ -361,14 +358,13 @@ namespace ReSolve
           vector_handler_->scal(&t, vec_v_, memspace_);  
         } else {
           assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
-          return -1;
+          return 1;
         }
         return 0;
-        break;
+        
       default:
         assert(0 && "Iterative refinement failed, wrong orthogonalization.\n");
-        return -1;
-        break;
+        return 1;
     } //switch
 
     return 0;

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -100,7 +100,6 @@ namespace ReSolve
     num_vecs_ = restart;
     if((variant_ == mgs_two_sync) || (variant_ == mgs_pm)) {
       h_L_  = new real_type[num_vecs_ * (num_vecs_ + 1)]();
-      h_rv_ = new real_type[num_vecs_ + 1]();
 
       vec_rv_ = new vector_type(num_vecs_ + 1, 2);
       vec_rv_->allocate(memspace_);
@@ -108,24 +107,32 @@ namespace ReSolve
 
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
       vec_Hcolumn_->allocate(memspace_);      
-      vec_Hcolumn_->setToZero(memspace_);      
+      vec_Hcolumn_->setToZero(memspace_);
+
+      setup_complete_ = true; 
     }
     if(variant_ == cgs2) {
       h_aux_ = new real_type[num_vecs_ + 1]();
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
       vec_Hcolumn_->allocate(memspace_);
       vec_Hcolumn_->setToZero(memspace_);      
+
+      setup_complete_ = true; 
     }
     if(variant_ == cgs1) {
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
       vec_Hcolumn_->allocate(memspace_);      
       vec_Hcolumn_->setToZero(memspace_);      
+
+      setup_complete_ = true; 
     }
     if(variant_ == mgs_pm) {
       h_aux_ = new real_type[num_vecs_ + 1]();
+
+      setup_complete_ = true; 
     }
 
-    return 0;
+    return setup_complete_ ? 0 : 1;
   }
 
   int GramSchmidt::orthogonalize(index_type n, vector::Vector* V, real_type* H, index_type i)
@@ -134,6 +141,7 @@ namespace ReSolve
 
     double t = 0.0;
     double s = 0.0;
+    real_type* h_rv = nullptr;
 
     switch (variant_) {
       case mgs: 
@@ -219,14 +227,14 @@ namespace ReSolve
         vec_rv_->copyData(memspace_, memory::HOST);
 
         vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
-        h_rv_ = vec_rv_->getVectorData(1, memory::HOST);
+        h_rv = vec_rv_->getVectorData(1, memory::HOST);
         
         for(int j=0; j<=i; ++j) {
           H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
         }
         // triangular solve
         for(int j = 0; j <= i; ++j) {
-          H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv_[j];
+          H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv[j];
           s = 0.0;
           for(int k = 0; k < j; ++k) {
             s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * H[ idxmap(i, k, num_vecs_ + 1) ];
@@ -254,6 +262,7 @@ namespace ReSolve
           assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
           return -1;
         }
+        h_rv = nullptr;
         return 0;
         break;
 
@@ -267,7 +276,7 @@ namespace ReSolve
         vec_rv_->copyData(memspace_, memory::HOST);
 
         vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
-        h_rv_ = vec_rv_->getVectorData(1, memory::HOST);
+        h_rv = vec_rv_->getVectorData(1, memory::HOST);
 
         for(int j = 0; j <= i; ++j) {
           H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
@@ -275,7 +284,7 @@ namespace ReSolve
 
         //triangular solve
         for(int j = 0; j <= i; ++j) {
-          H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv_[j];
+          H[ idxmap(i, j, num_vecs_ + 1) ] = h_rv[j];
           s = 0.0;
           for(int k = 0; k < j; ++k) {
             s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * H[ idxmap(i, k, num_vecs_ + 1) ];
@@ -287,16 +296,16 @@ namespace ReSolve
         double h;
         for(int j = 0; j <= i; ++j) {
           // go through COLUMN OF L
-          h_rv_[j] = 0.0;
+          h_rv[j] = 0.0;
           for(int k = j + 1; k <= i; ++k) {
             h = h_L_[ idxmap(k, j, num_vecs_ + 1)];
-            h_rv_[j] += H[ idxmap(i, k, num_vecs_ + 1) ] * h;
+            h_rv[j] += H[ idxmap(i, k, num_vecs_ + 1) ] * h;
           }
         }
 
         // and do one more tri solve with L^T: h_aux = (I-L)^{-1}h_rv
         for(int j = 0; j <= i; ++j) {
-          h_aux_[j] = h_rv_[j];
+          h_aux_[j] = h_rv[j];
           s = 0.0;
           for(int k = 0; k < j; ++k) {
             s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * h_aux_[k];
@@ -325,6 +334,7 @@ namespace ReSolve
           assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
           return -1;
         }
+        h_rv = nullptr;
         return 0;
         break;
 
@@ -373,8 +383,6 @@ namespace ReSolve
     if(variant_ == mgs_two_sync || variant_ == mgs_pm) {    
       delete h_L_;
       h_L_ = nullptr;
-      delete h_rv_;
-      h_rv_ = nullptr;  
 
       delete vec_rv_;
       vec_rv_ = nullptr;

--- a/resolve/GramSchmidt.hpp
+++ b/resolve/GramSchmidt.hpp
@@ -38,7 +38,6 @@ namespace ReSolve
       vector_type* vec_Hcolumn_{nullptr};
 
       real_type* h_L_{nullptr};
-      real_type* h_rv_{nullptr};
       real_type* h_aux_{nullptr};
       VectorHandler* vector_handler_{nullptr};
 

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -18,15 +18,6 @@ namespace ReSolve
   using out = io::Logger;
 
   LinSolverIterativeFGMRES::LinSolverIterativeFGMRES(MatrixHandler* matrix_handler,
-                                                     VectorHandler* vector_handler)
-  {
-    matrix_handler_ = matrix_handler;
-    vector_handler_ = vector_handler;
-    GS_ = nullptr;
-    setMemorySpace();
-  }
-
-  LinSolverIterativeFGMRES::LinSolverIterativeFGMRES(MatrixHandler* matrix_handler,
                                                      VectorHandler* vector_handler,
                                                      GramSchmidt*   gs)
   {
@@ -94,6 +85,8 @@ namespace ReSolve
       allocateSolverData();
       is_solver_set_ = true;
     }
+
+    GS_->setup(n_, restart_);
 
     return 0;
   }

--- a/resolve/LinSolverIterativeFGMRES.hpp
+++ b/resolve/LinSolverIterativeFGMRES.hpp
@@ -27,8 +27,6 @@ namespace ReSolve
 
     public:
       LinSolverIterativeFGMRES(MatrixHandler* matrix_handler,
-                               VectorHandler* vector_handler);
-      LinSolverIterativeFGMRES(MatrixHandler* matrix_handler,
                                VectorHandler* vector_handler,
                                GramSchmidt*   gs);
       LinSolverIterativeFGMRES(index_type restart,

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -22,16 +22,6 @@ namespace ReSolve
 {
   using out = io::Logger;
 
-  LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(MatrixHandler* matrix_handler,
-                                                             VectorHandler* vector_handler)
-  {
-    matrix_handler_ = matrix_handler;
-    vector_handler_ = vector_handler;
-    GS_ = nullptr;
-
-    setMemorySpace();
-  }
-
   LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(MatrixHandler*  matrix_handler,
                                                              VectorHandler*  vector_handler, 
                                                              SketchingMethod rand_method, 
@@ -122,6 +112,8 @@ namespace ReSolve
       allocateSketchingData();
       is_sketching_set_ = true;
     }
+
+    GS_->setup(n_, restart_);
 
     return 0;
   }

--- a/resolve/LinSolverIterativeRandFGMRES.hpp
+++ b/resolve/LinSolverIterativeRandFGMRES.hpp
@@ -41,9 +41,6 @@ namespace ReSolve
                             fwht};  // fast Walsh-Hadamard transform
     
       LinSolverIterativeRandFGMRES(MatrixHandler* matrix_handler,
-                                   VectorHandler* vector_handler);
-
-      LinSolverIterativeRandFGMRES(MatrixHandler* matrix_handler,
                                    VectorHandler* vector_handler,
                                    SketchingMethod rand_method, 
                                    GramSchmidt*   gs);

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -178,11 +178,9 @@ namespace ReSolve
     if (solveMethod_ == "randgmres") {
       auto* rgmres = dynamic_cast<LinSolverIterativeRandFGMRES*>(iterativeSolver_);
       status += rgmres->setup(A_);
-      status += gs_->setup(rgmres->getKrand(), rgmres->getRestart());
     } else if (solveMethod_ == "fgmres") {
       auto* fgmres = dynamic_cast<LinSolverIterativeFGMRES*>(iterativeSolver_);
       status += fgmres->setup(A_);
-      status += gs_->setup(A_->getNumRows(), fgmres->getRestart()); 
     } else {
       // do nothing
     }
@@ -417,7 +415,6 @@ namespace ReSolve
 #endif
 
     if (irMethod_ == "fgmres") {
-      gs_->setup(A_->getNumRows(), iterativeSolver_->getRestart()); 
       status += iterativeSolver_->setup(A_);
       status += iterativeSolver_->setupPreconditioner("LU", refactorizationSolver_);
     }

--- a/tests/functionality/testKLU_Rf_FGMRES.cpp
+++ b/tests/functionality/testKLU_Rf_FGMRES.cpp
@@ -186,7 +186,6 @@ int main(int argc, char *argv[])
   FGMRES->setFlexible(1); 
   FGMRES->setTol(1e-17); 
 
-  GS->setup(A->getNumRows(), FGMRES->getRestart()); 
   status =  FGMRES->setup(A); 
   error_sum += status;
 

--- a/tests/functionality/testKLU_RocSolver_FGMRES.cpp
+++ b/tests/functionality/testKLU_RocSolver_FGMRES.cpp
@@ -181,7 +181,6 @@ int main(int argc, char *argv[])
   FGMRES->setMaxit(200); 
   FGMRES->setRestart(100); 
 
-  GS->setup(A->getNumRows(), FGMRES->getRestart()); 
   status =  FGMRES->setup(A); 
   error_sum += status;
 

--- a/tests/functionality/testRandGMRES_Cuda.cpp
+++ b/tests/functionality/testRandGMRES_Cuda.cpp
@@ -63,9 +63,6 @@ int main(int argc, char *argv[])
   status = Rf->setup(A);
   error_sum += status;
 
-  status = GS->setup(FGMRES->getKrand(), FGMRES->getRestart()); 
-  error_sum += status;
-
   FGMRES->setMaxit(2500);
   FGMRES->setTol(tol);
   FGMRES->setup(A);

--- a/tests/functionality/testRandGMRES_Rocm.cpp
+++ b/tests/functionality/testRandGMRES_Rocm.cpp
@@ -61,9 +61,6 @@ int main(int argc, char *argv[])
   status = Rf->setup(A);
   error_sum += status;
 
-  status = GS->setup(FGMRES->getKrand(), FGMRES->getRestart()); 
-  error_sum += status;
-
   FGMRES->setMaxit(2500);
   FGMRES->setTol(tol);
   FGMRES->setup(A);


### PR DESCRIPTION
The PR addresses these issues issues:
1. Fix memory leak in `GramSchmidt` class (resolves #196).
2. Make iterative solver owning `GramSchmidt` instance responsible for setting it up (resolves #197).
3. Removes unused FGMRES constructors.
4. Sets flags correctly upon completing `GramSchmidt` instance setup.





