### PR TITLE
Fix warnings in LUSOL solver and unit test

### DIFF
--- a/resolve/LinSolverDirectLUSOL.cpp
+++ b/resolve/LinSolverDirectLUSOL.cpp
@@ -263,7 +263,8 @@ namespace ReSolve
     // NOTE: this is not one-indexed like the original is
     std::unique_ptr<index_type[]> pt = std::unique_ptr<index_type[]>(new index_type[m_]);
     for (index_type i = 0; i < m_; i++) {
-      pt[p_[i] - 1] = i;
+      size_t j = static_cast<size_t>(p_[i] - 1);
+      pt[j] = i;
     }
 
     // preprocessing since columns are stored unordered within lusol's workspace
@@ -274,7 +275,8 @@ namespace ReSolve
     for (index_type i = 0; i < initial_m; i++) {
       index_type column_nnz = lenc_[i];
       index_type column_nnz_end = offset - column_nnz;
-      index_type corresponding_column = pt[indr_[column_nnz_end + 1] - 1];
+      size_t j = static_cast<size_t>(indr_[column_nnz_end + 1] - 1);
+      index_type corresponding_column = pt[j];
 
       columns[corresponding_column + 1] = column_nnz;
       offset = column_nnz_end;
@@ -297,12 +299,14 @@ namespace ReSolve
 
     offset = lena_ - 1;
     for (index_type i = 0; i < initial_m; i++) {
-      index_type corresponding_column = pt[indr_[offset - lenc_[i] + 1] - 1];
+      size_t j = static_cast<size_t>(indr_[offset - lenc_[i] + 1] - 1);
+      index_type corresponding_column = pt[j];
 
       for (index_type destination_offset = columns[corresponding_column];
            destination_offset < columns[corresponding_column + 1] - 1;
            destination_offset++) {
-        index_type row = pt[indc_[offset] - 1];
+        size_t k = static_cast<size_t>(indc_[offset] - 1);
+        index_type row = pt[k];
 
         // closest position to the target row
         index_type* closest_position =
@@ -365,7 +369,8 @@ namespace ReSolve
     // NOTE: this is not one-indexed like the original is
     std::unique_ptr<index_type[]> qt = std::unique_ptr<index_type[]>(new index_type[n_]);
     for (index_type i = 0; i < n_; i++) {
-      qt[q_[i] - 1] = i;
+      size_t j = static_cast<size_t>(q_[i] - 1);
+      qt[j] = i;
     }
 
     // preprocessing since rows technically aren't ordered either
@@ -386,7 +391,8 @@ namespace ReSolve
       index_type offset = locr_[p_[row] - 1] - 1;
 
       for (index_type destination_offset = rows[row]; destination_offset < rows[row + 1]; destination_offset++) {
-        index_type column = qt[indr_[offset] - 1];
+        size_t j = static_cast<size_t>(indr_[offset] - 1);
+        index_type column = qt[j];
 
         // closest position to the target column
         index_type* closest_position =

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -80,14 +80,16 @@ namespace ReSolve
 
           index_type* p_ordering = solver.getPOrdering();
 
-          for (index_type i = 0; i < A->getNumRows(); i++) {
-            status *= p_ordering[i] == reference_p_ordering_[i];
+          size_t n = static_cast<size_t>(A->getNumRows());
+          for (size_t i = 0; i < n; i++) {
+            status *= (p_ordering[i] == reference_p_ordering_[i]);
           }
 
           index_type* q_ordering = solver.getQOrdering();
 
-          for (index_type i = 0; i < A->getNumColumns(); i++) {
-            status *= q_ordering[i] == reference_q_ordering_[i];
+          size_t m = static_cast<size_t>(A->getNumColumns());
+          for (size_t i = 0; i < m; i++) {
+            status *= (q_ordering[i] == reference_q_ordering_[i]);
           }
 
           if (solver.solve(&rhs, &x) < 0) {
@@ -202,7 +204,7 @@ namespace ReSolve
                           const std::vector<real_type>& coo_answer_values)
         {
           bool status = true;
-          index_type i = 0;
+          size_t i = 0;
 
           index_type* rows = A.getRowData(memory::HOST);
           index_type* columns = A.getColData(memory::HOST);
@@ -266,7 +268,7 @@ namespace ReSolve
                           const std::vector<real_type>& coo_answer_values)
         {
           bool status = true;
-          index_type i = 0;
+          size_t i = 0;
 
           index_type* columns = A.getColData(memory::HOST);
           index_type* rows = A.getRowData(memory::HOST);


### PR DESCRIPTION
Fix warnings when converting from integer index type to `size_t`.