### PR TITLE
Rename `copyData` -> `syncData` and ensure correct flags set when syncing

### DIFF
--- a/examples/r_KLU_GLU.cpp
+++ b/examples/r_KLU_GLU.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_KLU_GLU.cpp
+++ b/examples/r_KLU_GLU.cpp
@@ -96,19 +96,24 @@ int main(int argc, char *argv[])
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
-    std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+              << ", nnz: "       << A->getNnz() 
+              << ", symmetric? " << A->symmetric()
+              << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
     if (i < 1) {
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
     //Now call direct solver
     int status;
     if (i < 1) {

--- a/examples/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/r_KLU_GLU_matrix_values_update.cpp
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
         vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
         vec_rhs->setDataUpdated(ReSolve::memory::HOST);
       } else { 
-        A->copyData(ReSolve::memory::DEVICE);
+        A->syncData(ReSolve::memory::DEVICE);
         vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       }
       std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/r_KLU_GLU_matrix_values_update.cpp
@@ -105,57 +105,60 @@ int main(int argc, char *argv[])
       //ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
-      std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
-      mat_file.close();
-      rhs_file.close();
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
 
-      // Update host and device data.
-      if (i < 1) { 
-        vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-        vec_rhs->setDataUpdated(ReSolve::memory::HOST);
-      } else { 
-        A->syncData(ReSolve::memory::DEVICE);
-        vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-      }
-      std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
-      //Now call direct solver
-      int status;
-      if (i < 1){
-        KLU->setup(A);
-        status = KLU->analyze();
-        std::cout<<"KLU analysis status: "<<status<<std::endl;
-        status = KLU->factorize();
-        std::cout<<"KLU factorization status: "<<status<<std::endl;
-        matrix_type* L = KLU->getLFactor();
-        matrix_type* U = KLU->getUFactor();
-        if (L == nullptr) {printf("ERROR");}
-        index_type* P = KLU->getPOrdering();
-        index_type* Q = KLU->getQOrdering();
-        GLU->setup(A, L, U, P, Q); 
-        status = GLU->solve(vec_rhs, vec_x);
-        std::cout<<"GLU solve status: "<<status<<std::endl;      
-        //      status = KLU->solve(vec_rhs, vec_x);
-        //    std::cout<<"KLU solve status: "<<status<<std::endl;      
-      } else {
-        //status =  KLU->refactorize();
-        std::cout<<"Using CUSOLVER GLU"<<std::endl;
-        status = GLU->refactorize();
-        std::cout<<"CUSOLVER GLU refactorization status: "<<status<<std::endl;      
-        status = GLU->solve(vec_rhs, vec_x);
-        std::cout<<"CUSOLVER GLU solve status: "<<status<<std::endl;      
-      }
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+              << ", nnz: "       << A->getNnz() 
+              << ", symmetric? " << A->symmetric()
+              << ", Expanded? "  << A->expanded() << std::endl;
+    mat_file.close();
+    rhs_file.close();
 
-
-      matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
-
-      std::cout << "\t 2-Norm of the residual: " 
-                << std::scientific << std::setprecision(16) 
-                << sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE)) << "\n";
-
-
+    // Update host and device data.
+    if (i < 1) { 
+      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+    } else { 
+      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
+    //Now call direct solver
+    int status;
+    if (i < 1){
+      KLU->setup(A);
+      status = KLU->analyze();
+      std::cout<<"KLU analysis status: "<<status<<std::endl;
+      status = KLU->factorize();
+      std::cout<<"KLU factorization status: "<<status<<std::endl;
+      matrix_type* L = KLU->getLFactor();
+      matrix_type* U = KLU->getUFactor();
+      if (L == nullptr) {printf("ERROR");}
+      index_type* P = KLU->getPOrdering();
+      index_type* Q = KLU->getQOrdering();
+      GLU->setup(A, L, U, P, Q); 
+      status = GLU->solve(vec_rhs, vec_x);
+      std::cout<<"GLU solve status: "<<status<<std::endl;      
+      //      status = KLU->solve(vec_rhs, vec_x);
+      //    std::cout<<"KLU solve status: "<<status<<std::endl;      
+    } else {
+      //status =  KLU->refactorize();
+      std::cout<<"Using CUSOLVER GLU"<<std::endl;
+      status = GLU->refactorize();
+      std::cout<<"CUSOLVER GLU refactorization status: "<<status<<std::endl;      
+      status = GLU->solve(vec_rhs, vec_x);
+      std::cout<<"CUSOLVER GLU solve status: "<<status<<std::endl;      
+    }
+    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+
+
+    matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+
+    std::cout << "\t 2-Norm of the residual: " 
+              << std::scientific << std::setprecision(16) 
+              << sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE)) << "\n";
+  }
 
     //now DELETE
     delete A;

--- a/examples/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_cusolverrf_redo_factorization.cpp
@@ -105,19 +105,24 @@ int main(int argc, char *argv[] )
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
-    std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+              << ", nnz: "       << A->getNnz() 
+              << ", symmetric? " << A->symmetric()
+              << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
     if (i < 2) { 
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
     //Now call direct solver
     if (i < 2) {
       KLU->setup(A);
@@ -132,6 +137,8 @@ int main(int argc, char *argv[] )
         U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
         ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
         ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
+        L_csc->syncData(ReSolve::memory::DEVICE);
+        U_csc->syncData(ReSolve::memory::DEVICE);
         matrix_handler->csc2csr(L_csc,L, ReSolve::memory::DEVICE);
         matrix_handler->csc2csr(U_csc,U, ReSolve::memory::DEVICE);
         if (L == nullptr) {

--- a/examples/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_cusolverrf_redo_factorization.cpp
@@ -114,7 +114,7 @@ int main(int argc, char *argv[] )
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_KLU_rf.cpp
+++ b/examples/r_KLU_rf.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[] )
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_KLU_rf.cpp
+++ b/examples/r_KLU_rf.cpp
@@ -95,19 +95,24 @@ int main(int argc, char *argv[] )
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
-    std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+              << ", nnz: "       << A->getNnz() 
+              << ", symmetric? " << A->symmetric()
+              << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
     if (i < 2) { 
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
     //Now call direct solver
     int status;
     if (i < 2){
@@ -123,6 +128,8 @@ int main(int argc, char *argv[] )
         ReSolve::matrix::Csc* U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
         ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
         ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
+        L_csc->syncData(ReSolve::memory::DEVICE);
+        U_csc->syncData(ReSolve::memory::DEVICE);
         matrix_handler->csc2csr(L_csc,L, ReSolve::memory::DEVICE);
         matrix_handler->csc2csr(U_csc,U, ReSolve::memory::DEVICE);
         if (L == nullptr) {printf("ERROR");}

--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -99,19 +99,24 @@ int main(int argc, char *argv[])
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
-    std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+              << ", nnz: "       << A->getNnz() 
+              << ", symmetric? " << A->symmetric()
+              << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
     if (i < 2) { 
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
     //Now call direct solver
     int status;
     real_type norm_b;
@@ -146,6 +151,8 @@ int main(int argc, char *argv[])
         ReSolve::matrix::Csc* U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
         ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
         ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
+        L_csc->syncData(ReSolve::memory::DEVICE);
+        U_csc->syncData(ReSolve::memory::DEVICE);
         matrix_handler->csc2csr(L_csc,L, ReSolve::memory::DEVICE);
         matrix_handler->csc2csr(U_csc,U, ReSolve::memory::DEVICE);
         if (L == nullptr) {

--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -101,7 +101,13 @@ int main(int argc, char *argv[])
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
-    std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+              << ", nnz: "       << A->getNnz() 
+              << ", symmetric? " << A->symmetric()
+              << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
@@ -113,7 +119,8 @@ int main(int argc, char *argv[])
       A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
     //Now call direct solver
     int status;
     real_type norm_b;
@@ -139,6 +146,8 @@ int main(int argc, char *argv[])
         ReSolve::matrix::Csc* U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
         ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
         ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
+        L_csc->syncData(ReSolve::memory::DEVICE);
+        U_csc->syncData(ReSolve::memory::DEVICE);
 
         matrix_handler->csc2csr(L_csc,L, ReSolve::memory::DEVICE);
         matrix_handler->csc2csr(U_csc,U, ReSolve::memory::DEVICE);

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     RESOLVE_RANGE_POP("Convert to CSR");

--- a/examples/r_KLU_rocsolverrf.cpp
+++ b/examples/r_KLU_rocsolverrf.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[] )
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -27,8 +27,8 @@ int main(int argc, char *argv[] )
   std::string  rhsFileName = argv[2];
 
   index_type numSystems = atoi(argv[3]);
-  std::cout<<"Family mtx file name: "<< matrixFileName << ", total number of matrices: "<<numSystems<<std::endl;
-  std::cout<<"Family rhs file name: "<< rhsFileName << ", total number of RHSes: " << numSystems<<std::endl;
+  std::cout << "Family mtx file name: " << matrixFileName << ", total number of matrices: " << numSystems << std::endl;
+  std::cout << "Family rhs file name: " << rhsFileName    << ", total number of RHSes: "    << numSystems << std::endl;
 
   std::string fileId;
   std::string rhsId;
@@ -97,29 +97,34 @@ int main(int argc, char *argv[] )
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
-    std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+              << ", nnz: "       << A->getNnz() 
+              << ", symmetric? " << A->symmetric()
+              << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
     if (i < 2) { 
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
     //Now call direct solver
     int status;
     if (i < 2){
       KLU->setup(A);
       status = KLU->analyze();
-      std::cout<<"KLU analysis status: "<<status<<std::endl;
+      std::cout<<"KLU analysis status: " << status << std::endl;
       status = KLU->factorize();
-      std::cout<<"KLU factorization status: "<<status<<std::endl;
+      std::cout << "KLU factorization status: " << status << std::endl;
       status = KLU->solve(vec_rhs, vec_x);
-      std::cout<<"KLU solve status: "<<status<<std::endl;      
+      std::cout << "KLU solve status: " << status << std::endl;      
       if (i == 1) {
         ReSolve::matrix::Csc* L = (ReSolve::matrix::Csc*) KLU->getLFactor();
         ReSolve::matrix::Csc* U = (ReSolve::matrix::Csc*) KLU->getUFactor();
@@ -130,16 +135,16 @@ int main(int argc, char *argv[] )
         Rf->refactorize();
       }
     } else {
-      std::cout<<"Using rocsolver rf"<<std::endl;
+      std::cout << "Using rocsolver rf" << std::endl;
       status = Rf->refactorize();
-      std::cout<<"rocsolver rf refactorization status: "<<status<<std::endl;      
+      std::cout << "rocsolver rf refactorization status: " << status << std::endl;      
       status = Rf->solve(vec_rhs, vec_x);
-      std::cout<<"rocsolver rf solve status: "<<status<<std::endl;      
+      std::cout << "rocsolver rf solve status: " << status << std::endl;      
     }
+
+    // Check accuracy of the solution
     vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
     res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     b_nrm = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
@@ -148,15 +153,16 @@ int main(int argc, char *argv[] )
               << res_nrm/b_nrm << "\n";
     if (!isnan(res_nrm)) {
        if (res_nrm/b_nrm > 1e-7 ) {
-         std::cout << "\n \t !!! ALERT !!! Residual norm is too large; redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n \n";
+         std::cout << "\n \t !!! ALERT !!! Residual norm is too large; "
+                   << "redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n\n";
        
          KLU->setup(A);
          status = KLU->analyze();
-         std::cout<<"KLU analysis status: "<<status<<std::endl;
+         std::cout << "KLU analysis status: " << status << std::endl;
          status = KLU->factorize();
-         std::cout<<"KLU factorization status: "<<status<<std::endl;
+         std::cout << "KLU factorization status: " << status << std::endl;
          status = KLU->solve(vec_rhs, vec_x);
-         std::cout<<"KLU solve status: "<<status<<std::endl;      
+         std::cout << "KLU solve status: " << status << std::endl;      
          
          vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
          vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
@@ -166,7 +172,7 @@ int main(int argc, char *argv[] )
          matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
          res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
          
-         std::cout<<"\t New residual norm: "
+         std::cout << "\t New residual norm: "
            << std::scientific << std::setprecision(16)
            << res_nrm/b_nrm << "\n";
 

--- a/examples/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[] )
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_SysSolverCuda.cpp
+++ b/examples/r_SysSolverCuda.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_SysSolverHip.cpp
+++ b/examples/r_SysSolverHip.cpp
@@ -91,6 +91,9 @@ int main(int argc, char *argv[] )
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
     std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows()
               << " x " << A->getNumColumns()
               << ", nnz: " << A->getNnz()
@@ -102,12 +105,11 @@ int main(int argc, char *argv[] )
     // Update host and device data.
     if (i < 2) { 
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
     //Now call direct solver
     solver->setMatrix(A);
     int status = -1;

--- a/examples/r_SysSolverHip.cpp
+++ b/examples/r_SysSolverHip.cpp
@@ -104,7 +104,7 @@ int main(int argc, char *argv[] )
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_SysSolverHipRefine.cpp
+++ b/examples/r_SysSolverHipRefine.cpp
@@ -95,6 +95,9 @@ int main(int argc, char *argv[])
       ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
+    // Copy matrix data to device
+    A->syncData(ReSolve::memory::DEVICE);
+
     std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows()
               << " x " << A->getNumColumns()
               << ", nnz: " << A->getNnz()
@@ -106,12 +109,12 @@ int main(int argc, char *argv[])
     // Update host and device data.
     if (i < 2) { 
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
-    std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
+    std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
+
+    // Now call solver
     solver->setMatrix(A);
     int status;
     if (i < 2) {

--- a/examples/r_SysSolverHipRefine.cpp
+++ b/examples/r_SysSolverHipRefine.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      A->copyData(ReSolve::memory::DEVICE);
+      A->syncData(ReSolve::memory::DEVICE);
       vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;

--- a/examples/r_randGMRES.cpp
+++ b/examples/r_randGMRES.cpp
@@ -72,13 +72,17 @@ int main(int argc, char *argv[])
   vec_x->allocate(ReSolve::memory::DEVICE);
   vec_x->setToZero(ReSolve::memory::DEVICE);
   vec_r = new vector_type(A->getNumRows());
-  std::cout<<"Finished reading the matrix and rhs, size: "<<A->getNumRows()<<" x "<<A->getNumColumns()<< ", nnz: "<< A->getNnz()<< ", symmetric? "<<A->symmetric()<< ", Expanded? "<<A->expanded()<<std::endl;
+  std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
+            << ", nnz: "       << A->getNnz() 
+            << ", symmetric? " << A->symmetric()
+            << ", Expanded? "  << A->expanded() << std::endl;
   mat_file.close();
   rhs_file.close();
 
   A->syncData(ReSolve::memory::DEVICE);
   vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  //Now call direct solver
+
+  //Now call the solver
   real_type norm_b;
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
@@ -105,7 +109,6 @@ int main(int argc, char *argv[])
     << " final nrm: "
     << FGMRES->getFinalResidualNorm()/norm_b
     << " iter: " << FGMRES->getNumIter() << "\n";
-
 
   delete A;
   delete Rf;

--- a/examples/r_randGMRES.cpp
+++ b/examples/r_randGMRES.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
   mat_file.close();
   rhs_file.close();
 
-  A->copyData(ReSolve::memory::DEVICE);
+  A->syncData(ReSolve::memory::DEVICE);
   vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   //Now call direct solver
   real_type norm_b;

--- a/examples/r_randGMRES_CUDA.cpp
+++ b/examples/r_randGMRES_CUDA.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
   mat_file.close();
   rhs_file.close();
 
-  A->copyData(ReSolve::memory::DEVICE);
+  A->syncData(ReSolve::memory::DEVICE);
   vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   //Now call direct solver
   real_type norm_b;

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -223,7 +223,7 @@ namespace ReSolve
         // vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vec_rv_->setDataUpdated(memspace_);
-        vec_rv_->syncData(memspace_, memory::HOST);
+        vec_rv_->syncData(memory::HOST);
 
         vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);
@@ -271,7 +271,7 @@ namespace ReSolve
 
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vec_rv_->setDataUpdated(memspace_);
-        vec_rv_->syncData(memspace_, memory::HOST);
+        vec_rv_->syncData(memory::HOST);
 
         vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -223,7 +223,7 @@ namespace ReSolve
         // vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vec_rv_->setDataUpdated(memspace_);
-        vec_rv_->copyData(memspace_, memory::HOST);
+        vec_rv_->syncData(memspace_, memory::HOST);
 
         vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);
@@ -271,7 +271,7 @@ namespace ReSolve
 
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vec_rv_->setDataUpdated(memspace_);
-        vec_rv_->copyData(memspace_, memory::HOST);
+        vec_rv_->syncData(memspace_, memory::HOST);
 
         vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -44,7 +44,7 @@ namespace ReSolve
     addFactors(L, U);
 
     M_->setUpdated(ReSolve::memory::HOST);
-    M_->copyData(ReSolve::memory::DEVICE);
+    M_->syncData(ReSolve::memory::DEVICE);
 
     if (d_P_ == nullptr) {
       mem_.allocateArrayOnDevice(&d_P_, n); 

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -389,7 +389,9 @@ namespace ReSolve
     }
     if (refactorizationMethod_ == "cusolverrf") {
       matrix::Csc* L_csc = dynamic_cast<matrix::Csc*>(L_);
-      matrix::Csc* U_csc = dynamic_cast<matrix::Csc*>(U_);       
+      matrix::Csc* U_csc = dynamic_cast<matrix::Csc*>(U_);
+      L_csc->syncData(memory::DEVICE);
+      U_csc->syncData(memory::DEVICE);
       matrix::Csr* L_csr = new matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
       matrix::Csr* U_csr = new matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
       matrixHandler_->csc2csr(L_csc, L_csr, memory::DEVICE);

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -286,30 +286,38 @@ namespace ReSolve
     return -1;
   }
 
-  int matrix::Coo::syncData(memory::MemorySpace memspaceOut)
+  /**
+   * @brief Sync data in memspace with the updated memory space.
+   * 
+   * @param memspace - memory space to be synced up (HOST or DEVICE)
+   * @return int - 0 if successful, error code otherwise
+   * 
+   * @todo Handle case when neither memory space is updated. Currently,
+   * this function does nothing in that situation, quitely ignoring
+   * the sync call.
+   */
+  int matrix::Coo::syncData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
 
-    index_type nnz_current = nnz_;
-
-    switch (memspaceOut) {
+    switch (memspace) {
       case HOST:
         if ((d_data_updated_ == true) && (h_data_updated_ == false)) {
           if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
             out::error() << "In Coo::syncData one of host row or column data is null!\n";
           }
           if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
-            h_row_data_ = new index_type[nnz_current];      
-            h_col_data_ = new index_type[nnz_current];      
+            h_row_data_ = new index_type[nnz_];      
+            h_col_data_ = new index_type[nnz_];      
             owns_cpu_data_ = true;
           }
           if (h_val_data_ == nullptr) {
-            h_val_data_ = new real_type[nnz_current];      
+            h_val_data_ = new real_type[nnz_];      
             owns_cpu_vals_ = true;
           }
-          mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, nnz_current);
-          mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, nnz_current);
-          mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_, nnz_current);
+          mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, nnz_);
+          mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, nnz_);
+          mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_, nnz_);
           h_data_updated_ = true;
         }
         return 0;
@@ -319,22 +327,22 @@ namespace ReSolve
             out::error() << "In Coo::syncData one of device row or column data is null!\n";
           }
           if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
-            mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
-            mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);
+            mem_.allocateArrayOnDevice(&d_row_data_, nnz_);
+            mem_.allocateArrayOnDevice(&d_col_data_, nnz_);
             owns_gpu_data_ = true;
           }
           if (d_val_data_ == nullptr) {
-            mem_.allocateArrayOnDevice(&d_val_data_, nnz_current);
+            mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
             owns_gpu_vals_ = true;
           }
-          mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, nnz_current);
-          mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, nnz_current);
-          mem_.copyArrayHostToDevice(d_val_data_, h_val_data_, nnz_current);
+          mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, nnz_);
+          mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, nnz_);
+          mem_.copyArrayHostToDevice(d_val_data_, h_val_data_, nnz_);
           d_data_updated_ = true;
         }
         return 0;
       default:
-        return -1;
+        return 1;
     } // switch
   }
 

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -80,7 +80,7 @@ namespace ReSolve
         d_data_updated_ = true;
         owns_gpu_vals_ = true;
         owns_gpu_data_  = true;
-        copyData(memspaceDst);
+        syncData(memspaceDst);
         // Hijack data from the source
         *rows = nullptr;
         *cols = nullptr;
@@ -94,7 +94,7 @@ namespace ReSolve
         h_data_updated_ = true;
         owns_cpu_vals_ = true;
         owns_cpu_data_  = true;
-        copyData(memspaceDst);
+        syncData(memspaceDst);
         // Hijack data from the source
         *rows = nullptr;
         *cols = nullptr;
@@ -132,7 +132,7 @@ namespace ReSolve
   index_type* matrix::Coo::getRowData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_row_data_;
@@ -146,7 +146,7 @@ namespace ReSolve
   index_type* matrix::Coo::getColData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_col_data_;
@@ -160,7 +160,7 @@ namespace ReSolve
   real_type* matrix::Coo::getValues(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_val_data_;
@@ -286,7 +286,7 @@ namespace ReSolve
     return -1;
   }
 
-  int matrix::Coo::copyData(memory::MemorySpace memspaceOut)
+  int matrix::Coo::syncData(memory::MemorySpace memspaceOut)
   {
     using namespace ReSolve::memory;
 
@@ -296,7 +296,7 @@ namespace ReSolve
       case HOST:
         if ((d_data_updated_ == true) && (h_data_updated_ == false)) {
           if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-            out::error() << "In Coo::copyData one of host row or column data is null!\n";
+            out::error() << "In Coo::syncData one of host row or column data is null!\n";
           }
           if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
             h_row_data_ = new index_type[nnz_current];      
@@ -316,7 +316,7 @@ namespace ReSolve
       case DEVICE:
         if ((d_data_updated_ == false) && (h_data_updated_ == true)) {
           if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-            out::error() << "In Coo::copyData one of device row or column data is null!\n";
+            out::error() << "In Coo::syncData one of device row or column data is null!\n";
           }
           if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
             mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -1,6 +1,7 @@
 #include <cstring>  // <-- includes memcpy
 #include <iostream>
-#include <iomanip> 
+#include <iomanip>
+#include <cassert>
 
 #include <resolve/utilities/logger/Logger.hpp>
 #include "Coo.hpp"
@@ -132,7 +133,7 @@ namespace ReSolve
   index_type* matrix::Coo::getRowData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    syncData(memspace);
+
     switch (memspace) {
       case HOST:
         return this->h_row_data_;
@@ -146,7 +147,7 @@ namespace ReSolve
   index_type* matrix::Coo::getColData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    syncData(memspace);
+
     switch (memspace) {
       case HOST:
         return this->h_col_data_;
@@ -160,7 +161,7 @@ namespace ReSolve
   real_type* matrix::Coo::getValues(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    syncData(memspace);
+
     switch (memspace) {
       case HOST:
         return this->h_val_data_;
@@ -302,44 +303,56 @@ namespace ReSolve
 
     switch (memspace) {
       case HOST:
-        if ((d_data_updated_ == true) && (h_data_updated_ == false)) {
-          if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-            out::error() << "In Coo::syncData one of host row or column data is null!\n";
-          }
-          if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
-            h_row_data_ = new index_type[nnz_];      
-            h_col_data_ = new index_type[nnz_];      
-            owns_cpu_data_ = true;
-          }
-          if (h_val_data_ == nullptr) {
-            h_val_data_ = new real_type[nnz_];      
-            owns_cpu_vals_ = true;
-          }
-          mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, nnz_);
-          mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, nnz_);
-          mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_, nnz_);
-          h_data_updated_ = true;
+        if (h_data_updated_) {
+          out::misc() << "In Coo::syncData trying to sync host, but host already up to date!\n";
+          return 0;
         }
+        if (!d_data_updated_) {
+          out::error() << "In Coo::syncData trying to sync host with device, but device is out of date!\n";
+          assert(d_data_updated_);
+        }
+        if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
+          out::error() << "In Coo::syncData one of host row or column data is null!\n";
+        }
+        if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
+          h_row_data_ = new index_type[nnz_];      
+          h_col_data_ = new index_type[nnz_];      
+          owns_cpu_data_ = true;
+        }
+        if (h_val_data_ == nullptr) {
+          h_val_data_ = new real_type[nnz_];      
+          owns_cpu_vals_ = true;
+        }
+        mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, nnz_);
+        mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, nnz_);
+        mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_, nnz_);
+        h_data_updated_ = true;
         return 0;
       case DEVICE:
-        if ((d_data_updated_ == false) && (h_data_updated_ == true)) {
-          if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-            out::error() << "In Coo::syncData one of device row or column data is null!\n";
-          }
-          if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
-            mem_.allocateArrayOnDevice(&d_row_data_, nnz_);
-            mem_.allocateArrayOnDevice(&d_col_data_, nnz_);
-            owns_gpu_data_ = true;
-          }
-          if (d_val_data_ == nullptr) {
-            mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
-            owns_gpu_vals_ = true;
-          }
-          mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, nnz_);
-          mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, nnz_);
-          mem_.copyArrayHostToDevice(d_val_data_, h_val_data_, nnz_);
-          d_data_updated_ = true;
+        if (d_data_updated_) {
+          out::misc() << "In Coo::syncData trying to sync device, but device already up to date!\n";
+          return 0;
         }
+        if (!h_data_updated_) {
+          out::error() << "In Coo::syncData trying to sync device with host, but host is out of date!\n";
+          assert(h_data_updated_);
+        }
+        if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
+          out::error() << "In Coo::syncData one of device row or column data is null!\n";
+        }
+        if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
+          mem_.allocateArrayOnDevice(&d_row_data_, nnz_);
+          mem_.allocateArrayOnDevice(&d_col_data_, nnz_);
+          owns_gpu_data_ = true;
+        }
+        if (d_val_data_ == nullptr) {
+          mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
+          owns_gpu_vals_ = true;
+        }
+        mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, nnz_);
+        mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, nnz_);
+        mem_.copyArrayHostToDevice(d_val_data_, h_val_data_, nnz_);
+        d_data_updated_ = true;
         return 0;
       default:
         return 1;

--- a/resolve/matrix/Coo.hpp
+++ b/resolve/matrix/Coo.hpp
@@ -36,7 +36,7 @@ namespace ReSolve { namespace matrix {
 
       virtual void print(std::ostream& file_out = std::cout, index_type indexing_base = 0);
 
-      virtual int copyData(memory::MemorySpace memspaceOut);
+      virtual int syncData(memory::MemorySpace memspaceOut);
   };
 
 }} // namespace ReSolve::matrix

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -33,7 +33,7 @@ namespace ReSolve
   index_type* matrix::Csc::getRowData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_row_data_;
@@ -47,7 +47,7 @@ namespace ReSolve
   index_type* matrix::Csc::getColData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_col_data_;
@@ -61,7 +61,7 @@ namespace ReSolve
   real_type* matrix::Csc::getValues(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_val_data_;
@@ -193,7 +193,7 @@ namespace ReSolve
     return -1;
   }
 
-  int matrix::Csc::copyData(memory::MemorySpace memspaceOut)
+  int matrix::Csc::syncData(memory::MemorySpace memspaceOut)
   {
     using namespace ReSolve::memory;
 
@@ -203,7 +203,7 @@ namespace ReSolve
       case HOST:
         if ((d_data_updated_ == true) && (h_data_updated_ == false)) {
           if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-            out::error() << "In Csc::copyData one of host row or column data is null!\n";
+            out::error() << "In Csc::syncData one of host row or column data is null!\n";
           }
           if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
             h_col_data_ = new index_type[m_ + 1];      
@@ -223,7 +223,7 @@ namespace ReSolve
       case DEVICE:
         if ((d_data_updated_ == false) && (h_data_updated_ == true)) {
           if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-            out::error() << "In Csc::copyData one of device row or column data is null!\n";
+            out::error() << "In Csc::syncData one of device row or column data is null!\n";
           }
           if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
             mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -193,13 +193,21 @@ namespace ReSolve
     return -1;
   }
 
-  int matrix::Csc::syncData(memory::MemorySpace memspaceOut)
+  /**
+   * @brief Sync data in memspace with the updated memory space.
+   * 
+   * @param memspace - memory space to be synced up (HOST or DEVICE)
+   * @return int - 0 if successful, error code otherwise
+   * 
+   * @todo Handle case when neither memory space is updated. Currently,
+   * this function does nothing in that situation, quitely ignoring
+   * the sync call.
+   */
+  int matrix::Csc::syncData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
 
-    index_type nnz_current = nnz_;
-
-    switch(memspaceOut) {
+    switch(memspace) {
       case HOST:
         if ((d_data_updated_ == true) && (h_data_updated_ == false)) {
           if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
@@ -207,16 +215,16 @@ namespace ReSolve
           }
           if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
             h_col_data_ = new index_type[m_ + 1];      
-            h_row_data_ = new index_type[nnz_current];      
+            h_row_data_ = new index_type[nnz_];      
             owns_cpu_data_ = true;
           }
           if (h_val_data_ == nullptr) {
-            h_val_data_ = new real_type[nnz_current];      
+            h_val_data_ = new real_type[nnz_];      
             owns_cpu_vals_ = true;
           }
-          mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_,      m_ + 1);
-          mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, nnz_current);
-          mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_, nnz_current);
+          mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, m_ + 1);
+          mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_,   nnz_);
+          mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_,   nnz_);
           h_data_updated_ = true;
         }
         return 0;   
@@ -227,21 +235,21 @@ namespace ReSolve
           }
           if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
             mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
-            mem_.allocateArrayOnDevice(&d_row_data_, nnz_current); 
+            mem_.allocateArrayOnDevice(&d_row_data_,   nnz_);
             owns_gpu_data_ = true;
           }
           if (d_val_data_ == nullptr) {
-            mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
+            mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
             owns_gpu_vals_ = true;
           }
-          mem_.copyArrayHostToDevice(d_col_data_, h_col_data_,      m_ + 1);
-          mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, nnz_current);
-          mem_.copyArrayHostToDevice(d_val_data_, h_val_data_, nnz_current);
+          mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, m_ + 1);
+          mem_.copyArrayHostToDevice(d_row_data_, h_row_data_,   nnz_);
+          mem_.copyArrayHostToDevice(d_val_data_, h_val_data_,   nnz_);
           d_data_updated_ = true;
         }
         return 0;
       default:
-        return -1;
+        return 1;
     } // switch
   }
 

--- a/resolve/matrix/Csc.hpp
+++ b/resolve/matrix/Csc.hpp
@@ -35,7 +35,7 @@ namespace ReSolve { namespace matrix {
 
       virtual void print(std::ostream& file_out = std::cout, index_type indexing_base = 0);
 
-      virtual int copyData(memory::MemorySpace memspaceOut);
+      virtual int syncData(memory::MemorySpace memspaceOut);
   };
 
 }} // namespace ReSolve::matrix

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -95,7 +95,7 @@ namespace ReSolve
         d_val_data_ = *vals;
         d_data_updated_ = true;
         owns_gpu_data_  = true;
-        copyData(memspaceDst);
+        syncData(memspaceDst);
         // Hijack data from the source
         *rows = nullptr;
         *cols = nullptr;
@@ -108,7 +108,7 @@ namespace ReSolve
         h_val_data_ = *vals;
         h_data_updated_ = true;
         owns_cpu_data_  = true;
-        copyData(memspaceDst);
+        syncData(memspaceDst);
 
         // Hijack data from the source
         *rows = nullptr;
@@ -151,7 +151,7 @@ namespace ReSolve
   index_type* matrix::Csr::getRowData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_row_data_;
@@ -165,7 +165,7 @@ namespace ReSolve
   index_type* matrix::Csr::getColData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_col_data_;
@@ -179,7 +179,7 @@ namespace ReSolve
   real_type* matrix::Csr::getValues(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    copyData(memspace);
+    syncData(memspace);
     switch (memspace) {
       case HOST:
         return this->h_val_data_;
@@ -302,7 +302,7 @@ namespace ReSolve
     return -1;
   }
 
-  int matrix::Csr::copyData(memory::MemorySpace memspaceOut)
+  int matrix::Csr::syncData(memory::MemorySpace memspaceOut)
   {
     using namespace ReSolve::memory;
 
@@ -313,7 +313,7 @@ namespace ReSolve
         //check if we need to copy or not
         if ((d_data_updated_ == true) && (h_data_updated_ == false)) {
           if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-            out::error() << "In Csr::copyData one of host row or column data is null!\n";
+            out::error() << "In Csr::syncData one of host row or column data is null!\n";
           }
           if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
             h_row_data_ = new index_type[n_ + 1];
@@ -333,7 +333,7 @@ namespace ReSolve
       case DEVICE:
         if ((d_data_updated_ == false) && (h_data_updated_ == true)) {
           if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-            out::error() << "In Csr::copyData one of device row or column data is null!\n";
+            out::error() << "In Csr::syncData one of device row or column data is null!\n";
           }
           if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
             mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -151,7 +151,7 @@ namespace ReSolve
   index_type* matrix::Csr::getRowData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    syncData(memspace);
+
     switch (memspace) {
       case HOST:
         return this->h_row_data_;
@@ -165,7 +165,7 @@ namespace ReSolve
   index_type* matrix::Csr::getColData(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    syncData(memspace);
+
     switch (memspace) {
       case HOST:
         return this->h_col_data_;
@@ -179,7 +179,7 @@ namespace ReSolve
   real_type* matrix::Csr::getValues(memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
-    syncData(memspace);
+
     switch (memspace) {
       case HOST:
         return this->h_val_data_;
@@ -319,47 +319,59 @@ namespace ReSolve
     switch (memspace) {
       case HOST:
         //check if we need to copy or not
-        if ((d_data_updated_ == true) && (h_data_updated_ == false)) {
-          if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-            out::error() << "In Csr::syncData one of host row or column data is null!\n";
-          }
-          if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
-            h_row_data_ = new index_type[n_ + 1];
-            h_col_data_ = new index_type[nnz_];      
-            owns_cpu_data_ = true;
-          }
-          if (h_val_data_ == nullptr) {
-            h_val_data_ = new real_type[nnz_];      
-            owns_cpu_vals_ = true;
-          }
-          mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, n_ + 1);
-          mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_,   nnz_);
-          mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_,   nnz_);
-          h_data_updated_ = true;
+        if (h_data_updated_) {
+          out::misc() << "In Csr::syncData trying to sync host, but host already up to date!\n";
+          return 0;
         }
+        if (!d_data_updated_) {
+          out::error() << "In Csr::syncData trying to sync host with device, but device is out of date!\n";
+          assert(d_data_updated_);
+        }
+        if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
+          out::error() << "In Csr::syncData one of host row or column data is null!\n";
+        }
+        if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
+          h_row_data_ = new index_type[n_ + 1];
+          h_col_data_ = new index_type[nnz_];      
+          owns_cpu_data_ = true;
+        }
+        if (h_val_data_ == nullptr) {
+          h_val_data_ = new real_type[nnz_];      
+          owns_cpu_vals_ = true;
+        }
+        mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, n_ + 1);
+        mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, nnz_);
+        mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_, nnz_);
+        h_data_updated_ = true;
         return 0;
       case DEVICE:
-        if ((d_data_updated_ == false) && (h_data_updated_ == true)) {
-          if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-            out::error() << "In Csr::syncData one of device row or column data is null!\n";
-          }
-          if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
-            mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
-            mem_.allocateArrayOnDevice(&d_col_data_,   nnz_); 
-            owns_gpu_data_ = true;
-          }
-          if (d_val_data_ == nullptr) {
-            mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
-            owns_gpu_vals_ = true;
-          }
-          mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, n_ + 1);
-          mem_.copyArrayHostToDevice(d_col_data_, h_col_data_,   nnz_);
-          mem_.copyArrayHostToDevice(d_val_data_, h_val_data_,   nnz_);
-          d_data_updated_ = true;
+        if (d_data_updated_) {
+          out::misc() << "In Csr::syncData trying to sync device, but device already up to date!\n";
+          return 0;
         }
+        if (!h_data_updated_) {
+          out::error() << "In Csr::syncData trying to sync device with host, but host is out of date!\n";
+          assert(h_data_updated_);
+        }
+        if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
+          out::error() << "In Csr::syncData one of device row or column data is null!\n";
+        }
+        if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
+          mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
+          mem_.allocateArrayOnDevice(&d_col_data_, nnz_); 
+          owns_gpu_data_ = true;
+        }
+        if (d_val_data_ == nullptr) {
+          mem_.allocateArrayOnDevice(&d_val_data_, nnz_); 
+          owns_gpu_vals_ = true;
+        }
+        mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, n_ + 1);
+        mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, nnz_);
+        mem_.copyArrayHostToDevice(d_val_data_, h_val_data_, nnz_);
+        d_data_updated_ = true;
         return 0;
       default:
-        return -1;
+        return 1;
     } // switch
   }
 

--- a/resolve/matrix/Csr.hpp
+++ b/resolve/matrix/Csr.hpp
@@ -43,7 +43,7 @@ namespace ReSolve { namespace matrix {
 
       virtual void print(std::ostream& file_out = std::cout, index_type indexing_base = 0);
 
-      virtual int copyData(memory::MemorySpace memspaceOut);
+      virtual int syncData(memory::MemorySpace memspaceOut);
 
   };
 

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -65,7 +65,7 @@ namespace ReSolve { namespace matrix {
 
       virtual void print(std::ostream& file_out, index_type indexing_base) = 0;
 
-      virtual int copyData(memory::MemorySpace memspaceOut) = 0;
+      virtual int syncData(memory::MemorySpace memspaceOut) = 0;
 
 
       //update Values just updates values; it allocates if necessary.

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -249,12 +249,12 @@ namespace ReSolve { namespace vector {
   {
     if ((memspace == memory::HOST) && (cpu_updated_ == false) && (gpu_updated_ == true )) {
       // remember IN FIRST OUT SECOND!!!
-      copyData(memory::DEVICE, memspace);  
+      syncData(memory::DEVICE, memspace);  
       owns_cpu_data_ = true;
     } 
 
     if ((memspace == memory::DEVICE) && (gpu_updated_ == false) && (cpu_updated_ == true )) {
-      copyData(memory::HOST, memspace);
+      syncData(memory::HOST, memspace);
       owns_gpu_data_ = true;
     }
     if (memspace == memory::HOST) {
@@ -278,7 +278,7 @@ namespace ReSolve { namespace vector {
    * @return 0 if successful, -1 otherwise.
    *
    */
-  int Vector::copyData(memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int Vector::syncData(memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
   {
     int control=-1;
     if ((memspaceIn == memory::HOST)   && (memspaceOut == memory::DEVICE)){ control = 0;}

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -248,13 +248,12 @@ namespace ReSolve { namespace vector {
   real_type* Vector::getData(index_type i, memory::MemorySpace memspace)
   {
     if ((memspace == memory::HOST) && (cpu_updated_ == false) && (gpu_updated_ == true )) {
-      // remember IN FIRST OUT SECOND!!!
-      syncData(memory::DEVICE, memspace);  
+      syncData(memspace);  
       owns_cpu_data_ = true;
     } 
 
     if ((memspace == memory::DEVICE) && (gpu_updated_ == false) && (cpu_updated_ == true )) {
-      syncData(memory::HOST, memspace);
+      syncData(memspace);
       owns_gpu_data_ = true;
     }
     if (memspace == memory::HOST) {
@@ -272,13 +271,12 @@ namespace ReSolve { namespace vector {
   /** 
    * @brief copy internal vector data from HOST to DEVICE or from DEVICE to HOST 
    * 
-   * @param[in] memspaceIn   - Memory space of the data to copy FROM  
-   * @param[in] memspaceOut  - Memory space of the data to copy TO 
+   * @param[in] memspaceOut  - Memory space to sync
    *
-   * @return 0 if successful, -1 otherwise.
+   * @return 0 if successful, 1 otherwise.
    *
    */
-  int Vector::syncData(memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int Vector::syncData(memory::MemorySpace memspaceOut)
   {
     using namespace ReSolve::memory;
 
@@ -316,7 +314,7 @@ namespace ReSolve { namespace vector {
         cpu_updated_ = true;
         break;
       default:
-        return -1;
+        return 1;
     }
     return 0;
   }

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -280,32 +280,44 @@ namespace ReSolve { namespace vector {
    */
   int Vector::syncData(memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
   {
-    int control=-1;
-    if ((memspaceIn == memory::HOST)   && (memspaceOut == memory::DEVICE)){ control = 0;}
-    if ((memspaceIn == memory::DEVICE) && (memspaceOut == memory::HOST))  { control = 1;}
+    using namespace ReSolve::memory;
 
-    if ((memspaceOut == memory::HOST) && (h_data_ == nullptr)) {
-      //allocate first
-      h_data_ = new real_type[n_ * k_];
-      owns_cpu_data_ = true;
-    }
-    if ((memspaceOut == memory::DEVICE) && (d_data_ == nullptr)) {
-      //allocate first
-      mem_.allocateArrayOnDevice(&d_data_, n_ * k_);
-      owns_gpu_data_ = true;
-    } 
-    switch(control)  {
-      case 0: //cpu->cuda
+    switch(memspaceOut)  {
+      case DEVICE: // cpu->gpu
+        if (gpu_updated_) {
+          out::misc() << "Trying to sync device, but device already up to date!\n";
+          return 0;
+        }
+        if (!cpu_updated_) {
+          out::error() << "Trying to sync device with host, but host is out of date!\n";
+        }
+        if (d_data_ == nullptr) {
+          //allocate first
+          mem_.allocateArrayOnDevice(&d_data_, n_ * k_);
+          owns_gpu_data_ = true;
+        } 
         mem_.copyArrayHostToDevice(d_data_, h_data_, n_current_ * k_);
+        gpu_updated_ = true;
         break;
-      case 1: //cuda->cpu
+      case HOST: //cuda->cpu
+        if (cpu_updated_) {
+          out::misc() << "Trying to sync host, but host already up to date!\n";
+          return 0;
+        }
+        if (!gpu_updated_) {
+          out::error() << "Trying to sync host with device, but device is out of date!\n";
+        }
+        if (h_data_ == nullptr) {
+          //allocate first
+          h_data_ = new real_type[n_ * k_];
+          owns_cpu_data_ = true;
+        }
         mem_.copyArrayDeviceToHost(h_data_, d_data_, n_current_ * k_);
+        cpu_updated_ = true;
         break;
       default:
         return -1;
     }
-    cpu_updated_ = true;
-    gpu_updated_ = true;
     return 0;
   }
 

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -46,7 +46,7 @@ namespace ReSolve { namespace vector {
       void setToZero(index_type i, memory::MemorySpace memspace); // set i-th ivector to 0
       void setToConst(real_type C, memory::MemorySpace memspace);
       void setToConst(index_type i, real_type C, memory::MemorySpace memspace); // set i-th vector to C  - needed for unit tests, Gram Schmidt tests
-      int copyData(memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut); 
+      int syncData(memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut); 
       int setCurrentSize(index_type new_n_current);
       real_type* getVectorData(index_type i, memory::MemorySpace memspace); // get ith vector data out of multivector   
       int deepCopyVectorData(real_type* dest, index_type i, memory::MemorySpace memspace);  

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -46,7 +46,7 @@ namespace ReSolve { namespace vector {
       void setToZero(index_type i, memory::MemorySpace memspace); // set i-th ivector to 0
       void setToConst(real_type C, memory::MemorySpace memspace);
       void setToConst(index_type i, real_type C, memory::MemorySpace memspace); // set i-th vector to C  - needed for unit tests, Gram Schmidt tests
-      int syncData(memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut); 
+      int syncData(memory::MemorySpace memspaceOut); 
       int setCurrentSize(index_type new_n_current);
       real_type* getVectorData(index_type i, memory::MemorySpace memspace); // get ith vector data out of multivector   
       int deepCopyVectorData(real_type* dest, index_type i, memory::MemorySpace memspace);  

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -123,6 +123,7 @@ namespace ReSolve {
         devImpl_->scal(alpha, x);
         break;
     }
+    x->setDataUpdated(memspace);
   }
 
   /** 
@@ -169,6 +170,7 @@ namespace ReSolve {
         devImpl_->axpy(alpha, x, y);      
         break;
     }
+    y->setDataUpdated(memspace);
   }
 
   /** 
@@ -207,6 +209,7 @@ namespace ReSolve {
         devImpl_->gemv(transpose, n, k, alpha, beta, V, y, x);
         break;
     }
+    x->setDataUpdated(memspace);
   }
 
   /** 
@@ -232,6 +235,7 @@ namespace ReSolve {
         devImpl_->massAxpy(size, alpha, k, x, y);
         break;
     }
+    y->setDataUpdated(memspace);
   }
 
   /** 
@@ -259,6 +263,7 @@ namespace ReSolve {
         devImpl_->massDot2Vec(size, V, k, x, res);
         break;
     }
+    res->setDataUpdated(memspace);
   }
 
   /**

--- a/tests/functionality/testKLU_GLU.cpp
+++ b/tests/functionality/testKLU_GLU.cpp
@@ -57,6 +57,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1);
+  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -165,6 +166,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
+  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector

--- a/tests/functionality/testKLU_Rf.cpp
+++ b/tests/functionality/testKLU_Rf.cpp
@@ -57,6 +57,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1);
+  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -145,6 +146,8 @@ int main(int argc, char *argv[])
   
   ReSolve::matrix::Csc* L_csc = (ReSolve::matrix::Csc*) KLU->getLFactor();
   ReSolve::matrix::Csc* U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
+  L_csc->syncData(ReSolve::memory::DEVICE);
+  U_csc->syncData(ReSolve::memory::DEVICE);
   ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
   ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
   error_sum += matrix_handler->csc2csr(L_csc,L, ReSolve::memory::DEVICE);
@@ -164,6 +167,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
+  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector

--- a/tests/functionality/testKLU_Rf_FGMRES.cpp
+++ b/tests/functionality/testKLU_Rf_FGMRES.cpp
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1);
+  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -171,6 +172,8 @@ int main(int argc, char *argv[])
   ReSolve::matrix::Csc* U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
   ReSolve::matrix::Csr* L = new ReSolve::matrix::Csr(L_csc->getNumRows(), L_csc->getNumColumns(), L_csc->getNnz());
   ReSolve::matrix::Csr* U = new ReSolve::matrix::Csr(U_csc->getNumRows(), U_csc->getNumColumns(), U_csc->getNnz());
+  L_csc->syncData(ReSolve::memory::DEVICE);
+  U_csc->syncData(ReSolve::memory::DEVICE);
   error_sum += matrix_handler->csc2csr(L_csc,L, ReSolve::memory::DEVICE);
   error_sum += matrix_handler->csc2csr(U_csc,U, ReSolve::memory::DEVICE);
 
@@ -197,6 +200,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
+  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector

--- a/tests/functionality/testKLU_RocSolver.cpp
+++ b/tests/functionality/testKLU_RocSolver.cpp
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1);
+  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -173,6 +174,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
+  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector

--- a/tests/functionality/testKLU_RocSolver_FGMRES.cpp
+++ b/tests/functionality/testKLU_RocSolver_FGMRES.cpp
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1);
+  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -192,6 +193,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
+  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector

--- a/tests/functionality/testRandGMRES_Cuda.cpp
+++ b/tests/functionality/testRandGMRES_Cuda.cpp
@@ -166,6 +166,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N)
       data[i] = -111.0;
     }
   }
+  vec_rhs->setDataUpdated(ReSolve::memory::HOST);
   vec_rhs->syncData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   return vec_rhs;
 } 

--- a/tests/functionality/testRandGMRES_Cuda.cpp
+++ b/tests/functionality/testRandGMRES_Cuda.cpp
@@ -167,7 +167,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N)
     }
   }
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
-  vec_rhs->syncData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->syncData(ReSolve::memory::DEVICE);
   return vec_rhs;
 } 
 

--- a/tests/functionality/testRandGMRES_Cuda.cpp
+++ b/tests/functionality/testRandGMRES_Cuda.cpp
@@ -166,7 +166,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N)
       data[i] = -111.0;
     }
   }
-  vec_rhs->copyData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->syncData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   return vec_rhs;
 } 
 
@@ -229,6 +229,6 @@ ReSolve::matrix::Csr* generateMatrix(const index_type N)
 
 
   A->setUpdated(ReSolve::memory::HOST);
-  A->copyData(ReSolve::memory::DEVICE);
+  A->syncData(ReSolve::memory::DEVICE);
   return A;
 }

--- a/tests/functionality/testRandGMRES_Rocm.cpp
+++ b/tests/functionality/testRandGMRES_Rocm.cpp
@@ -166,6 +166,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N)
       data[i] = -111.0;
     }
   }
+  vec_rhs->setDataUpdated(ReSolve::memory::HOST);
   vec_rhs->syncData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   return vec_rhs;
 } 

--- a/tests/functionality/testRandGMRES_Rocm.cpp
+++ b/tests/functionality/testRandGMRES_Rocm.cpp
@@ -167,7 +167,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N)
     }
   }
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
-  vec_rhs->syncData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->syncData(ReSolve::memory::DEVICE);
   return vec_rhs;
 } 
 

--- a/tests/functionality/testRandGMRES_Rocm.cpp
+++ b/tests/functionality/testRandGMRES_Rocm.cpp
@@ -166,7 +166,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N)
       data[i] = -111.0;
     }
   }
-  vec_rhs->copyData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->syncData(ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   return vec_rhs;
 } 
 
@@ -229,6 +229,6 @@ ReSolve::matrix::Csr* generateMatrix(const index_type N)
 
 
   A->setUpdated(ReSolve::memory::HOST);
-  A->copyData(ReSolve::memory::DEVICE);
+  A->syncData(ReSolve::memory::DEVICE);
   return A;
 }

--- a/tests/functionality/testSysGLU.cpp
+++ b/tests/functionality/testSysGLU.cpp
@@ -66,6 +66,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1);
+  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -202,6 +203,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
+  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector

--- a/tests/functionality/testSysRandGMRES.cpp
+++ b/tests/functionality/testSysRandGMRES.cpp
@@ -272,7 +272,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N, ReSolve::memory::Memory
     }
   }
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
-  vec_rhs->syncData(ReSolve::memory::HOST, memspace);
+  vec_rhs->syncData(memspace);
   return vec_rhs;
 } 
 

--- a/tests/functionality/testSysRandGMRES.cpp
+++ b/tests/functionality/testSysRandGMRES.cpp
@@ -271,6 +271,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N, ReSolve::memory::Memory
       data[i] = -111.0;
     }
   }
+  vec_rhs->setDataUpdated(ReSolve::memory::HOST);
   vec_rhs->syncData(ReSolve::memory::HOST, memspace);
   return vec_rhs;
 } 

--- a/tests/functionality/testSysRandGMRES.cpp
+++ b/tests/functionality/testSysRandGMRES.cpp
@@ -271,7 +271,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N, ReSolve::memory::Memory
       data[i] = -111.0;
     }
   }
-  vec_rhs->copyData(ReSolve::memory::HOST, memspace);
+  vec_rhs->syncData(ReSolve::memory::HOST, memspace);
   return vec_rhs;
 } 
 
@@ -334,6 +334,6 @@ ReSolve::matrix::Csr* generateMatrix(const index_type N, ReSolve::memory::Memory
 
 
   A->setUpdated(ReSolve::memory::HOST);
-  A->copyData(memspace);
+  A->syncData(memspace);
   return A;
 }

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -92,6 +92,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1, true);
+  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -224,6 +225,7 @@ int main(int argc, char *argv[])
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
+  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector

--- a/tests/unit/matrix/MatrixFactorizationTests.hpp
+++ b/tests/unit/matrix/MatrixFactorizationTests.hpp
@@ -167,7 +167,7 @@ private:
     // A->print();
 
     if ((memspace == "cuda") || (memspace == "hip")) {
-      A->copyData(memory::DEVICE);
+      A->syncData(memory::DEVICE);
     }
 
     return A;
@@ -307,7 +307,7 @@ private:
   {
     bool status = true;
     if (memspace != "cpu") {
-      A.copyData(memory::DEVICE);
+      A.syncData(memory::DEVICE);
     }
 
     size_t N = static_cast<size_t>(A.getNumRows());
@@ -362,7 +362,7 @@ private:
   {
     bool status = true;
     if (memspace != "cpu") {
-      x.copyData(memory::DEVICE, memory::HOST);
+      x.syncData(memory::DEVICE, memory::HOST);
     }
 
     for (index_type i = 0; i < x.getSize(); ++i) {

--- a/tests/unit/matrix/MatrixFactorizationTests.hpp
+++ b/tests/unit/matrix/MatrixFactorizationTests.hpp
@@ -362,7 +362,7 @@ private:
   {
     bool status = true;
     if (memspace != "cpu") {
-      x.syncData(memory::DEVICE, memory::HOST);
+      x.syncData(memory::HOST);
     }
 
     for (index_type i = 0; i < x.getSize(); ++i) {

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -87,7 +87,7 @@ private:
   {
     bool status = true;
     if (memspace_ == memory::DEVICE) {
-      x.copyData(memory::DEVICE, memory::HOST);
+      x.syncData(memory::DEVICE, memory::HOST);
     }
 
     for (index_type i = 0; i < x.getSize(); ++i) {
@@ -149,7 +149,7 @@ private:
     A->setUpdated(memory::HOST);
 
     if (memspace_ == memory::DEVICE) {
-      A->copyData(memspace_);
+      A->syncData(memspace_);
     }
 
     return A;

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -87,7 +87,7 @@ private:
   {
     bool status = true;
     if (memspace_ == memory::DEVICE) {
-      x.syncData(memory::DEVICE, memory::HOST);
+      x.syncData(memory::HOST);
     }
 
     for (index_type i = 0; i < x.getSize(); ++i) {

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -96,7 +96,7 @@ namespace ReSolve
             }
           }
           V.setDataUpdated(memory::HOST); 
-          V.syncData(memory::HOST, memspace_);
+          V.syncData(memspace_);
 
           //set the first vector to all 1s, normalize 
           V.setToConst(0, 1.0, memspace_);

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -96,7 +96,7 @@ namespace ReSolve
             }
           }
           V.setDataUpdated(memory::HOST); 
-          V.copyData(memory::HOST, memspace_);
+          V.syncData(memory::HOST, memspace_);
 
           //set the first vector to all 1s, normalize 
           V.setToConst(0, 1.0, memspace_);

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -230,7 +230,7 @@ namespace ReSolve {
           bool status = true;
 
           if (memspace_ == memory::DEVICE) {
-            x.syncData(memory::DEVICE, memory::HOST);
+            x.syncData(memory::HOST);
           }
 
           for (index_type i = 0; i < x.getSize(); ++i) {

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -230,7 +230,7 @@ namespace ReSolve {
           bool status = true;
 
           if (memspace_ == memory::DEVICE) {
-            x.copyData(memory::DEVICE, memory::HOST);
+            x.syncData(memory::DEVICE, memory::HOST);
           }
 
           for (index_type i = 0; i < x.getSize(); ++i) {


### PR DESCRIPTION
There are two issues addressed here:
- Make wholesale name change `copyData` -> `syncData`. Methods `syncData` synchronize data between the host and device within the same vector or matrix object. "Copy" often suggests data is copied from/to another object. Resolves #187. 
- The "update" methods copy matrix or vector data to/from external sources and set flags indicating which memory space within the object is up-to-date. For example, if the host memory is updated, host flag `h_data_updated_` is set to `true` and device flag `d_data_updated_` is set to `false`. A sync method needs to be used if one wants to update both. Resolves #126.

Both, sync and update methods need to check if the operations are meaningful. For example if syncing device memory space, the host needs to be up-to-date. 
