### PR TITLE
address issue #183

### DIFF
--- a/resolve/LinSolverDirectLUSOL.cpp
+++ b/resolve/LinSolverDirectLUSOL.cpp
@@ -192,8 +192,23 @@ namespace ReSolve
 
   int LinSolverDirectLUSOL::solve(vector_type* rhs, vector_type* x)
   {
-    if (rhs->getSize() != m_ || x->getSize() != n_ || !is_factorized_) {
+    if (rhs->getSize() != m_ || x->getSize() != n_) {
       return -1;
+    }
+
+    if (!is_factorized_) {
+      out::warning() << "LinSolverDirect::solve(vector_type*, vector_type*) "
+                     << "called on LinSolverDirectLUSOL without factorizing "
+                     << "first!\n";
+
+      if (m_ == 0) {
+        return -1;
+      }
+
+      index_type inform = factorize();
+      if (inform < 0) {
+        return inform;
+      }
     }
 
     index_type mode = 5;
@@ -480,7 +495,7 @@ namespace ReSolve
   int LinSolverDirectLUSOL::allocateSolverData()
   {
     // LUSOL does not do symbolic analysis to determine workspace size to store
-    // L and U factors, so we have to guess something. See documentation for 
+    // L and U factors, so we have to guess something. See documentation for
     // lena_ in resolve/lusol/lusol.f90 file.
     lena_ = std::max({20 * nelem_, 10 * m_, 10 * n_, 10000});
 

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -43,6 +43,33 @@ namespace ReSolve
           return status.report(__func__);
         }
 
+        TestOutcome automaticAllocationSolve()
+        {
+          TestStatus status;
+
+          LinSolverDirectLUSOL solver;
+          matrix::Coo* A = createMatrix();
+
+          vector::Vector rhs(A->getNumRows());
+          rhs.setToConst(constants::ONE, memory::HOST);
+
+          vector::Vector x(A->getNumColumns());
+          x.allocate(memory::HOST);
+
+          if (solver.setup(A) < 0) {
+            status *= false;
+          }
+          if (solver.solve(&rhs, &x) < 0) {
+            status *= false;
+          }
+
+          status *= verifyAnswer(x, solX_);
+
+          delete A;
+
+          return status.report(__func__);
+        }
+
         TestOutcome automaticFactorizationSolve()
         {
           TestStatus status;

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -43,6 +43,36 @@ namespace ReSolve
           return status.report(__func__);
         }
 
+        TestOutcome automaticFactorization()
+        {
+          TestStatus status;
+
+          LinSolverDirectLUSOL solver;
+          matrix::Coo* A = createMatrix();
+
+          vector::Vector rhs(A->getNumRows());
+          rhs.setToConst(constants::ONE, memory::HOST);
+
+          vector::Vector x(A->getNumColumns());
+          x.allocate(memory::HOST);
+
+          if (solver.setup(A) < 0) {
+            status *= false;
+          }
+          if (solver.analyze() < 0) {
+            status *= false;
+          }
+          if (solver.solve(&rhs, &x) < 0) {
+            status *= false;
+          }
+
+          status *= verifyAnswer(x, solX_);
+
+          delete A;
+
+          return status.report(__func__);
+        }
+
         TestOutcome simpleSolve()
         {
           TestStatus status;

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -43,7 +43,7 @@ namespace ReSolve
           return status.report(__func__);
         }
 
-        TestOutcome automaticFactorization()
+        TestOutcome automaticFactorizationSolve()
         {
           TestStatus status;
 

--- a/tests/unit/matrix/runLUSOLTests.cpp
+++ b/tests/unit/matrix/runLUSOLTests.cpp
@@ -11,6 +11,7 @@ int main(int, char**)
     ReSolve::tests::LUSOLTests test;
 
     result += test.lusolConstructor();
+    result += test.automaticFactorization();
     result += test.simpleSolve();
 
     std::cout << "\n";

--- a/tests/unit/matrix/runLUSOLTests.cpp
+++ b/tests/unit/matrix/runLUSOLTests.cpp
@@ -11,7 +11,7 @@ int main(int, char**)
     ReSolve::tests::LUSOLTests test;
 
     result += test.lusolConstructor();
-    result += test.automaticFactorization();
+    result += test.automaticFactorizationSolve();
     result += test.simpleSolve();
 
     std::cout << "\n";

--- a/tests/unit/matrix/runLUSOLTests.cpp
+++ b/tests/unit/matrix/runLUSOLTests.cpp
@@ -11,6 +11,7 @@ int main(int, char**)
     ReSolve::tests::LUSOLTests test;
 
     result += test.lusolConstructor();
+    result += test.automaticAllocationSolve();
     result += test.automaticFactorizationSolve();
     result += test.simpleSolve();
 


### PR DESCRIPTION
this probably addresses all of issue #183.

some additional considerations:

- do we also call the workspace allocation method too (`LinSolverDirectLUSOL::analyze()`)
- are there any other invariants we should check for before automatically factorizing?