### PR TITLE
Change member functions and data names in vector and matrix classes to be more consistent

### DIFF
--- a/examples/r_KLU_GLU.cpp
+++ b/examples/r_KLU_GLU.cpp
@@ -108,9 +108,9 @@ int main(int argc, char *argv[])
 
     // Update host and device data.
     if (i < 1) {
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     }
 
     // Estimate solution error
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     real_type bnorm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 

--- a/examples/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/r_KLU_GLU_matrix_values_update.cpp
@@ -117,9 +117,9 @@ int main(int argc, char *argv[])
 
     // Update host and device data.
     if (i < 1) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
       status = GLU->solve(vec_rhs, vec_x);
       std::cout<<"CUSOLVER GLU solve status: "<<status<<std::endl;      
     }
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);

--- a/examples/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/r_KLU_GLU_matrix_values_update.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
         ReSolve::io::updateMatrixFromFile(mat_file, A_exp);
       }
       std::cout<<"Updating values of A_coo!"<<std::endl; 
-      A->updateValues(A_exp->getValues(ReSolve::memory::HOST), ReSolve::memory::HOST, ReSolve::memory::HOST);
+      A->copyValues(A_exp->getValues(ReSolve::memory::HOST), ReSolve::memory::HOST, ReSolve::memory::HOST);
       //ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }

--- a/examples/r_KLU_KLU.cpp
+++ b/examples/r_KLU_KLU.cpp
@@ -102,10 +102,10 @@ int main(int argc, char *argv[])
 
     // Update data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
     //Now call direct solver
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
       status = KLU->solve(vec_rhs, vec_x);
       std::cout<<"KLU solve status: "<<status<<std::endl;      
     }
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 

--- a/examples/r_KLU_KLU_standalone.cpp
+++ b/examples/r_KLU_KLU_standalone.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
   mat_file.close();
   rhs_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
   std::cout << "COO to CSR completed. Expanded NNZ: " << A->getNnz() << std::endl;
   //Now call direct solver
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
   std::cout << "KLU factorization status: " << status << std::endl;
   status = KLU->solve(vec_rhs, vec_x);
   std::cout << "KLU solve status: " << status << std::endl;      
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 

--- a/examples/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_cusolverrf_redo_factorization.cpp
@@ -117,9 +117,9 @@ int main(int argc, char *argv[] )
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -158,7 +158,7 @@ int main(int argc, char *argv[] )
       status = Rf->solve(vec_rhs, vec_x);
       std::cout<<"cusolver rf solve status: "<<status<<std::endl;      
     }
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
@@ -182,8 +182,8 @@ int main(int argc, char *argv[] )
       status = KLU->solve(vec_rhs, vec_x);
       std::cout<<"KLU solve status: "<<status<<std::endl;      
 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 

--- a/examples/r_KLU_rf.cpp
+++ b/examples/r_KLU_rf.cpp
@@ -107,9 +107,9 @@ int main(int argc, char *argv[] )
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -151,7 +151,7 @@ int main(int argc, char *argv[] )
       //status = KLU->solve(vec_rhs, vec_x);
       //std::cout<<"KLU solve status: "<<status<<std::endl;      
     }
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 

--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -111,9 +111,9 @@ int main(int argc, char *argv[])
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
       std::cout<<"KLU factorization status: "<<status<<std::endl;
       status = KLU->solve(vec_rhs, vec_x);
       std::cout<<"KLU solve status: "<<status<<std::endl;      
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
       status = Rf->solve(vec_rhs, vec_x);
       std::cout<<"CUSOLVER RF solve status: "<<status<<std::endl;      
 
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
 
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
                 << sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE))/norm_b << "\n";
 
       matrix_handler->matrixInfNorm(A, &norm_A, ReSolve::memory::DEVICE); 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       
       if(!std::isnan(norm_r) && !std::isinf(norm_r)) {
         FGMRES->solve(vec_rhs, vec_x);

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -113,11 +113,11 @@ int main(int argc, char *argv[])
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
       A->syncData(ReSolve::memory::DEVICE);
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
       std::cout<<"KLU factorization status: "<<status<<std::endl;
       status = KLU->solve(vec_rhs, vec_x);
       std::cout<<"KLU solve status: "<<status<<std::endl;      
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
         status = Rf->refactorize();
         std::cout << "CUSOLVER RF, using REAL refactorization, refactorization status: "
                   << status << std::endl;    
-        vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+        vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         status = Rf->solve(vec_rhs, vec_x);
         FGMRES->setupPreconditioner("LU", Rf);
       }
@@ -181,8 +181,8 @@ int main(int argc, char *argv[])
                 << sqrt(norm_x) << "\n";
       std::cout<<"CUSOLVER RF solve status: "<<status<<std::endl;      
       
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
 
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
                 << std::scientific << std::setprecision(16) 
                 << norm_b << "\n";
 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       FGMRES->solve(vec_rhs, vec_x);
 
       std::cout << "FGMRES: init nrm: " 

--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -116,9 +116,9 @@ int main(int argc, char *argv[])
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     RESOLVE_RANGE_POP("Matrix Read");
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
 
       status = KLU->solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;      
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
       std::cout << "ROCSOLVER RF refactorization status: " << status << std::endl;      
       status = Rf->solve(vec_rhs, vec_x);
       std::cout << "ROCSOLVER RF solve status: " << status << std::endl;      
-      vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
 
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
                 << "\t Solution inf norm: "        << norm_x << "\n"  
                 << "\t Norm of scaled residuals: " << norm_r / (norm_A * norm_x) << "\n";
 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       if(!std::isnan(rnrm) && !std::isinf(rnrm)) {
         FGMRES->solve(vec_rhs, vec_x);
 

--- a/examples/r_KLU_rocsolverrf.cpp
+++ b/examples/r_KLU_rocsolverrf.cpp
@@ -109,9 +109,9 @@ int main(int argc, char *argv[])
 
     // Update right-hand-side vector.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
         ReSolve::matrix::Csc* U = (ReSolve::matrix::Csc*) KLU->getUFactor();
         index_type* P = KLU->getPOrdering();
         index_type* Q = KLU->getQOrdering();
-        vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+        vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         Rf->setup(A, L, U, P, Q, vec_rhs); 
       }
     } else {
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
     }
 
     // Check accuracy of the solution
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     real_type bnorm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 

--- a/examples/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -109,9 +109,9 @@ int main(int argc, char *argv[] )
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -130,7 +130,7 @@ int main(int argc, char *argv[] )
         ReSolve::matrix::Csc* U = (ReSolve::matrix::Csc*) KLU->getUFactor();
         index_type* P = KLU->getPOrdering();
         index_type* Q = KLU->getQOrdering();
-        vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+        vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         Rf->setup(A, L, U, P, Q, vec_rhs); 
         Rf->refactorize();
       }
@@ -143,7 +143,7 @@ int main(int argc, char *argv[] )
     }
 
     // Check accuracy of the solution
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
     res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -164,8 +164,8 @@ int main(int argc, char *argv[] )
          status = KLU->solve(vec_rhs, vec_x);
          std::cout << "KLU solve status: " << status << std::endl;      
          
-         vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-         vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+         vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+         vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
          matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 

--- a/examples/r_SysSolver.cpp
+++ b/examples/r_SysSolver.cpp
@@ -102,10 +102,10 @@ int main(int argc, char *argv[])
 
     // Update data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
     //Now call direct solver
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
       status = solver->solve(vec_rhs, vec_x);
       std::cout<<"solver solve status: "<<status<<std::endl;      
     }
-    vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 

--- a/examples/r_SysSolverCuda.cpp
+++ b/examples/r_SysSolverCuda.cpp
@@ -101,11 +101,11 @@ int main(int argc, char *argv[])
 
     // Update host and device data.
     if (i < 1) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     } else { 
       A->syncData(ReSolve::memory::DEVICE);
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
     //Now call direct solver

--- a/examples/r_SysSolverHip.cpp
+++ b/examples/r_SysSolverHip.cpp
@@ -104,9 +104,9 @@ int main(int argc, char *argv[] )
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 

--- a/examples/r_SysSolverHipRefine.cpp
+++ b/examples/r_SysSolverHipRefine.cpp
@@ -108,9 +108,9 @@ int main(int argc, char *argv[])
 
     // Update host and device data.
     if (i < 2) { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     } else { 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
                 << solver->getNormOfScaledResiduals(vec_rhs, vec_x)
                 << "\n";
 
-      vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       real_type norm_b = solver->getVectorNorm(vec_rhs);
       if (!std::isnan(rnrm) && !std::isinf(rnrm)) {
         std::cout << "FGMRES solve status: " << status << std::endl;      

--- a/examples/r_randGMRES.cpp
+++ b/examples/r_randGMRES.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
   rhs_file.close();
 
   A->syncData(ReSolve::memory::DEVICE);
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   //Now call the solver
   real_type norm_b;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
   FGMRES->setupPreconditioner("LU", Rf);
   FGMRES->setFlexible(1); 
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   FGMRES->solve(vec_rhs, vec_x);
 
   norm_b = vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE);

--- a/examples/r_randGMRES_CUDA.cpp
+++ b/examples/r_randGMRES_CUDA.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
   rhs_file.close();
 
   A->syncData(ReSolve::memory::DEVICE);
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   //Now call direct solver
   real_type norm_b;
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
   FGMRES->setupPreconditioner("LU", Rf);
   FGMRES->setFlexible(1); 
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   FGMRES->solve(vec_rhs, vec_x);
 
   norm_b = vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE);

--- a/examples/r_randGMRES_cpu.cpp
+++ b/examples/r_randGMRES_cpu.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
   mat_file.close();
   rhs_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   //Now call direct solver
   real_type norm_b;
   matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
   FGMRES->setupPreconditioner("LU", Rf);
   FGMRES->setFlexible(1); 
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   FGMRES->solve(vec_rhs, vec_x);
 
   norm_b = vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::HOST);

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -241,7 +241,7 @@ namespace ReSolve
           H[ idxmap(i, j, num_vecs_ + 1) ] -= s; 
         }   // for j
         vec_Hcolumn_->setCurrentSize(i + 1);
-        vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_); 
+        vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_); 
         vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V, vec_w_, memspace_);
 
         // normalize (second synch)
@@ -317,7 +317,7 @@ namespace ReSolve
         }
 
         vec_Hcolumn_->setCurrentSize(i + 1);
-        vec_Hcolumn_->update(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_); 
+        vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_); 
 
         vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V,  vec_w_, memspace_);
         // normalize (second synch)

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -178,7 +178,7 @@ namespace ReSolve
         // copy H_col to aux, we will need it later
         vec_Hcolumn_->setDataUpdated(memspace_);
         vec_Hcolumn_->setCurrentSize(i + 1);
-        vec_Hcolumn_->deepCopyVectorData(h_aux_, 0, memory::HOST);
+        vec_Hcolumn_->copyDataTo(h_aux_, 0, memory::HOST);
         mem_.deviceSynchronize();
 
         //Hcol = V(:,1:i)^T*V(:,i+1);
@@ -191,7 +191,7 @@ namespace ReSolve
 
         // copy H_col to H
         vec_Hcolumn_->setDataUpdated(memspace_);
-        vec_Hcolumn_->deepCopyVectorData(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+        vec_Hcolumn_->copyDataTo(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         mem_.deviceSynchronize();
 
         // add both pieces together (unstable otherwise, careful here!!)
@@ -225,7 +225,7 @@ namespace ReSolve
         vec_rv_->setDataUpdated(memspace_);
         vec_rv_->syncData(memory::HOST);
 
-        vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+        vec_rv_->copyDataTo(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);
         
         for(int j=0; j<=i; ++j) {
@@ -273,7 +273,7 @@ namespace ReSolve
         vec_rv_->setDataUpdated(memspace_);
         vec_rv_->syncData(memory::HOST);
 
-        vec_rv_->deepCopyVectorData(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+        vec_rv_->copyDataTo(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);
 
         for(int j = 0; j <= i; ++j) {
@@ -346,7 +346,7 @@ namespace ReSolve
         // copy H_col to H
         vec_Hcolumn_->setDataUpdated(memspace_);
         vec_Hcolumn_->setCurrentSize(i + 1);
-        vec_Hcolumn_->deepCopyVectorData(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+        vec_Hcolumn_->copyDataTo(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         mem_.deviceSynchronize();
 
         t = vector_handler_->dot(vec_v_, vec_v_, memspace_);  

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -133,7 +133,7 @@ namespace ReSolve
 
   int LinSolverDirectCuSolverRf::solve(vector_type* rhs, vector_type* x)
   {
-    x->update(rhs->getData(memory::DEVICE), memory::DEVICE, memory::DEVICE);
+    x->copyDataFrom(rhs->getData(memory::DEVICE), memory::DEVICE, memory::DEVICE);
     x->setDataUpdated(memory::DEVICE);
     status_cusolverrf_ =  cusolverRfSolve(handle_cusolverrf_,
                                           d_P_,

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -148,7 +148,7 @@ namespace ReSolve
   int LinSolverDirectKLU::solve(vector_type* rhs, vector_type* x) 
   {
     //copy the vector
-    x->update(rhs->getData(memory::HOST), memory::HOST, memory::HOST);
+    x->copyDataFrom(rhs->getData(memory::HOST), memory::HOST, memory::HOST);
     x->setDataUpdated(memory::HOST);
 
     int kluStatus = klu_solve(Symbolic_, Numeric_, A_->getNumRows(), 1, x->getData(memory::HOST), &Common_);

--- a/resolve/LinSolverDirectLUSOL.hpp
+++ b/resolve/LinSolverDirectLUSOL.hpp
@@ -129,7 +129,7 @@ namespace ReSolve
       /// @brief Number of entries in each row of U, stored in original order
       index_type* lenr_ = nullptr;
 
-      /// @brief Appears to be internal storage for LUSOL, used by the LU copyDataFrom routines
+      /// @brief Appears to be internal storage for LUSOL, used by the LU update routines
       index_type* locc_ = nullptr;
 
       /// @brief Points to the beginning of rows of U within a

--- a/resolve/LinSolverDirectLUSOL.hpp
+++ b/resolve/LinSolverDirectLUSOL.hpp
@@ -129,7 +129,7 @@ namespace ReSolve
       /// @brief Number of entries in each row of U, stored in original order
       index_type* lenr_ = nullptr;
 
-      /// @brief Appears to be internal storage for LUSOL, used by the LU update routines
+      /// @brief Appears to be internal storage for LUSOL, used by the LU copyDataFrom routines
       index_type* locc_ = nullptr;
 
       /// @brief Points to the beginning of rows of U within a

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -302,7 +302,7 @@ namespace ReSolve
   int LinSolverDirectRocSolverRf::solve(vector_type* rhs, vector_type* x)
   {
     RESOLVE_RANGE_PUSH(__FUNCTION__);
-    x->update(rhs->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::DEVICE);
+    x->copyDataFrom(rhs->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::DEVICE);
     x->setDataUpdated(ReSolve::memory::DEVICE);
     int error_sum = 0;
     if (solve_mode_ == 0) {

--- a/resolve/LinSolverDirectSerialILU0.cpp
+++ b/resolve/LinSolverDirectSerialILU0.cpp
@@ -166,7 +166,7 @@ namespace ReSolve
           kL++;
         }
       }  
-      //copyDataFrom row pointers
+      // update row pointers (offsets)
       L_->getRowData(ReSolve::memory::HOST)[i + 1] = L_->getRowData(ReSolve::memory::HOST)[i] + kL; 
       U_->getRowData(ReSolve::memory::HOST)[i + 1] = U_->getRowData(ReSolve::memory::HOST)[i] + kU; 
     }

--- a/resolve/LinSolverDirectSerialILU0.cpp
+++ b/resolve/LinSolverDirectSerialILU0.cpp
@@ -166,7 +166,7 @@ namespace ReSolve
           kL++;
         }
       }  
-      //update row pointers
+      //copyDataFrom row pointers
       L_->getRowData(ReSolve::memory::HOST)[i + 1] = L_->getRowData(ReSolve::memory::HOST)[i] + kL; 
       U_->getRowData(ReSolve::memory::HOST)[i + 1] = U_->getRowData(ReSolve::memory::HOST)[i] + kU; 
     }

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -118,7 +118,7 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
+    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
     matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
@@ -271,7 +271,7 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
+      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
       matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
       rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
       // rnorm = ||V_1||

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -147,7 +147,7 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
+    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
     matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
 
     vec_v->setData(vec_V_->getVectorData(0, memspace_), memspace_);
@@ -337,7 +337,7 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->deepCopyVectorData(vec_V_->getData(memspace_), 0, memspace_);  
+      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
       matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
       if (outer_flag) {
 

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -662,15 +662,15 @@ namespace ReSolve
     real_type resnorm = 0.0;
     memory::MemorySpace ms = memory::HOST;
     if (memspace_ == "cpu") {
-      resVector_->update(rhs, memory::HOST, memory::HOST);
+      resVector_->copyDataFrom(rhs, memory::HOST, memory::HOST);
       norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::HOST));
 #if defined(RESOLVE_USE_HIP) || defined(RESOLVE_USE_CUDA)
     } else if (memspace_ == "cuda" || memspace_ == "hip") {
       if (isSolveOnDevice_) {
-        resVector_->update(rhs, memory::DEVICE, memory::DEVICE);
+        resVector_->copyDataFrom(rhs, memory::DEVICE, memory::DEVICE);
         norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::DEVICE));
       } else {
-        resVector_->update(rhs, memory::HOST, memory::DEVICE);
+        resVector_->copyDataFrom(rhs, memory::HOST, memory::DEVICE);
         norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::HOST));
         // ms = memory::HOST;
       }
@@ -695,13 +695,13 @@ namespace ReSolve
     real_type resnorm = 0.0;
     memory::MemorySpace ms = memory::HOST;
     if (memspace_ == "cpu") {
-      resVector_->update(rhs, memory::HOST, memory::HOST);
+      resVector_->copyDataFrom(rhs, memory::HOST, memory::HOST);
 #if defined(RESOLVE_USE_HIP) || defined(RESOLVE_USE_CUDA)
     } else if (memspace_ == "cuda" || memspace_ == "hip") {
       if (isSolveOnDevice_) {
-        resVector_->update(rhs, memory::DEVICE, memory::DEVICE);
+        resVector_->copyDataFrom(rhs, memory::DEVICE, memory::DEVICE);
       } else {
-        resVector_->update(rhs, memory::HOST, memory::DEVICE);
+        resVector_->copyDataFrom(rhs, memory::HOST, memory::DEVICE);
       }
       ms = memory::DEVICE;
 #endif

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -61,8 +61,8 @@ namespace ReSolve
         h_col_data_ = *cols;
         h_val_data_ = *vals;
         h_data_updated_ = true;
-        owns_cpu_vals_ = true;
-        owns_cpu_data_  = true;
+        owns_cpu_values_ = true;
+        owns_cpu_sparsity_pattern_ = true;
         // Make sure there is no device data.
         if (d_row_data_ || d_col_data_ || d_val_data_) {
           out::error() << "Device data unexpectedly allocated. "
@@ -79,8 +79,8 @@ namespace ReSolve
         d_col_data_ = *cols;
         d_val_data_ = *vals;
         d_data_updated_ = true;
-        owns_gpu_vals_ = true;
-        owns_gpu_data_  = true;
+        owns_gpu_values_ = true;
+        owns_gpu_sparsity_pattern_ = true;
         syncData(memspaceDst);
         // Hijack data from the source
         *rows = nullptr;
@@ -93,8 +93,8 @@ namespace ReSolve
         h_col_data_ = *cols;
         h_val_data_ = *vals;
         h_data_updated_ = true;
-        owns_cpu_vals_ = true;
-        owns_cpu_data_  = true;
+        owns_cpu_values_ = true;
+        owns_cpu_sparsity_pattern_ = true;
         syncData(memspaceDst);
         // Hijack data from the source
         *rows = nullptr;
@@ -107,8 +107,8 @@ namespace ReSolve
         d_col_data_ = *cols;
         d_val_data_ = *vals;
         d_data_updated_ = true;
-        owns_gpu_vals_ = true;
-        owns_gpu_data_  = true;
+        owns_gpu_values_ = true;
+        owns_gpu_sparsity_pattern_ = true;
         // Make sure there is no device data.
         if (h_row_data_ || h_col_data_ || h_val_data_) {
           out::error() << "Host data unexpectedly allocated. "
@@ -196,11 +196,11 @@ namespace ReSolve
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[nnz_current];
         this->h_col_data_ = new index_type[nnz_current];
-        owns_cpu_data_ = true;
+        owns_cpu_sparsity_pattern_ = true;
       }
       if (h_val_data_ == nullptr) {
         this->h_val_data_ = new real_type[nnz_current];
-        owns_cpu_vals_ = true;
+        owns_cpu_values_ = true;
       }
     }
 
@@ -212,11 +212,11 @@ namespace ReSolve
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
         mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);
-        owns_gpu_data_ = true;
+        owns_gpu_sparsity_pattern_ = true;
       }
       if (d_val_data_ == nullptr) {
         mem_.allocateArrayOnDevice(&d_val_data_, nnz_current);
-        owns_gpu_vals_ = true;
+        owns_gpu_values_ = true;
       }
     }
 
@@ -275,8 +275,8 @@ namespace ReSolve
       std::fill(h_col_data_, h_col_data_ + nnz_current, 0);  
       this->h_val_data_ = new real_type[nnz_current];
       std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);  
-      owns_cpu_data_ = true;
-      owns_cpu_vals_ = true;
+      owns_cpu_sparsity_pattern_ = true;
+      owns_cpu_values_ = true;
       return 0;
     }
 
@@ -284,8 +284,8 @@ namespace ReSolve
       mem_.allocateArrayOnDevice(&d_row_data_, nnz_current); 
       mem_.allocateArrayOnDevice(&d_col_data_, nnz_current); 
       mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
-      owns_gpu_data_ = true;
-      owns_gpu_vals_ = true;
+      owns_gpu_sparsity_pattern_ = true;
+      owns_gpu_values_ = true;
       return 0;
     }
     return -1;
@@ -321,11 +321,11 @@ namespace ReSolve
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
           h_row_data_ = new index_type[nnz_];      
           h_col_data_ = new index_type[nnz_];      
-          owns_cpu_data_ = true;
+          owns_cpu_sparsity_pattern_ = true;
         }
         if (h_val_data_ == nullptr) {
           h_val_data_ = new real_type[nnz_];      
-          owns_cpu_vals_ = true;
+          owns_cpu_values_ = true;
         }
         mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, nnz_);
         mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, nnz_);
@@ -347,11 +347,11 @@ namespace ReSolve
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_row_data_, nnz_);
           mem_.allocateArrayOnDevice(&d_col_data_, nnz_);
-          owns_gpu_data_ = true;
+          owns_gpu_sparsity_pattern_ = true;
         }
         if (d_val_data_ == nullptr) {
           mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
-          owns_gpu_vals_ = true;
+          owns_gpu_values_ = true;
         }
         mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, nnz_);
         mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, nnz_);

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -172,11 +172,11 @@ namespace ReSolve
     }
   }
 
-  int matrix::Coo::updateData(const index_type* row_data,
-                              const index_type* col_data,
-                              const real_type* val_data,
-                              memory::MemorySpace memspaceIn,
-                              memory::MemorySpace memspaceOut)
+  int matrix::Coo::copyData(const index_type* row_data,
+                            const index_type* col_data,
+                            const real_type* val_data,
+                            memory::MemorySpace memspaceIn,
+                            memory::MemorySpace memspaceOut)
   {
 
     //four cases (for now)
@@ -191,7 +191,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated	
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Coo::updateData one of host row or column data is null!\n";
+        out::error() << "In Coo::copyData one of host row or column data is null!\n";
       }
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[nnz_current];
@@ -207,7 +207,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Coo::updateData one of device row or column data is null!\n";
+        out::error() << "In Coo::copyData one of device row or column data is null!\n";
       }
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
@@ -251,16 +251,16 @@ namespace ReSolve
     return 0;
   } 
 
-  int matrix::Coo::updateData(const index_type* row_data,
-                              const index_type* col_data,
-                              const real_type* val_data,
-                              index_type new_nnz,
-                              memory::MemorySpace memspaceIn,
-                              memory::MemorySpace memspaceOut)
+  int matrix::Coo::copyData(const index_type* row_data,
+                            const index_type* col_data,
+                            const real_type* val_data,
+                            index_type new_nnz,
+                            memory::MemorySpace memspaceIn,
+                            memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return updateData(row_data, col_data, val_data, memspaceIn, memspaceOut);
+    return copyData(row_data, col_data, val_data, memspaceIn, memspaceOut);
   } 
 
   int matrix::Coo::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -172,11 +172,11 @@ namespace ReSolve
     }
   }
 
-  int matrix::Coo::copyData(const index_type* row_data,
-                            const index_type* col_data,
-                            const real_type* val_data,
-                            memory::MemorySpace memspaceIn,
-                            memory::MemorySpace memspaceOut)
+  int matrix::Coo::copyDataFrom(const index_type* row_data,
+                                const index_type* col_data,
+                                const real_type* val_data,
+                                memory::MemorySpace memspaceIn,
+                                memory::MemorySpace memspaceOut)
   {
 
     //four cases (for now)
@@ -191,7 +191,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated	
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Coo::copyData one of host row or column data is null!\n";
+        out::error() << "In Coo::copyDataFrom one of host row or column data is null!\n";
       }
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[nnz_current];
@@ -207,7 +207,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Coo::copyData one of device row or column data is null!\n";
+        out::error() << "In Coo::copyDataFrom one of device row or column data is null!\n";
       }
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
@@ -251,16 +251,16 @@ namespace ReSolve
     return 0;
   } 
 
-  int matrix::Coo::copyData(const index_type* row_data,
-                            const index_type* col_data,
-                            const real_type* val_data,
-                            index_type new_nnz,
-                            memory::MemorySpace memspaceIn,
-                            memory::MemorySpace memspaceOut)
+  int matrix::Coo::copyDataFrom(const index_type* row_data,
+                                const index_type* col_data,
+                                const real_type* val_data,
+                                index_type new_nnz,
+                                memory::MemorySpace memspaceIn,
+                                memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return copyData(row_data, col_data, val_data, memspaceIn, memspaceOut);
+    return copyDataFrom(row_data, col_data, val_data, memspaceIn, memspaceOut);
   } 
 
   int matrix::Coo::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -172,9 +172,9 @@ namespace ReSolve
     }
   }
 
-  int matrix::Coo::updateData(index_type* row_data,
-                              index_type* col_data,
-                              real_type* val_data,
+  int matrix::Coo::updateData(const index_type* row_data,
+                              const index_type* col_data,
+                              const real_type* val_data,
                               memory::MemorySpace memspaceIn,
                               memory::MemorySpace memspaceOut)
   {
@@ -251,12 +251,16 @@ namespace ReSolve
     return 0;
   } 
 
-  int matrix::Coo::updateData(index_type* row_data, index_type* col_data, real_type* val_data, index_type new_nnz, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int matrix::Coo::updateData(const index_type* row_data,
+                              const index_type* col_data,
+                              const real_type* val_data,
+                              index_type new_nnz,
+                              memory::MemorySpace memspaceIn,
+                              memory::MemorySpace memspaceOut)
   {
-    this->destroyMatrixData(memspaceOut);
-    this->nnz_ = new_nnz;
-    int i = this->updateData(row_data, col_data, val_data, memspaceIn, memspaceOut);
-    return i;
+    destroyMatrixData(memspaceOut);
+    nnz_ = new_nnz;
+    return updateData(row_data, col_data, val_data, memspaceIn, memspaceOut);
   } 
 
   int matrix::Coo::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Coo.hpp
+++ b/resolve/matrix/Coo.hpp
@@ -29,8 +29,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int updateData(index_type* row_data, index_type* col_data, real_type* val_data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut); 
-      virtual int updateData(index_type* row_data, index_type* col_data, real_type* val_data, index_type new_nnz, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut); 
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
+                             memory::MemorySpace memspaceIn,
+                             memory::MemorySpace memspaceOut);
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
+                             index_type new_nnz,
+                             memory::MemorySpace memspaceIn,
+                             memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/Coo.hpp
+++ b/resolve/matrix/Coo.hpp
@@ -29,17 +29,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut);
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             index_type new_nnz,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut);
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut);
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           index_type new_nnz,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/Coo.hpp
+++ b/resolve/matrix/Coo.hpp
@@ -29,17 +29,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut);
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           index_type new_nnz,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut);
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut);
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               index_type new_nnz,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -73,11 +73,11 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csc::updateData(const index_type* row_data,
-                              const index_type* col_data,
-                              const real_type* val_data,
-                              memory::MemorySpace memspaceIn,
-                              memory::MemorySpace memspaceOut)
+  int matrix::Csc::copyData(const index_type* row_data,
+                            const index_type* col_data,
+                            const real_type* val_data,
+                            memory::MemorySpace memspaceIn,
+                            memory::MemorySpace memspaceOut)
   {
     index_type nnz_current = nnz_;
 
@@ -92,7 +92,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csc::updateData one of host row or column data is null!\n";
+        out::error() << "In Csc::copyData one of host row or column data is null!\n";
       }
       if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
         this->h_col_data_ = new index_type[m_ + 1];
@@ -108,7 +108,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csc::updateData one of device row or column data is null!\n";
+        out::error() << "In Csc::copyData one of device row or column data is null!\n";
       }
       if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
@@ -153,16 +153,16 @@ namespace ReSolve
 
   } 
 
-  int matrix::Csc::updateData(const index_type* row_data,
-                              const index_type* col_data,
-                              const real_type* val_data,
-                              index_type new_nnz,
-                              memory::MemorySpace memspaceIn,
-                              memory::MemorySpace memspaceOut)
+  int matrix::Csc::copyData(const index_type* row_data,
+                            const index_type* col_data,
+                            const real_type* val_data,
+                            index_type new_nnz,
+                            memory::MemorySpace memspaceIn,
+                            memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return updateData(col_data, row_data, val_data, memspaceIn, memspaceOut);
+    return copyData(col_data, row_data, val_data, memspaceIn, memspaceOut);
   }
 
   int matrix::Csc::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -73,9 +73,9 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csc::updateData(index_type* row_data,
-                              index_type* col_data,
-                              real_type* val_data,
+  int matrix::Csc::updateData(const index_type* row_data,
+                              const index_type* col_data,
+                              const real_type* val_data,
                               memory::MemorySpace memspaceIn,
                               memory::MemorySpace memspaceOut)
   {
@@ -153,17 +153,16 @@ namespace ReSolve
 
   } 
 
-  int matrix::Csc::updateData(index_type* row_data,
-                              index_type* col_data,
-                              real_type* val_data,
+  int matrix::Csc::updateData(const index_type* row_data,
+                              const index_type* col_data,
+                              const real_type* val_data,
                               index_type new_nnz,
                               memory::MemorySpace memspaceIn,
                               memory::MemorySpace memspaceOut)
   {
-    this->destroyMatrixData(memspaceOut);
-    this->nnz_ = new_nnz;
-    int i = this->updateData(col_data, row_data, val_data, memspaceIn, memspaceOut);
-    return i;
+    destroyMatrixData(memspaceOut);
+    nnz_ = new_nnz;
+    return updateData(col_data, row_data, val_data, memspaceIn, memspaceOut);
   }
 
   int matrix::Csc::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -73,11 +73,11 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csc::copyData(const index_type* row_data,
-                            const index_type* col_data,
-                            const real_type* val_data,
-                            memory::MemorySpace memspaceIn,
-                            memory::MemorySpace memspaceOut)
+  int matrix::Csc::copyDataFrom(const index_type* row_data,
+                                const index_type* col_data,
+                                const real_type* val_data,
+                                memory::MemorySpace memspaceIn,
+                                memory::MemorySpace memspaceOut)
   {
     index_type nnz_current = nnz_;
 
@@ -92,7 +92,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csc::copyData one of host row or column data is null!\n";
+        out::error() << "In Csc::copyDataFrom one of host row or column data is null!\n";
       }
       if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
         this->h_col_data_ = new index_type[m_ + 1];
@@ -108,7 +108,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csc::copyData one of device row or column data is null!\n";
+        out::error() << "In Csc::copyDataFrom one of device row or column data is null!\n";
       }
       if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
@@ -153,16 +153,16 @@ namespace ReSolve
 
   } 
 
-  int matrix::Csc::copyData(const index_type* row_data,
-                            const index_type* col_data,
-                            const real_type* val_data,
-                            index_type new_nnz,
-                            memory::MemorySpace memspaceIn,
-                            memory::MemorySpace memspaceOut)
+  int matrix::Csc::copyDataFrom(const index_type* row_data,
+                                const index_type* col_data,
+                                const real_type* val_data,
+                                index_type new_nnz,
+                                memory::MemorySpace memspaceIn,
+                                memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return copyData(col_data, row_data, val_data, memspaceIn, memspaceOut);
+    return copyDataFrom(col_data, row_data, val_data, memspaceIn, memspaceOut);
   }
 
   int matrix::Csc::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -97,11 +97,11 @@ namespace ReSolve
       if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
         this->h_col_data_ = new index_type[m_ + 1];
         this->h_row_data_ = new index_type[nnz_current];
-        owns_cpu_data_ = true;
+        owns_cpu_sparsity_pattern_ = true;
       } 
       if (h_val_data_ == nullptr) {
         this->h_val_data_ = new real_type[nnz_current];
-        owns_cpu_vals_ = true;
+        owns_cpu_values_ = true;
       }
     }
 
@@ -113,11 +113,11 @@ namespace ReSolve
       if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
-        owns_gpu_data_ = true;
+        owns_gpu_sparsity_pattern_ = true;
       }
       if (d_val_data_ == nullptr) {
         mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
-        owns_gpu_vals_ = true;
+        owns_gpu_values_ = true;
       }
     }
 
@@ -177,8 +177,8 @@ namespace ReSolve
       std::fill(h_row_data_, h_row_data_ + nnz_current, 0);  
       this->h_val_data_ = new real_type[nnz_current];
       std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);  
-      owns_cpu_data_ = true;
-      owns_cpu_vals_ = true;
+      owns_cpu_sparsity_pattern_ = true;
+      owns_cpu_values_ = true;
       return 0;
     }
 
@@ -186,8 +186,8 @@ namespace ReSolve
       mem_.allocateArrayOnDevice(&d_col_data_,      m_ + 1); 
       mem_.allocateArrayOnDevice(&d_row_data_, nnz_current); 
       mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
-      owns_gpu_data_ = true;
-      owns_gpu_vals_ = true;
+      owns_gpu_sparsity_pattern_ = true;
+      owns_gpu_values_ = true;
       return 0;   
     }
     return -1;
@@ -223,11 +223,11 @@ namespace ReSolve
         if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
           h_col_data_ = new index_type[m_ + 1];      
           h_row_data_ = new index_type[nnz_];      
-          owns_cpu_data_ = true;
+          owns_cpu_sparsity_pattern_ = true;
         }
         if (h_val_data_ == nullptr) {
           h_val_data_ = new real_type[nnz_];      
-          owns_cpu_vals_ = true;
+          owns_cpu_values_ = true;
         }
         mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, m_ + 1);
         mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_,   nnz_);
@@ -249,11 +249,11 @@ namespace ReSolve
         if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
           mem_.allocateArrayOnDevice(&d_row_data_,   nnz_);
-          owns_gpu_data_ = true;
+          owns_gpu_sparsity_pattern_ = true;
         }
         if (d_val_data_ == nullptr) {
           mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
-          owns_gpu_vals_ = true;
+          owns_gpu_values_ = true;
         }
         mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, m_ + 1);
         mem_.copyArrayHostToDevice(d_row_data_, h_row_data_,   nnz_);

--- a/resolve/matrix/Csc.hpp
+++ b/resolve/matrix/Csc.hpp
@@ -19,14 +19,14 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int updateData(index_type* row_data,
-                             index_type* col_data,
-                             real_type* val_data,
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
                              memory::MemorySpace memspaceIn,
                              memory::MemorySpace memspaceOut); 
-      virtual int updateData(index_type* row_data,
-                             index_type* col_data,
-                             real_type* val_data,
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
                              index_type new_nnz,
                              memory::MemorySpace memspaceIn,
                              memory::MemorySpace memspaceOut); 

--- a/resolve/matrix/Csc.hpp
+++ b/resolve/matrix/Csc.hpp
@@ -19,17 +19,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut); 
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           index_type new_nnz,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut); 
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut); 
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               index_type new_nnz,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut); 
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/Csc.hpp
+++ b/resolve/matrix/Csc.hpp
@@ -19,17 +19,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut); 
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             index_type new_nnz,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut); 
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut); 
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           index_type new_nnz,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut); 
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -190,11 +190,11 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csr::updateData(const index_type* row_data,
-                              const index_type* col_data,
-                              const real_type* val_data,
-                              memory::MemorySpace memspaceIn,
-                              memory::MemorySpace memspaceOut)
+  int matrix::Csr::copyData(const index_type* row_data,
+                            const index_type* col_data,
+                            const real_type* val_data,
+                            memory::MemorySpace memspaceIn,
+                            memory::MemorySpace memspaceOut)
   {
     //four cases (for now)
     index_type nnz_current = nnz_;
@@ -208,7 +208,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csr::updateData one of host row or column data is null!\n";
+        out::error() << "In Csr::copyData one of host row or column data is null!\n";
       }
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[n_ + 1];
@@ -224,7 +224,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csr::updateData one of device row or column data is null!\n";
+        out::error() << "In Csr::copyData one of device row or column data is null!\n";
       }
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
@@ -270,16 +270,16 @@ namespace ReSolve
     return 0;
   } 
 
-  int matrix::Csr::updateData(const index_type* row_data,
-                              const index_type* col_data,
-                              const real_type* val_data,
-                              index_type new_nnz,
-                              memory::MemorySpace memspaceIn,
-                              memory::MemorySpace memspaceOut)
+  int matrix::Csr::copyData(const index_type* row_data,
+                            const index_type* col_data,
+                            const real_type* val_data,
+                            index_type new_nnz,
+                            memory::MemorySpace memspaceIn,
+                            memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return updateData(row_data, col_data, val_data, memspaceIn, memspaceOut);
+    return copyData(row_data, col_data, val_data, memspaceIn, memspaceOut);
   } 
 
   int matrix::Csr::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -190,7 +190,11 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csr::updateData(index_type* row_data, index_type* col_data, real_type* val_data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int matrix::Csr::updateData(const index_type* row_data,
+                              const index_type* col_data,
+                              const real_type* val_data,
+                              memory::MemorySpace memspaceIn,
+                              memory::MemorySpace memspaceOut)
   {
     //four cases (for now)
     index_type nnz_current = nnz_;
@@ -266,12 +270,16 @@ namespace ReSolve
     return 0;
   } 
 
-  int matrix::Csr::updateData(index_type* row_data, index_type* col_data, real_type* val_data, index_type new_nnz, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int matrix::Csr::updateData(const index_type* row_data,
+                              const index_type* col_data,
+                              const real_type* val_data,
+                              index_type new_nnz,
+                              memory::MemorySpace memspaceIn,
+                              memory::MemorySpace memspaceOut)
   {
-    this->destroyMatrixData(memspaceOut);
-    this->nnz_ = new_nnz;
-    int i = this->updateData(row_data, col_data, val_data, memspaceIn, memspaceOut);
-    return i;
+    destroyMatrixData(memspaceOut);
+    nnz_ = new_nnz;
+    return updateData(row_data, col_data, val_data, memspaceIn, memspaceOut);
   } 
 
   int matrix::Csr::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -190,11 +190,11 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csr::copyData(const index_type* row_data,
-                            const index_type* col_data,
-                            const real_type* val_data,
-                            memory::MemorySpace memspaceIn,
-                            memory::MemorySpace memspaceOut)
+  int matrix::Csr::copyDataFrom(const index_type* row_data,
+                                const index_type* col_data,
+                                const real_type* val_data,
+                                memory::MemorySpace memspaceIn,
+                                memory::MemorySpace memspaceOut)
   {
     //four cases (for now)
     index_type nnz_current = nnz_;
@@ -208,7 +208,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csr::copyData one of host row or column data is null!\n";
+        out::error() << "In Csr::copyDataFrom one of host row or column data is null!\n";
       }
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[n_ + 1];
@@ -224,7 +224,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csr::copyData one of device row or column data is null!\n";
+        out::error() << "In Csr::copyDataFrom one of device row or column data is null!\n";
       }
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
@@ -270,16 +270,16 @@ namespace ReSolve
     return 0;
   } 
 
-  int matrix::Csr::copyData(const index_type* row_data,
-                            const index_type* col_data,
-                            const real_type* val_data,
-                            index_type new_nnz,
-                            memory::MemorySpace memspaceIn,
-                            memory::MemorySpace memspaceOut)
+  int matrix::Csr::copyDataFrom(const index_type* row_data,
+                                const index_type* col_data,
+                                const real_type* val_data,
+                                index_type new_nnz,
+                                memory::MemorySpace memspaceIn,
+                                memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return copyData(row_data, col_data, val_data, memspaceIn, memspaceOut);
+    return copyDataFrom(row_data, col_data, val_data, memspaceIn, memspaceOut);
   } 
 
   int matrix::Csr::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -72,7 +72,7 @@ namespace ReSolve
         h_col_data_ = *cols;
         h_val_data_ = *vals;
         h_data_updated_ = true;
-        owns_cpu_data_  = true;
+        owns_cpu_sparsity_pattern_ = true;
         // Set device data to null
         if (d_row_data_ || d_col_data_ || d_val_data_) {
           out::error() << "Device data unexpectedly allocated. "
@@ -82,7 +82,7 @@ namespace ReSolve
         d_col_data_ = nullptr;
         d_val_data_ = nullptr;
         d_data_updated_ = false;
-        owns_gpu_data_  = false;
+        owns_gpu_sparsity_pattern_ = false;
         // Hijack data from the source
         *rows = nullptr;
         *cols = nullptr;
@@ -94,7 +94,7 @@ namespace ReSolve
         d_col_data_ = *cols;
         d_val_data_ = *vals;
         d_data_updated_ = true;
-        owns_gpu_data_  = true;
+        owns_gpu_sparsity_pattern_ = true;
         syncData(memspaceDst);
         // Hijack data from the source
         *rows = nullptr;
@@ -107,7 +107,7 @@ namespace ReSolve
         h_col_data_ = *cols;
         h_val_data_ = *vals;
         h_data_updated_ = true;
-        owns_cpu_data_  = true;
+        owns_cpu_sparsity_pattern_ = true;
         syncData(memspaceDst);
 
         // Hijack data from the source
@@ -121,7 +121,7 @@ namespace ReSolve
         d_col_data_ = *cols;
         d_val_data_ = *vals;
         d_data_updated_ = true;
-        owns_gpu_data_  = true;
+        owns_gpu_sparsity_pattern_ = true;
         // Set host data to null
         if (h_row_data_ || h_col_data_ || h_val_data_) {
           out::error() << "Host data unexpectedly allocated. "
@@ -131,7 +131,7 @@ namespace ReSolve
         h_col_data_ = nullptr;
         h_val_data_ = nullptr;
         h_data_updated_ = false;
-        owns_cpu_data_  = false;
+        owns_cpu_sparsity_pattern_ = false;
         // Hijack data from the source
         *rows = nullptr;
         *cols = nullptr;
@@ -213,11 +213,11 @@ namespace ReSolve
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[n_ + 1];
         this->h_col_data_ = new index_type[nnz_current];
-        owns_cpu_data_ = true;
+        owns_cpu_sparsity_pattern_ = true;
       } 
       if (h_val_data_ == nullptr) {
         this->h_val_data_ = new real_type[nnz_current];
-        owns_cpu_vals_ = true;
+        owns_cpu_values_ = true;
       }
     }
 
@@ -229,11 +229,11 @@ namespace ReSolve
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
         mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);
-        owns_gpu_vals_ = true;
+        owns_gpu_values_ = true;
       }
       if (d_val_data_ == nullptr) {
         mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
-        owns_gpu_data_ = true;
+        owns_gpu_sparsity_pattern_ = true;
       }
     }
 
@@ -294,8 +294,8 @@ namespace ReSolve
       std::fill(h_col_data_, h_col_data_ + nnz_current, 0);  
       this->h_val_data_ = new real_type[nnz_current];
       std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);  
-      owns_cpu_data_ = true;
-      owns_cpu_vals_ = true;
+      owns_cpu_sparsity_pattern_ = true;
+      owns_cpu_values_ = true;
       return 0;   
     }
 
@@ -303,8 +303,8 @@ namespace ReSolve
       mem_.allocateArrayOnDevice(&d_row_data_,      n_ + 1); 
       mem_.allocateArrayOnDevice(&d_col_data_, nnz_current); 
       mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
-      owns_gpu_data_ = true;
-      owns_gpu_vals_ = true;
+      owns_gpu_sparsity_pattern_ = true;
+      owns_gpu_values_ = true;
       return 0;  
     }
     return -1;
@@ -341,11 +341,11 @@ namespace ReSolve
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
           h_row_data_ = new index_type[n_ + 1];
           h_col_data_ = new index_type[nnz_];      
-          owns_cpu_data_ = true;
+          owns_cpu_sparsity_pattern_ = true;
         }
         if (h_val_data_ == nullptr) {
           h_val_data_ = new real_type[nnz_];      
-          owns_cpu_vals_ = true;
+          owns_cpu_values_ = true;
         }
         mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, n_ + 1);
         mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, nnz_);
@@ -367,11 +367,11 @@ namespace ReSolve
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
           mem_.allocateArrayOnDevice(&d_col_data_, nnz_); 
-          owns_gpu_data_ = true;
+          owns_gpu_sparsity_pattern_ = true;
         }
         if (d_val_data_ == nullptr) {
           mem_.allocateArrayOnDevice(&d_val_data_, nnz_); 
-          owns_gpu_vals_ = true;
+          owns_gpu_values_ = true;
         }
         mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, n_ + 1);
         mem_.copyArrayHostToDevice(d_col_data_, h_col_data_, nnz_);

--- a/resolve/matrix/Csr.hpp
+++ b/resolve/matrix/Csr.hpp
@@ -36,8 +36,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int updateData(index_type* row_data, index_type* col_data, real_type* val_data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut); 
-      virtual int updateData(index_type* row_data, index_type* col_data, real_type* val_data, index_type new_nnz, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
+                             memory::MemorySpace memspaceIn,
+                             memory::MemorySpace memspaceOut);
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
+                             index_type new_nnz,
+                             memory::MemorySpace memspaceIn,
+                             memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace); 
 

--- a/resolve/matrix/Csr.hpp
+++ b/resolve/matrix/Csr.hpp
@@ -36,17 +36,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut);
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             index_type new_nnz,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut);
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut);
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           index_type new_nnz,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace); 
 

--- a/resolve/matrix/Csr.hpp
+++ b/resolve/matrix/Csr.hpp
@@ -36,17 +36,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues( memory::MemorySpace memspace); 
 
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut);
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           index_type new_nnz,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut);
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut);
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               index_type new_nnz,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace); 
 

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -333,9 +333,9 @@ namespace ReSolve {
    *
    * @return 0 if successful, -1 if not.
    */  
-  int matrix::Sparse::updateValues(const real_type* new_vals,
-                                   memory::MemorySpace memspaceIn,
-                                   memory::MemorySpace memspaceOut)
+  int matrix::Sparse::copyValues(const real_type* new_vals,
+                                 memory::MemorySpace memspaceIn,
+                                 memory::MemorySpace memspaceOut)
   {
  
     index_type nnz_current = nnz_;
@@ -393,8 +393,8 @@ namespace ReSolve {
    * This function only assigns a pointer, but does not copy. It sets update
    * flags.
    *
-   * @param[in] new_vals    - pointer to new values data (array of real numbers)
-   * @param[in] memspace    - memory space (HOST or DEVICE) of _new_vals_
+   * @param[in] new_vals - pointer to new values data (array of real numbers)
+   * @param[in] memspace - memory space (HOST or DEVICE) of _new_vals_
    *
    * @return 0 if successful, -1 if not.
    */  

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -229,7 +229,10 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 if not.
    */  
-  int matrix::Sparse::setMatrixData(index_type* row_data, index_type* col_data, real_type* val_data, memory::MemorySpace memspace)
+  int matrix::Sparse::setDataPointers(index_type* row_data,
+                                      index_type* col_data,
+                                      real_type*  val_data,
+                                      memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
 
@@ -239,7 +242,7 @@ namespace ReSolve {
       case HOST:
         if (owns_cpu_data_ && (h_row_data_ || h_col_data_)) {
           out::error() << "Trying to set matrix host data, but the data already set!\n";
-          out::error() << "Ignoring setMatrixData function call ...\n";
+          out::error() << "Ignoring setDataPointers function call ...\n";
           return 1;
         }
         if (owns_cpu_vals_ && h_val_data_) {
@@ -257,7 +260,7 @@ namespace ReSolve {
       case DEVICE:
         if (owns_gpu_data_ && (d_row_data_ || d_col_data_)) {
           out::error() << "Trying to set matrix host data, but the data already set!\n";
-          out::error() << "Ignoring setMatrixData function call ...\n";
+          out::error() << "Ignoring setDataPointers function call ...\n";
           return 1;
         }
         if (owns_gpu_vals_ && d_val_data_) {

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -330,7 +330,9 @@ namespace ReSolve {
    *
    * @return 0 if successful, -1 if not.
    */  
-  int matrix::Sparse::updateValues(real_type* new_vals, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int matrix::Sparse::updateValues(const real_type* new_vals,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut)
   {
  
     index_type nnz_current = nnz_;

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -247,7 +247,7 @@ namespace ReSolve {
         }
         if (owns_cpu_vals_ && h_val_data_) {
           out::error() << "Trying to set matrix host values, but the values already set!\n";
-          out::error() << "Ignoring setNewValues function call ...\n";
+          out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
         }
         h_row_data_ = row_data;
@@ -265,7 +265,7 @@ namespace ReSolve {
         }
         if (owns_gpu_vals_ && d_val_data_) {
           out::error() << "Trying to set matrix device values, but the values already set!\n";
-          out::error() << "Ignoring setNewValues function call ...\n";
+          out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
         }
         d_row_data_ = row_data;
@@ -387,16 +387,19 @@ namespace ReSolve {
   }
 
   /**
-   * @brief updata matrix values using the _new_values_ provided either as HOST or as DEVICE array.
+   * @brief updata matrix values using the _new_values_ provided either as
+   * HOST or as DEVICE array.
    * 
-   * This function only assigns a pointer, but does not copy. It sets update flags.
+   * This function only assigns a pointer, but does not copy. It sets update
+   * flags.
    *
    * @param[in] new_vals    - pointer to new values data (array of real numbers)
    * @param[in] memspace    - memory space (HOST or DEVICE) of _new_vals_
    *
    * @return 0 if successful, -1 if not.
    */  
-  int matrix::Sparse::setNewValues(real_type* new_vals, memory::MemorySpace memspace)
+  int matrix::Sparse::setValuesPointer(real_type* new_vals,
+                                       memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
     setNotUpdated();
@@ -405,7 +408,7 @@ namespace ReSolve {
       case HOST:
         if (owns_cpu_vals_ && h_val_data_) {
           out::error() << "Trying to set matrix host values, but the values already set!\n";
-          out::error() << "Ignoring setNewValues function call ...\n";
+          out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
         }
         h_val_data_ = new_vals;	
@@ -415,7 +418,7 @@ namespace ReSolve {
       case DEVICE:
         if (owns_gpu_vals_ && d_val_data_) {
           out::error() << "Trying to set matrix device values, but the values already set!\n";
-          out::error() << "Ignoring setNewValues function call ...\n";
+          out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
         }
         d_val_data_ = new_vals;	

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -42,11 +42,11 @@ namespace ReSolve {
     d_col_data_ = nullptr;
     d_val_data_ = nullptr;
     
-    owns_cpu_data_ = false;
-    owns_cpu_vals_ = false;
+    owns_cpu_sparsity_pattern_ = false;
+    owns_cpu_values_ = false;
     
-    owns_gpu_data_ = false;
-    owns_gpu_vals_ = false;
+    owns_gpu_sparsity_pattern_ = false;
+    owns_gpu_values_ = false;
   }
 
   /** 
@@ -80,11 +80,11 @@ namespace ReSolve {
     d_col_data_ = nullptr;
     d_val_data_ = nullptr;
 
-    owns_cpu_data_ = false;
-    owns_cpu_vals_ = false;
+    owns_cpu_sparsity_pattern_ = false;
+    owns_cpu_values_ = false;
     
-    owns_gpu_data_ = false;
-    owns_gpu_vals_ = false;
+    owns_gpu_sparsity_pattern_ = false;
+    owns_gpu_values_ = false;
   }
   
   /**
@@ -240,12 +240,12 @@ namespace ReSolve {
 
     switch (memspace) {
       case HOST:
-        if (owns_cpu_data_ && (h_row_data_ || h_col_data_)) {
+        if (owns_cpu_sparsity_pattern_ && (h_row_data_ || h_col_data_)) {
           out::error() << "Trying to set matrix host data, but the data already set!\n";
           out::error() << "Ignoring setDataPointers function call ...\n";
           return 1;
         }
-        if (owns_cpu_vals_ && h_val_data_) {
+        if (owns_cpu_values_ && h_val_data_) {
           out::error() << "Trying to set matrix host values, but the values already set!\n";
           out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
@@ -254,16 +254,16 @@ namespace ReSolve {
         h_col_data_ = col_data;
         h_val_data_ = val_data;	
         h_data_updated_ = true;
-        owns_cpu_data_  = false;
-        owns_cpu_vals_  = false;
+        owns_cpu_sparsity_pattern_ = false;
+        owns_cpu_values_ = false;
         break;
       case DEVICE:
-        if (owns_gpu_data_ && (d_row_data_ || d_col_data_)) {
+        if (owns_gpu_sparsity_pattern_ && (d_row_data_ || d_col_data_)) {
           out::error() << "Trying to set matrix host data, but the data already set!\n";
           out::error() << "Ignoring setDataPointers function call ...\n";
           return 1;
         }
-        if (owns_gpu_vals_ && d_val_data_) {
+        if (owns_gpu_values_ && d_val_data_) {
           out::error() << "Trying to set matrix device values, but the values already set!\n";
           out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
@@ -272,8 +272,8 @@ namespace ReSolve {
         d_col_data_ = col_data;
         d_val_data_ = val_data;	
         d_data_updated_ = true;
-        owns_gpu_data_  = false;
-        owns_gpu_vals_  = false;
+        owns_gpu_sparsity_pattern_ = false;
+        owns_gpu_values_ = false;
         break;
     }
     return 0;
@@ -293,25 +293,25 @@ namespace ReSolve {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        if (owns_cpu_data_) {
+        if (owns_cpu_sparsity_pattern_) {
           delete [] h_row_data_;
           delete [] h_col_data_;
           h_row_data_ = nullptr;
           h_col_data_ = nullptr;
         }
-        if (owns_cpu_vals_) {
+        if (owns_cpu_values_) {
           delete [] h_val_data_;
           h_val_data_ = nullptr;
         }
         return 0;
       case DEVICE:
-        if (owns_gpu_data_) {
+        if (owns_gpu_sparsity_pattern_) {
           mem_.deleteOnDevice(d_row_data_);
           mem_.deleteOnDevice(d_col_data_);
           d_row_data_ = nullptr;
           d_col_data_ = nullptr;
         }
-        if (owns_gpu_vals_) {
+        if (owns_gpu_values_) {
           mem_.deleteOnDevice(d_val_data_);
           d_val_data_ = nullptr;
         }
@@ -351,7 +351,7 @@ namespace ReSolve {
       //check if cpu data allocated
       if (h_val_data_ == nullptr) {
         this->h_val_data_ = new real_type[nnz_current];
-        owns_cpu_vals_ = true;
+        owns_cpu_values_ = true;
       }
     }
 
@@ -359,7 +359,7 @@ namespace ReSolve {
       //check if cuda data allocated
       if (d_val_data_ == nullptr) {
         mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
-        owns_gpu_vals_ = true;
+        owns_gpu_values_ = true;
       }
     }
 
@@ -406,24 +406,24 @@ namespace ReSolve {
 
     switch (memspace) {
       case HOST:
-        if (owns_cpu_vals_ && h_val_data_) {
+        if (owns_cpu_values_ && h_val_data_) {
           out::error() << "Trying to set matrix host values, but the values already set!\n";
           out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
         }
         h_val_data_ = new_vals;	
         h_data_updated_ = true;
-        owns_cpu_vals_  = false;
+        owns_cpu_values_  = false;
         break;
       case DEVICE:
-        if (owns_gpu_vals_ && d_val_data_) {
+        if (owns_gpu_values_ && d_val_data_) {
           out::error() << "Trying to set matrix device values, but the values already set!\n";
           out::error() << "Ignoring setValuesPointer function call ...\n";
           return 1;
         }
         d_val_data_ = new_vals;	
         d_data_updated_ = true;
-        owns_gpu_vals_  = false;
+        owns_gpu_values_  = false;
         break;
       default:
         return -1;

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -55,17 +55,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace) = 0;
       virtual real_type*  getValues( memory::MemorySpace memspace) = 0;
 
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut) = 0;
-      virtual int updateData(const index_type* row_data,
-                             const index_type* col_data,
-                             const real_type* val_data,
-                             index_type new_nnz,
-                             memory::MemorySpace memspaceIn,
-                             memory::MemorySpace memspaceOut) = 0;
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut) = 0;
+      virtual int copyData(const index_type* row_data,
+                           const index_type* col_data,
+                           const real_type* val_data,
+                           index_type new_nnz,
+                           memory::MemorySpace memspaceIn,
+                           memory::MemorySpace memspaceOut) = 0;
 
       virtual int allocateMatrixData(memory::MemorySpace memspace) = 0;
       int setDataPointers(index_type* row_data,
@@ -82,9 +82,9 @@ namespace ReSolve { namespace matrix {
 
       //update Values just updates values; it allocates if necessary.
       //values have the same dimensions between different formats 
-      virtual int updateValues(const real_type* new_vals,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut);
+      virtual int copyValues(const real_type* new_vals,
+                             memory::MemorySpace memspaceIn,
+                             memory::MemorySpace memspaceOut);
       
       //set new values just sets the pointer, use caution.   
       virtual int setValuesPointer(real_type* new_vals,

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -55,8 +55,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace) = 0;
       virtual real_type*  getValues( memory::MemorySpace memspace) = 0;
 
-      virtual int updateData(index_type* row_data, index_type* col_data, real_type* val_data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut) = 0;
-      virtual int updateData(index_type* row_data, index_type* col_data, real_type* val_data, index_type new_nnz, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut) = 0;
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
+                             memory::MemorySpace memspaceIn,
+                             memory::MemorySpace memspaceOut) = 0;
+      virtual int updateData(const index_type* row_data,
+                             const index_type* col_data,
+                             const real_type* val_data,
+                             index_type new_nnz,
+                             memory::MemorySpace memspaceIn,
+                             memory::MemorySpace memspaceOut) = 0;
 
       virtual int allocateMatrixData(memory::MemorySpace memspace) = 0;
       int setMatrixData(index_type* row_data, index_type* col_data, real_type* val_data, memory::MemorySpace memspace);

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -114,11 +114,11 @@ namespace ReSolve { namespace matrix {
       void setNotUpdated();
       
       // Data ownership flags
-      bool owns_cpu_data_{false}; ///< for row/col data
-      bool owns_cpu_vals_{false}; ///< for values
+      bool owns_cpu_sparsity_pattern_{false}; ///< for row/col data
+      bool owns_cpu_values_{false};           ///< for nonzero values
 
-      bool owns_gpu_data_{false}; ///< for row/col data
-      bool owns_gpu_vals_{false}; ///< for values
+      bool owns_gpu_sparsity_pattern_{false}; ///< for row/col data
+      bool owns_gpu_values_{false};           ///< for nonzero values
 
       MemoryHandler mem_; ///< Device memory manager object
   };

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -55,17 +55,17 @@ namespace ReSolve { namespace matrix {
       virtual index_type* getColData(memory::MemorySpace memspace) = 0;
       virtual real_type*  getValues( memory::MemorySpace memspace) = 0;
 
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut) = 0;
-      virtual int copyData(const index_type* row_data,
-                           const index_type* col_data,
-                           const real_type* val_data,
-                           index_type new_nnz,
-                           memory::MemorySpace memspaceIn,
-                           memory::MemorySpace memspaceOut) = 0;
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut) = 0;
+      virtual int copyDataFrom(const index_type* row_data,
+                               const index_type* col_data,
+                               const real_type* val_data,
+                               index_type new_nnz,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut) = 0;
 
       virtual int allocateMatrixData(memory::MemorySpace memspace) = 0;
       int setDataPointers(index_type* row_data,

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -79,7 +79,9 @@ namespace ReSolve { namespace matrix {
 
       //update Values just updates values; it allocates if necessary.
       //values have the same dimensions between different formats 
-      virtual int updateValues(real_type* new_vals, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
+      virtual int updateValues(const real_type* new_vals,
+                               memory::MemorySpace memspaceIn,
+                               memory::MemorySpace memspaceOut);
       
       //set new values just sets the pointer, use caution.   
       virtual int setNewValues(real_type* new_vals, memory::MemorySpace memspace);

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -87,7 +87,8 @@ namespace ReSolve { namespace matrix {
                                memory::MemorySpace memspaceOut);
       
       //set new values just sets the pointer, use caution.   
-      virtual int setNewValues(real_type* new_vals, memory::MemorySpace memspace);
+      virtual int setValuesPointer(real_type* new_vals,
+                                   memory::MemorySpace memspace);
     
     protected:
       SparseFormat sparse_format_{NONE}; ///< Matrix format

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -68,7 +68,10 @@ namespace ReSolve { namespace matrix {
                              memory::MemorySpace memspaceOut) = 0;
 
       virtual int allocateMatrixData(memory::MemorySpace memspace) = 0;
-      int setMatrixData(index_type* row_data, index_type* col_data, real_type* val_data, memory::MemorySpace memspace);
+      int setDataPointers(index_type* row_data,
+                          index_type* col_data,
+                          real_type*  val_data,
+                          memory::MemorySpace memspace);
 
       int destroyMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -146,7 +146,7 @@ namespace ReSolve { namespace vector {
   }
 
   /** 
-   * @brief update vector values based on another vector data.  
+   * @brief Copy data from another vector.  
    * 
    * @param[in] v           - Vector, which data will be copied
    * @param[in] memspaceIn  - Memory space of the incoming data (HOST or DEVICE)  
@@ -154,14 +154,14 @@ namespace ReSolve { namespace vector {
    *
    * @pre   size of _v_ is equal or larger than the current vector size.
    */
-  int Vector::update(Vector* v, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int Vector::copyDataFrom(Vector* v, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
   {
     real_type* data = v->getData(memspaceIn);
-    return update(data, memspaceIn, memspaceOut);
+    return copyDataFrom(data, memspaceIn, memspaceOut);
   }
 
   /** 
-   * @brief update vector data based on given input. 
+   * @brief Copy vector data from input array. 
    * 
    * This function allocates (if necessary) and copies the data. 
    * 
@@ -171,7 +171,7 @@ namespace ReSolve { namespace vector {
    *
    * @return 0 if successful, -1 otherwise.
    */
-  int Vector::update(const real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int Vector::copyDataFrom(const real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
   {
     int control=-1;
     if ((memspaceIn == memory::HOST)   && (memspaceOut == memory::HOST))  { control = 0;}

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -171,7 +171,7 @@ namespace ReSolve { namespace vector {
    *
    * @return 0 if successful, -1 otherwise.
    */
-  int Vector::update(real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+  int Vector::update(const real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
   {
     int control=-1;
     if ((memspaceIn == memory::HOST)   && (memspaceOut == memory::HOST))  { control = 0;}
@@ -503,7 +503,8 @@ namespace ReSolve { namespace vector {
   }
 
   /** 
-   * @brief copy HOST or DEVICE data of a specified vector in a multivector to _dest_. 
+   * @brief copy HOST or DEVICE data of a specified vector in a multivector
+   * to _dest_. 
    * 
    * @param[out] dest      - Pointer to the memory to which data is copied
    * @param[in] i          - Index of a vector in a multivector
@@ -511,17 +512,21 @@ namespace ReSolve { namespace vector {
    *
    * @return 0 if successful, -1 otherwise.
    *
-   * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in multivector.
-   * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (lenght of a single vector in the multivector).
+   * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors
+   * in multivector.
+   * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (lenght
+   * of a single vector in the multivector).
    */
-  int  Vector::deepCopyVectorData(real_type* dest, index_type i, memory::MemorySpace memspaceOut)
+  int  Vector::copyDataTo(real_type* dest,
+                          index_type i,
+                          memory::MemorySpace memspaceInOut)
   {
     using namespace ReSolve::memory;
     if (i > this->k_) {
       return -1;
     } else {
-      real_type* data = this->getData(i, memspaceOut);
-      switch (memspaceOut) {
+      real_type* data = this->getData(i, memspaceInOut);
+      switch (memspaceInOut) {
         case HOST:
           mem_.copyArrayHostToHost(dest, data, n_current_);
           break;
@@ -545,11 +550,11 @@ namespace ReSolve { namespace vector {
    *
    * @pre _dest_ is allocated, and the size of _dest_ is at least _k_ * _n_ .
    */
-  int  Vector::deepCopyVectorData(real_type* dest, memory::MemorySpace memspaceOut)
+  int  Vector::copyDataTo(real_type* dest, memory::MemorySpace memspaceInOut)
   {
     using namespace ReSolve::memory;
-    real_type* data = this->getData(memspaceOut);
-    switch (memspaceOut) {
+    real_type* data = this->getData(memspaceInOut);
+    switch (memspaceInOut) {
       case HOST:
         mem_.copyArrayHostToHost(dest, data, n_current_ * k_);
         break;

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -508,7 +508,7 @@ namespace ReSolve { namespace vector {
    * 
    * @param[out] dest      - Pointer to the memory to which data is copied
    * @param[in] i          - Index of a vector in a multivector
-   * @param[in] memspace   - Memory space (HOST or DEVICE) to copy from
+   * @param[in] memspace   - Memory space (HOST or DEVICE) to copy from and to
    *
    * @return 0 if successful, -1 otherwise.
    *
@@ -516,6 +516,8 @@ namespace ReSolve { namespace vector {
    * in multivector.
    * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (lenght
    * of a single vector in the multivector).
+   * @pre _dest_ is allocated in memspaceInOut memory space.
+   * @post All elements of the vector _i_ are copied to the array _dest_.
    */
   int  Vector::copyDataTo(real_type* dest,
                           index_type i,

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -30,7 +30,7 @@ namespace ReSolve { namespace vector {
       Vector(index_type n, index_type k);
       ~Vector();
 
-      int update(real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
+      int update(const real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
       int update(Vector* v, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
       real_type* getData(memory::MemorySpace memspace);
       real_type* getData(index_type i, memory::MemorySpace memspace); // get pointer to i-th vector in multivector
@@ -49,8 +49,8 @@ namespace ReSolve { namespace vector {
       int syncData(memory::MemorySpace memspaceOut); 
       int setCurrentSize(index_type new_n_current);
       real_type* getVectorData(index_type i, memory::MemorySpace memspace); // get ith vector data out of multivector   
-      int deepCopyVectorData(real_type* dest, index_type i, memory::MemorySpace memspace);  
-      int deepCopyVectorData(real_type* dest, memory::MemorySpace memspace);  //copy FULL multivector 
+      int copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspace);  
+      int copyDataTo(real_type* dest, memory::MemorySpace memspace);  //copy FULL multivector 
     
     private:
       index_type n_{0}; ///< size

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -30,8 +30,8 @@ namespace ReSolve { namespace vector {
       Vector(index_type n, index_type k);
       ~Vector();
 
-      int update(const real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
-      int update(Vector* v, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
+      int copyDataFrom(const real_type* data, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
+      int copyDataFrom(Vector* v, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
       real_type* getData(memory::MemorySpace memspace);
       real_type* getData(index_type i, memory::MemorySpace memspace); // get pointer to i-th vector in multivector
 

--- a/tests/functionality/testKLU.cpp
+++ b/tests/functionality/testKLU.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
   rhs1_file.close();
 
   // Convert first matrix to CSR format
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Solve the first system using KLU
@@ -95,8 +95,8 @@ int main(int argc, char *argv[])
   }
 
   vec_test->setData(x_data, ReSolve::memory::HOST);
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   // real_type normXmatrix1 = sqrt(vector_handler->dot(vec_test, vec_test, ReSolve::memory::HOST));
   matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
@@ -117,13 +117,13 @@ int main(int argc, char *argv[])
   real_type normDiffMatrix1 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::HOST));
  
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
   //evaluate the residual ON THE CPU using COMPUTED solution
  
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   // and solve it too
   status =  KLU->refactorize();
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
   status = KLU->solve(vec_rhs, vec_x);
   error_sum += status;
 
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   matrix_handler->setValuesChanged(true, ReSolve::memory::HOST);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
@@ -178,13 +178,13 @@ int main(int argc, char *argv[])
   //for testing only - control
   real_type normB2 = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::HOST));
   //compute x-x_true
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vector_handler->axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::HOST);
   //evaluate its norm
   real_type normDiffMatrix2 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::HOST));
  
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));

--- a/tests/functionality/testKLU_GLU.cpp
+++ b/tests/functionality/testKLU_GLU.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
   rhs1_file.close();
 
   // Convert first matrix to CSR format
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Solve the first system using KLU
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
   status = GLU->setup(A, L, U, P, Q); 
   error_sum += status;
   std::cout<<"GLU setup status: "<<status<<std::endl;      
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = GLU->solve(vec_rhs, vec_x);
   error_sum += status;
   std::cout<<"GLU solve status: "<<status<<std::endl;      
@@ -115,8 +115,8 @@ int main(int argc, char *argv[])
   }
 
   vec_test->setData(x_data, ReSolve::memory::HOST);
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
@@ -134,15 +134,15 @@ int main(int argc, char *argv[])
   real_type normDiffMatrix1 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
  
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
 
-  vec_x->update(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
+  vec_x->copyDataFrom(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   status = GLU->refactorize();
   error_sum += status;
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
   status = GLU->solve(vec_rhs, vec_x);
   error_sum += status;
 
-   vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
    matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
@@ -199,13 +199,13 @@ int main(int argc, char *argv[])
   //for testing only - control
   real_type normB2 = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
   //compute x-x_true
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler->axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   //evaluate its norm
   real_type normDiffMatrix2 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
  
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/functionality/testKLU_Rf.cpp
+++ b/tests/functionality/testKLU_Rf.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
   rhs1_file.close();
 
   // Convert first matrix to CSR format
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Solve the first system using KLU
@@ -102,8 +102,8 @@ int main(int argc, char *argv[])
   }
 
   vec_test->setData(x_data, ReSolve::memory::HOST);
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
@@ -121,13 +121,13 @@ int main(int argc, char *argv[])
   real_type normDiffMatrix1 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
  
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   status = Rf->refactorize();
   error_sum += status;
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
   status = Rf->solve(vec_rhs, vec_x);
   error_sum += status;
 
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
@@ -199,13 +199,13 @@ int main(int argc, char *argv[])
   //for testing only - control
   real_type normB2 = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
   //compute x-x_true
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler->axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   //evaluate its norm
   real_type normDiffMatrix2 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
  
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/functionality/testKLU_Rf_FGMRES.cpp
+++ b/tests/functionality/testKLU_Rf_FGMRES.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
   rhs1_file.close();
 
   // Convert first matrix to CSR format
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Solve the first system using KLU
@@ -123,8 +123,8 @@ int main(int argc, char *argv[])
   }
 
   vec_test->setData(x_data, ReSolve::memory::HOST);
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
   //evaluate the residual ||b-Ax||
@@ -144,13 +144,13 @@ int main(int argc, char *argv[])
   real_type normDiffMatrix1 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
@@ -213,13 +213,13 @@ int main(int argc, char *argv[])
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   Rf->setNumericalProperties(1e-14, 1e-1);
 
   status = Rf->refactorize();
   error_sum += status;
   
-  vec_x->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_x->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = Rf->solve(vec_x);
   error_sum += status;
   
@@ -227,11 +227,11 @@ int main(int argc, char *argv[])
   status = FGMRES->setupPreconditioner("LU", Rf);
   error_sum += status;
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = FGMRES->solve(vec_rhs, vec_x);
   error_sum += status;
 
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
   //evaluate final residual
@@ -244,13 +244,13 @@ int main(int argc, char *argv[])
   //for testing only - control
   real_type normB2 = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
   //compute x-x_true
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler->axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   //evaluate its norm
   real_type normDiffMatrix2 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/functionality/testKLU_RocSolver.cpp
+++ b/tests/functionality/testKLU_RocSolver.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
   rhs1_file.close();
 
   // Convert first matrix to CSR format
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Solve the first system using KLU
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
   if (L == nullptr) {printf("ERROR");}
   index_type* P = KLU->getPOrdering();
   index_type* Q = KLU->getQOrdering();
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vec_rhs->setDataUpdated(ReSolve::memory::DEVICE);
 
   status = Rf->setup(A, L, U, P, Q, vec_rhs); 
@@ -123,8 +123,8 @@ int main(int argc, char *argv[])
   }
 
   vec_test->setData(x_data, ReSolve::memory::HOST);
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // real_type normXmatrix1 = sqrt(vector_handler->dot(vec_test, vec_test, ReSolve::memory::DEVICE));
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -144,13 +144,13 @@ int main(int argc, char *argv[])
   real_type normDiffMatrix1 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
   //evaluate the residual ON THE CPU using COMPUTED solution
 
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // this hangs up
   status = Rf->refactorize();
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
   status = Rf->solve(vec_rhs, vec_x);
   error_sum += status;
 
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
@@ -208,13 +208,13 @@ int main(int argc, char *argv[])
   //for testing only - control
   real_type normB2 = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
   //compute x-x_true
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler->axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   //evaluate its norm
   real_type normDiffMatrix2 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/functionality/testKLU_RocSolver_FGMRES.cpp
+++ b/tests/functionality/testKLU_RocSolver_FGMRES.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
   rhs1_file.close();
 
   // Convert first matrix to CSR format
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Solve the first system using KLU
@@ -123,8 +123,8 @@ int main(int argc, char *argv[])
   }
 
   vec_test->setData(x_data, ReSolve::memory::HOST);
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
   //evaluate the residual ||b-Ax||
@@ -144,13 +144,13 @@ int main(int argc, char *argv[])
   real_type normDiffMatrix1 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
   index_type* P = KLU->getPOrdering();
   index_type* Q = KLU->getQOrdering();
   Rf->setSolveMode(1);
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   error_sum += Rf->setup(A, L, U, P, Q, vec_rhs); 
   FGMRES->setMaxit(200); 
   FGMRES->setRestart(100); 
@@ -206,12 +206,12 @@ int main(int argc, char *argv[])
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   status = Rf->refactorize();
   error_sum += status;
   
-  vec_x->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_x->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = Rf->solve(vec_x);
   error_sum += status;
   
@@ -219,11 +219,11 @@ int main(int argc, char *argv[])
   status = FGMRES->setupPreconditioner("LU", Rf);
   error_sum += status;
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = FGMRES->solve(vec_rhs, vec_x);
   error_sum += status;
 
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
   //evaluate final residual
@@ -236,13 +236,13 @@ int main(int argc, char *argv[])
   //for testing only - control
   real_type normB2 = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
   //compute x-x_true
-  vec_diff->update(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler->axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   //evaluate its norm
   real_type normDiffMatrix2 = sqrt(vector_handler->dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler->matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
   vector_type vec_x(A->getNumRows());
   vector_type vec_r(A->getNumRows());
 
-  vec_rhs.update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs.setDataUpdated(ReSolve::memory::HOST);
   vec_x.allocate(ReSolve::memory::HOST);
 
@@ -102,9 +102,9 @@ int main(int argc, char* argv[])
   real_type* x_data = new real_type[A->getNumRows()];
   std::fill_n(x_data, A->getNumRows(), 1.0);
 
-  vec_test.update(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_r.update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_diff.update(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_test.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_diff.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   // Matrix-vector product does not support COO format so we need to convert to CSR
   ReSolve::matrix::Csr A_csr(A->getNumRows(), A->getNumColumns(), A->getNnz(), A->symmetric(), A->expanded());
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
   real_type normDiffMatrix = sqrt(vector_handler.dot(&vec_diff, &vec_diff, ReSolve::memory::HOST));
 
   // Compute residual r := A*x - r using exact solution x
-  vec_r.update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   error_sum += matrix_handler.matvec(&A_csr,
                                      &vec_test,
                                      &vec_r,
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
 
   x = new real_type[A->getNumRows()];
 
-  vec_rhs.update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs.setDataUpdated(ReSolve::memory::HOST);
   vec_x.allocate(ReSolve::memory::HOST);
 
@@ -202,9 +202,9 @@ int main(int argc, char* argv[])
   x_data = new real_type[A->getNumRows()];
   std::fill_n(x_data, A->getNumRows(), 1.0);
 
-  vec_test.update(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_r.update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_diff.update(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_test.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_diff.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   // Matrix-vector product does not support COO format so we need to convert to CSR
   error_sum += coo2csr(A.get(), &A_csr, ReSolve::memory::HOST);
@@ -231,7 +231,7 @@ int main(int argc, char* argv[])
   normDiffMatrix = sqrt(vector_handler.dot(&vec_diff, &vec_diff, ReSolve::memory::HOST));
 
   // compute the residual using exact solution
-  vec_r.update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   // Compute residual r := A*x - r using exact solution x
   error_sum += matrix_handler.matvec(&A_csr,
                                      &vec_test,

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -312,7 +312,7 @@ int coo2csr(ReSolve::matrix::Coo* A_coo, ReSolve::matrix::Csr* A_csr, ReSolve::m
     }
   }
   row_csr[n] = nnz;
-  A_csr->copyData(row_csr, cols_coo, vals_coo, ReSolve::memory::HOST, memspace);
+  A_csr->copyDataFrom(row_csr, cols_coo, vals_coo, ReSolve::memory::HOST, memspace);
 
   delete [] row_csr;
   

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -312,7 +312,7 @@ int coo2csr(ReSolve::matrix::Coo* A_coo, ReSolve::matrix::Csr* A_csr, ReSolve::m
     }
   }
   row_csr[n] = nnz;
-  A_csr->updateData(row_csr, cols_coo, vals_coo, ReSolve::memory::HOST, memspace);
+  A_csr->copyData(row_csr, cols_coo, vals_coo, ReSolve::memory::HOST, memspace);
 
   delete [] row_csr;
   

--- a/tests/functionality/testSysGLU.cpp
+++ b/tests/functionality/testSysGLU.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
   vec_x->allocate(ReSolve::memory::DEVICE);
 
   // Set RHS vector on CPU
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Set system matrix
@@ -106,13 +106,13 @@ int main(int argc, char *argv[])
   std::cout << "GLU setup status: " << status << std::endl;      
 
   // Move rhs vector data to GPU
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = solver.solve(vec_rhs, vec_x);
   error_sum += status;
   std::cout << "GLU solve status: " << status << std::endl;      
 
   // Compute residual on device
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
@@ -155,23 +155,23 @@ int main(int argc, char *argv[])
   for (int i = 0; i < A->getNumRows(); ++i) {
     x_data_ref[i] = 1.0;
   }
-  vec_test->update(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_test->update(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_test->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_test->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   //compute ||x_diff|| = ||x - x_true|| norm
-  vec_diff->update(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix1 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
  
   // Compute residual norm ON THE GPU using REFERENCE solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   // Compute residual norm ON THE CPU using COMPUTED solution
-  vec_x->update(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_x->copyDataFrom(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
   real_type normRmatrix1CPU = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::HOST));
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
   rhs2_file.close();
 
   // Update system values
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // Refactorize and solve
   status = solver.refactorize();
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
   error_sum += status;
 
   // Compute residual norm for the second system
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
@@ -257,12 +257,12 @@ int main(int argc, char *argv[])
   }
 
   //compute ||x_diff|| = ||x - x_true|| norm
-  vec_diff->update(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix2 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
  
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -113,8 +113,8 @@ int main(int argc, char *argv[])
   vec_x->allocate(ReSolve::memory::HOST);  //for KLU
   vec_x->allocate(ReSolve::memory::DEVICE);
 
-  // Set RHS vector on CPU (update function allocates)
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  // Set RHS vector on CPU (copyDataFrom function allocates)
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Add system matrix to the solver
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
   error_sum += status;
 
   // Evaluate the residual norm ||b-Ax|| on the device
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
@@ -174,21 +174,21 @@ int main(int argc, char *argv[])
   for (int i=0; i<A->getNumRows(); ++i){
     x_data_ref[i] = 1.0;
   }
-  vec_test->update(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vec_diff->update(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_test->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // compute ||x-x_true|| norm
   vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix1 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   //evaluate the residual ON THE CPU using COMPUTED solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
   error_sum += status;
   real_type normRmatrix1CPU = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::HOST));
@@ -237,17 +237,17 @@ int main(int argc, char *argv[])
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   status = solver.refactorize();
   error_sum += status;
   
-  vec_x->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_x->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = solver.solve(vec_rhs, vec_x);
   error_sum += status;
   
   // Compute residual norm for the second system
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
@@ -277,12 +277,12 @@ int main(int argc, char *argv[])
   }
 
   //compute ||x_diff|| = ||x - x_true|| norm
-  vec_diff->update(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix2 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   //compute the residual using exact solution
-  vec_r->update(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -155,11 +155,11 @@ namespace ReSolve
           // NOTE: these are hardcoded for now
           index_type size = static_cast<index_type>(valsA_.size());
           matrix::Coo* A = new matrix::Coo(9, 9, size, true, true);
-          A->updateData(rowsA_.data(),
-                        colsA_.data(),
-                        valsA_.data(),
-                        memory::HOST,
-                        memory::HOST);
+          A->copyData(rowsA_.data(),
+                      colsA_.data(),
+                      valsA_.data(),
+                      memory::HOST,
+                      memory::HOST);
 
           return A;
         }

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -155,11 +155,11 @@ namespace ReSolve
           // NOTE: these are hardcoded for now
           index_type size = static_cast<index_type>(valsA_.size());
           matrix::Coo* A = new matrix::Coo(9, 9, size, true, true);
-          A->copyData(rowsA_.data(),
-                      colsA_.data(),
-                      valsA_.data(),
-                      memory::HOST,
-                      memory::HOST);
+          A->copyDataFrom(rowsA_.data(),
+                          colsA_.data(),
+                          valsA_.data(),
+                          memory::HOST,
+                          memory::HOST);
 
           return A;
         }

--- a/tests/unit/matrix/MatrixFactorizationTests.hpp
+++ b/tests/unit/matrix/MatrixFactorizationTests.hpp
@@ -162,7 +162,7 @@ private:
     // Allocate NxN CSR matrix with NNZ nonzeros
     matrix::Csr* A = new matrix::Csr(N, N, NNZ);
     A->allocateMatrixData(memory::HOST);
-    A->copyData(&rowsA_[0], &colsA_[0], &valsA_[0], memory::HOST, memory::HOST);
+    A->copyDataFrom(&rowsA_[0], &colsA_[0], &valsA_[0], memory::HOST, memory::HOST);
 
     // A->print();
 

--- a/tests/unit/matrix/MatrixFactorizationTests.hpp
+++ b/tests/unit/matrix/MatrixFactorizationTests.hpp
@@ -162,7 +162,7 @@ private:
     // Allocate NxN CSR matrix with NNZ nonzeros
     matrix::Csr* A = new matrix::Csr(N, N, NNZ);
     A->allocateMatrixData(memory::HOST);
-    A->updateData(&rowsA_[0], &colsA_[0], &valsA_[0], memory::HOST, memory::HOST);
+    A->copyData(&rowsA_[0], &colsA_[0], &valsA_[0], memory::HOST, memory::HOST);
 
     // A->print();
 

--- a/tests/unit/matrix/MatrixIoTests.hpp
+++ b/tests/unit/matrix/MatrixIoTests.hpp
@@ -161,10 +161,10 @@ public:
 
     // Create the test COO matrix
     ReSolve::matrix::Coo A(N, M, NNZ, false, false);
-    A.setMatrixData(&rows[0],
-                    &cols[0],
-                    &vals[0],
-                    memory::HOST);
+    A.setDataPointers(&rows[0],
+                      &cols[0],
+                      &vals[0],
+                      memory::HOST);
 
     // Write the matrix to an ostream
     ReSolve::io::writeMatrixToFile(&A, buffer);
@@ -197,7 +197,7 @@ public:
 
     // Create the test CSR matrix
     ReSolve::matrix::Csr A(N, M, NNZ, false, false);
-    A.setMatrixData(&rows[0],
+    A.setDataPointers(&rows[0],
                     &cols[0],
                     &vals[0],
                     memory::HOST);

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -129,8 +129,8 @@ namespace ReSolve
 
           for (index_type i = 0; i < K; ++i) {
             for (index_type j = 0; j < K; ++j) {
-              a.update(x.getVectorData(i, memspace_), memspace_, memory::HOST);
-              b.update(x.getVectorData(j, memspace_), memspace_, memory::HOST);
+              a.copyDataFrom(x.getVectorData(i, memspace_), memspace_, memory::HOST);
+              b.copyDataFrom(x.getVectorData(j, memspace_), memspace_, memory::HOST);
               ip = handler_.dot(&a, &b, memory::HOST);
               if ( (i != j) && !isEqual(ip, 0.0)) {
                 status = false;

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -51,7 +51,7 @@ namespace ReSolve {
           for (int i = 0; i < N; ++i) {
             data[i] = 0.1 * (real_type) i;
           }
-          x.update(data, memory::HOST, memspace_);
+          x.copyDataFrom(data, memory::HOST, memspace_);
 
           real_type result = handler_.infNorm(&x, memspace_);
           real_type answer = static_cast<real_type>(N - 1) * 0.1;


### PR DESCRIPTION
Change names of methods and data members in vector and matrix classes to be more consistent and accurate. Specific changes include:
- Matrix classes (`Sparse`, `Csr`, `Csc`, `Coo`)
    - Rename `setMatrixData` to `setDataPointers`
    - Rename `setNewValues` to `setValuesPointers`
    - Rename `updateData` to `copyData`
    - Change input data arrays in `copyData` to `const` arrays.
    - Rename `owns_*_data_` to `owns_*_sparsity_pattern_`
- Vector class
    - Rename `deepCopyVectorData` to `copyDataTo`
    - Rename `update` to `copyDataFrom`.


Fixes #167 