### PR TITLE
Fix issue with linking workspace to HyKKT.

### DIFF
--- a/resolve/hykkt/CMakeLists.txt
+++ b/resolve/hykkt/CMakeLists.txt
@@ -33,19 +33,21 @@ target_include_directories(resolve_hykkt PUBLIC ${SUITESPARSE_INCLUDE_DIR})
 
 # Link to CUDA ReSolve backend if CUDA is support enabled
 if (RESOLVE_USE_CUDA)
-#   target_sources(resolve_hykkt PRIVATE ${HyKKT_CUDASDK_SRC})
-#   target_link_libraries(resolve_hykkt PUBLIC resolve_backend_cuda)
+  target_sources(resolve_hykkt PRIVATE ${HyKKT_CUDASDK_SRC})
+  target_link_libraries(resolve_hykkt PUBLIC resolve_backend_cuda)
 endif()
 
 if (RESOLVE_USE_HIP)
-#   target_sources(resolve_hykkt PRIVATE ${HyKKT_ROCM_SRC})
-#   target_link_libraries(resolve_hykkt PUBLIC resolve_backend_hip)
+  target_sources(resolve_hykkt PRIVATE ${HyKKT_ROCM_SRC})
+  target_link_libraries(resolve_hykkt PUBLIC resolve_backend_hip)
 endif()
 
 # Link to dummy device backend if GPU support is not enabled
 if (NOT RESOLVE_USE_GPU)
   target_link_libraries(resolve_hykkt PUBLIC resolve_backend_cpu)
 endif()
+
+target_link_libraries(resolve_hykkt PUBLIC resolve_workspace)
 
 target_include_directories(resolve_hykkt INTERFACE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>


### PR DESCRIPTION
Make sure a workspace library is linked to HyKKT module in Re::Solve.

Also, if CUDA or HIP are enabled, they can be linked with HyKKT module. The module may not use any of those backends, but it can be linked to them.