### PR TITLE
Parameter setting for direct solvers

### DIFF
--- a/examples/r_KLU_GLU.cpp
+++ b/examples/r_KLU_GLU.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA;
   workspace_CUDA->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_CUDA);
@@ -43,9 +43,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
   real_type norm_A, norm_x, norm_r;//used for INF norm
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;

--- a/examples/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/r_KLU_GLU_matrix_values_update.cpp
@@ -37,8 +37,8 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
-  ReSolve::matrix::Csr* A_exp;
+  ReSolve::matrix::Csr* A = nullptr;
+  ReSolve::matrix::Csr* A_exp = nullptr;
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA;
   workspace_CUDA->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_CUDA);
@@ -46,9 +46,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x = nullptr;
+  vector_type* vec_r = nullptr;
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
   ReSolve::LinSolverDirectCuSolverGLU* GLU = new ReSolve::LinSolverDirectCuSolverGLU(workspace_CUDA);

--- a/examples/r_KLU_KLU.cpp
+++ b/examples/r_KLU_KLU.cpp
@@ -35,16 +35,16 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCpu* workspace = new ReSolve::LinAlgWorkspaceCpu();
   ReSolve::MatrixHandler* matrix_handler = new ReSolve::MatrixHandler(workspace);
   ReSolve::VectorHandler* vector_handler = new ReSolve::VectorHandler(workspace);
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
   real_type norm_A, norm_x, norm_r;//used for INF norm
   
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;

--- a/examples/r_KLU_KLU_standalone.cpp
+++ b/examples/r_KLU_KLU_standalone.cpp
@@ -31,16 +31,16 @@ int main(int argc, char *argv[])
   std::string fileId;
   std::string rhsId;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCpu* workspace = new ReSolve::LinAlgWorkspaceCpu();
   ReSolve::MatrixHandler* matrix_handler = new ReSolve::MatrixHandler(workspace);
   ReSolve::VectorHandler* vector_handler = new ReSolve::VectorHandler(workspace);
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
 

--- a/examples/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_cusolverrf_redo_factorization.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[] )
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
 
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA;
   workspace_CUDA->initializeHandles();
@@ -44,15 +44,15 @@ int main(int argc, char *argv[] )
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
   ReSolve::LinSolverDirectCuSolverRf* Rf = new ReSolve::LinSolverDirectCuSolverRf();
 
-  real_type res_nrm;
-  real_type b_nrm;
+  real_type res_nrm = 0.0;
+  real_type b_nrm = 0.0;
 
   // We need them. They hold a POINTER. Don't delete them here. KLU deletes them.
   ReSolve::matrix::Csc* L_csc;
@@ -60,7 +60,7 @@ int main(int argc, char *argv[] )
   index_type* P;
   index_type* Q;
 
-  int status;
+  int status = 0;
   int status_refactor = 0;
   for (int i = 0; i < numSystems; ++i)
   {

--- a/examples/r_KLU_rf.cpp
+++ b/examples/r_KLU_rf.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[] )
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
 
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA;
   workspace_CUDA->initializeHandles();
@@ -44,9 +44,9 @@ int main(int argc, char *argv[] )
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
   ReSolve::LinSolverDirectCuSolverRf* Rf = new ReSolve::LinSolverDirectCuSolverRf;

--- a/examples/r_KLU_rf_FGMRES.cpp
+++ b/examples/r_KLU_rf_FGMRES.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA;
   workspace_CUDA->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_CUDA);
@@ -44,9 +44,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
   real_type norm_A, norm_x, norm_r;//used for INF norm
   
   ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(vector_handler, ReSolve::GramSchmidt::CGS2);

--- a/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
 
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA;
   workspace_CUDA->initializeHandles();
@@ -46,9 +46,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(vector_handler, ReSolve::GramSchmidt::CGS2);
   
@@ -121,8 +121,8 @@ int main(int argc, char *argv[])
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
-    //Now call direct solver
-    int status;
+    // Now call direct solver
+    int status = 0;
     real_type norm_b;
     if (i < 2){
       KLU->setup(A);

--- a/examples/r_KLU_rocSolverRf_FGMRES.cpp
+++ b/examples/r_KLU_rocSolverRf_FGMRES.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceHIP* workspace_HIP = new ReSolve::LinAlgWorkspaceHIP();
   workspace_HIP->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_HIP);
@@ -45,9 +45,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
   real_type norm_A;
   real_type norm_x;
   real_type norm_r;

--- a/examples/r_KLU_rocsolverrf.cpp
+++ b/examples/r_KLU_rocsolverrf.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
 
   ReSolve::LinAlgWorkspaceHIP* workspace_HIP = new ReSolve::LinAlgWorkspaceHIP;
   workspace_HIP->initializeHandles();
@@ -44,9 +44,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   real_type norm_A, norm_x, norm_r; //used for INF norm
   

--- a/examples/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[] )
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
 
   ReSolve::LinAlgWorkspaceHIP* workspace_HIP = new ReSolve::LinAlgWorkspaceHIP;
   workspace_HIP->initializeHandles();
@@ -44,9 +44,9 @@ int main(int argc, char *argv[] )
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
   ReSolve::LinSolverDirectRocSolverRf* Rf = new ReSolve::LinSolverDirectRocSolverRf(workspace_HIP);
@@ -116,7 +116,7 @@ int main(int argc, char *argv[] )
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
     //Now call direct solver
-    int status;
+    int status = 0;
     if (i < 2){
       KLU->setup(A);
       status = KLU->analyze();

--- a/examples/r_SysSolver.cpp
+++ b/examples/r_SysSolver.cpp
@@ -36,16 +36,16 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCpu* workspace = new ReSolve::LinAlgWorkspaceCpu();
   ReSolve::MatrixHandler* matrix_handler = new ReSolve::MatrixHandler(workspace);
   ReSolve::VectorHandler* vector_handler = new ReSolve::VectorHandler(workspace);
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::SystemSolver* solver = new ReSolve::SystemSolver(workspace);
 

--- a/examples/r_SysSolverCuda.cpp
+++ b/examples/r_SysSolverCuda.cpp
@@ -35,15 +35,15 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA;
   workspace_CUDA->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_CUDA);
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
 
   ReSolve::SystemSolver* solver = new ReSolve::SystemSolver(workspace_CUDA);
 

--- a/examples/r_SysSolverHip.cpp
+++ b/examples/r_SysSolverHip.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[] )
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
 
   ReSolve::LinAlgWorkspaceHIP* workspace_HIP = new ReSolve::LinAlgWorkspaceHIP();
   workspace_HIP->initializeHandles();

--- a/examples/r_SysSolverHipRefine.cpp
+++ b/examples/r_SysSolverHipRefine.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
   std::string matrixFileNameFull;
   std::string rhsFileNameFull;
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceHIP* workspace_HIP = new ReSolve::LinAlgWorkspaceHIP();
   workspace_HIP->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_HIP);

--- a/examples/r_randGMRES.cpp
+++ b/examples/r_randGMRES.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
   std::string  rhsFileName = argv[2];
 
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceHIP* workspace_HIP = new ReSolve::LinAlgWorkspaceHIP();
   workspace_HIP->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_HIP);
@@ -34,9 +34,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(vector_handler, ReSolve::GramSchmidt::CGS2);
 

--- a/examples/r_randGMRES_CUDA.cpp
+++ b/examples/r_randGMRES_CUDA.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
   std::string  matrixFileName = argv[1];
   std::string  rhsFileName = argv[2];
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCUDA* workspace_CUDA = new ReSolve::LinAlgWorkspaceCUDA();
   workspace_CUDA->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_CUDA);
@@ -33,9 +33,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(vector_handler, ReSolve::GramSchmidt::CGS2);
 

--- a/examples/r_randGMRES_cpu.cpp
+++ b/examples/r_randGMRES_cpu.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
   std::string  matrixFileName = argv[1];
   std::string  rhsFileName = argv[2];
 
-  ReSolve::matrix::Csr* A;
+  ReSolve::matrix::Csr* A = nullptr;
   ReSolve::LinAlgWorkspaceCpu* workspace_Cpu = new ReSolve::LinAlgWorkspaceCpu();
   workspace_Cpu->initializeHandles();
   ReSolve::MatrixHandler* matrix_handler =  new ReSolve::MatrixHandler(workspace_Cpu);
@@ -33,9 +33,9 @@ int main(int argc, char *argv[])
   real_type* rhs = nullptr;
   real_type* x   = nullptr;
 
-  vector_type* vec_rhs;
-  vector_type* vec_x;
-  vector_type* vec_r;
+  vector_type* vec_rhs = nullptr;
+  vector_type* vec_x   = nullptr;
+  vector_type* vec_r   = nullptr;
 
   ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(vector_handler, ReSolve::GramSchmidt::MGS);
 

--- a/resolve/LinSolver.hpp
+++ b/resolve/LinSolver.hpp
@@ -48,35 +48,12 @@ namespace ReSolve
 
       real_type evaluateResidual();
 
-      virtual int setCliParam(const std::string /* id */, const std::string /* value */)
-      {
-        return 1;
-      }
-        
-      virtual std::string getCliParamString(const std::string /* id */) const
-      {
-        return "";
-      }
-        
-      virtual index_type getCliParamInt(const std::string /* id */) const
-      {
-        return -1;
-      }
-        
-      virtual real_type getCliParamReal(const std::string /* id */) const
-      {
-        return 1.0;
-      }
-        
-      virtual bool getCliParamBool(const std::string /* id */) const
-      {
-        return false;
-      }
-        
-      virtual int printCliParam(const std::string /* id */) const
-      {
-        return 1;
-      }
+      virtual int setCliParam(const std::string /* id */, const std::string /* value */) = 0;        
+      virtual std::string getCliParamString(const std::string /* id */) const = 0;        
+      virtual index_type getCliParamInt(const std::string /* id */) const = 0;
+      virtual real_type getCliParamReal(const std::string /* id */) const = 0;
+      virtual bool getCliParamBool(const std::string /* id */) const = 0;
+      virtual int printCliParam(const std::string /* id */) const = 0;
         
     protected:
       int getParamId(std::string id) const;

--- a/resolve/LinSolverDirect.cpp
+++ b/resolve/LinSolverDirect.cpp
@@ -76,25 +76,4 @@ namespace ReSolve
     return nullptr;
   }
 
-  void LinSolverDirect::setPivotThreshold(real_type tol)
-  {
-    pivot_threshold_tol_ = tol;
-  }
-
-  void LinSolverDirect::setOrdering(int ordering)
-  {
-    ordering_ = ordering;
-  }
-
-  void LinSolverDirect::setHaltIfSingular(bool is_halt)
-  {
-    halt_if_singular_ = is_halt;
-  }
-
-  real_type LinSolverDirect::getMatrixConditionNumber()
-  {
-    out::error() << "Solver does not implement returning system matrix condition number.\n";
-    return -1.0;
-  }
-
 } // namespace ReSolve

--- a/resolve/LinSolverDirect.hpp
+++ b/resolve/LinSolverDirect.hpp
@@ -35,21 +35,12 @@ namespace ReSolve
       virtual index_type*  getPOrdering();
       virtual index_type*  getQOrdering();
 
-      virtual void setPivotThreshold(real_type tol);
-      virtual void setOrdering(int ordering);
-      virtual void setHaltIfSingular(bool is_halt);
-
-      virtual real_type getMatrixConditionNumber();
-    
     protected:
       matrix::Sparse* L_{nullptr};
       matrix::Sparse* U_{nullptr};
       index_type* P_{nullptr};
       index_type* Q_{nullptr};
 
-      int ordering_{1}; // 0 = AMD, 1 = COLAMD, 2 = user provided P, Q
-      real_type pivot_threshold_tol_{0.1};
-      bool halt_if_singular_{false};
   };
 
 }

--- a/resolve/LinSolverDirectCpuILU0.cpp
+++ b/resolve/LinSolverDirectCpuILU0.cpp
@@ -347,7 +347,7 @@ namespace ReSolve
     return 0;
   }
 
-  int LinSolverDirectCpuILU0::setCliParam(const std::string id, const std::string value)
+  int LinSolverDirectCpuILU0::setCliParam(const std::string id, const std::string /* value */)
   {
     switch (getParamId(id))
     {

--- a/resolve/LinSolverDirectCpuILU0.cpp
+++ b/resolve/LinSolverDirectCpuILU0.cpp
@@ -16,6 +16,8 @@
 
 namespace ReSolve 
 {
+  using out = io::Logger;
+
   LinSolverDirectCpuILU0::LinSolverDirectCpuILU0(LinAlgWorkspaceCpu* /* workspace */)
     // : workspace_(workspace)
   {
@@ -342,6 +344,67 @@ namespace ReSolve
   int LinSolverDirectCpuILU0::setZeroDiagonal(real_type z)
   {
     zero_diagonal_ = z;
+    return 0;
+  }
+
+  int LinSolverDirectCpuILU0::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectCpuILU0::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectCpuILU0::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectCpuILU0::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectCpuILU0::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectCpuILU0::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
     return 0;
   }
 

--- a/resolve/LinSolverDirectCpuILU0.hpp
+++ b/resolve/LinSolverDirectCpuILU0.hpp
@@ -67,6 +67,13 @@ namespace ReSolve
 
       int setZeroDiagonal(real_type z);
 
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
+
     private:
       // MemoryHandler mem_; ///< Device memory manager object
       // LinAlgWorkspaceCpu* workspace_{nullptr};

--- a/resolve/LinSolverDirectCuSolverGLU.cpp
+++ b/resolve/LinSolverDirectCuSolverGLU.cpp
@@ -200,7 +200,7 @@ namespace ReSolve
     return 1;
   }
 
-  int LinSolverDirectCuSolverGLU::setCliParam(const std::string id, const std::string value)
+  int LinSolverDirectCuSolverGLU::setCliParam(const std::string id, const std::string /* value */)
   {
     switch (getParamId(id))
     {

--- a/resolve/LinSolverDirectCuSolverGLU.cpp
+++ b/resolve/LinSolverDirectCuSolverGLU.cpp
@@ -199,4 +199,66 @@ namespace ReSolve
                  << "Consider using solve(Vector* rhs, Vector* x) instead.\n";
     return 1;
   }
+
+  int LinSolverDirectCuSolverGLU::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectCuSolverGLU::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectCuSolverGLU::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectCuSolverGLU::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectCuSolverGLU::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectCuSolverGLU::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
 }

--- a/resolve/LinSolverDirectCuSolverGLU.hpp
+++ b/resolve/LinSolverDirectCuSolverGLU.hpp
@@ -42,6 +42,13 @@ namespace ReSolve
                 index_type*     Q,
                 vector_type* rhs = nullptr) override;
     
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
+
     private:
       void addFactors(matrix::Sparse* L, matrix::Sparse* U);  ///< creates L+U from sepeate L, U factors
       matrix::Sparse* M_; ///< the matrix that contains added factors
@@ -54,8 +61,8 @@ namespace ReSolve
       cusparseStatus_t status_cusparse_;
       csrgluInfo_t info_M_;
       void* glu_buffer_;
-      double r_nrminf_;
-      int ite_refine_succ_; 
+      double r_nrminf_; ///< Error norm of the solution
+      int ite_refine_succ_; ///< Stores return value of cusolverSpDgluSolve
 
       MemoryHandler mem_; ///< Device memory manager object
   };

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -10,6 +10,7 @@ namespace ReSolve
   {
     cusolverRfCreate(&handle_cusolverrf_);
     setup_completed_ = false;
+    initParamList();
   }
 
   LinSolverDirectCuSolverRf::~LinSolverDirectCuSolverRf()
@@ -161,10 +162,18 @@ namespace ReSolve
     return status_cusolverrf_;
   }
 
-  int LinSolverDirectCuSolverRf::setCliParam(const std::string id, const std::string /* value */)
+  int LinSolverDirectCuSolverRf::setCliParam(const std::string id, const std::string value)
   {
     switch (getParamId(id))
     {
+      case ZERO_PIVOT:
+        zero_pivot_ = atof(value.c_str());
+        setNumericalProperties(zero_pivot_, pivot_boost_);
+        break;
+      case PIVOT_BOOST:
+        pivot_boost_ = atof(value.c_str());
+        setNumericalProperties(zero_pivot_, pivot_boost_);
+        break;
       default:
         std::cout << "Setting parameter failed!\n";
     }
@@ -195,6 +204,10 @@ namespace ReSolve
   {
     switch (getParamId(id))
     {
+      case ZERO_PIVOT:
+        return zero_pivot_;
+      case PIVOT_BOOST:
+        return pivot_boost_;
       default:
         out::error() << "Trying to get unknown real parameter " << id << "\n";
     }
@@ -215,11 +228,27 @@ namespace ReSolve
   {
     switch (getParamId(id))
     {
-    default:
-      out::error() << "Trying to print unknown parameter " << id << "\n";
-      return 1;
+      case ZERO_PIVOT:
+        std::cout << zero_pivot_ << "\n";
+        break;
+      case PIVOT_BOOST:
+        std::cout << pivot_boost_ << "\n";
+        break;
+      default:
+        out::error() << "Trying to print unknown parameter " << id << "\n";
+        return 1;
     }
     return 0;
   }
 
-}// namespace resolve
+  //
+  // Private methods
+  //
+
+  void LinSolverDirectCuSolverRf::initParamList()
+  {
+    params_list_["zero_pivot"]  = ZERO_PIVOT;
+    params_list_["pivot_boost"] = PIVOT_BOOST;
+  }
+
+} // namespace resolve

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -4,6 +4,8 @@
 
 namespace ReSolve 
 {
+  using out = io::Logger;
+
   LinSolverDirectCuSolverRf::LinSolverDirectCuSolverRf(LinAlgWorkspaceCUDA* /* workspace */)
   {
     cusolverRfCreate(&handle_cusolverrf_);
@@ -92,7 +94,8 @@ namespace ReSolve
     return error_sum;
   }
 
-  void LinSolverDirectCuSolverRf::setAlgorithms(cusolverRfFactorization_t fact_alg,  cusolverRfTriangularSolve_t solve_alg)
+  void LinSolverDirectCuSolverRf::setAlgorithms(cusolverRfFactorization_t fact_alg,
+                                                cusolverRfTriangularSolve_t solve_alg)
   {
     cusolverRfSetAlgs(handle_cusolverrf_, fact_alg, solve_alg);
   }
@@ -146,9 +149,77 @@ namespace ReSolve
     return status_cusolverrf_;
   }
 
-  int LinSolverDirectCuSolverRf::setNumericalProperties(double nzero, double nboost)
+  int LinSolverDirectCuSolverRf::setNumericalProperties(real_type nzero,
+                                                        real_type nboost)
   {
-    status_cusolverrf_ = cusolverRfSetNumericProperties(handle_cusolverrf_, nzero, nboost);
+    // Zero flagging threshold and boost NEED TO BE DOUBLE!
+    double zero = static_cast<double>(nzero);
+    double boost = static_cast<double>(nboost);
+    status_cusolverrf_ = cusolverRfSetNumericProperties(handle_cusolverrf_,
+                                                        nzero,
+                                                        nboost);
     return status_cusolverrf_;
   }
+
+  int LinSolverDirectCuSolverRf::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectCuSolverRf::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectCuSolverRf::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectCuSolverRf::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectCuSolverRf::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectCuSolverRf::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
 }// namespace resolve

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -156,12 +156,12 @@ namespace ReSolve
     double zero = static_cast<double>(nzero);
     double boost = static_cast<double>(nboost);
     status_cusolverrf_ = cusolverRfSetNumericProperties(handle_cusolverrf_,
-                                                        nzero,
-                                                        nboost);
+                                                        zero,
+                                                        boost);
     return status_cusolverrf_;
   }
 
-  int LinSolverDirectCuSolverRf::setCliParam(const std::string id, const std::string value)
+  int LinSolverDirectCuSolverRf::setCliParam(const std::string id, const std::string /* value */)
   {
     switch (getParamId(id))
     {

--- a/resolve/LinSolverDirectCuSolverRf.hpp
+++ b/resolve/LinSolverDirectCuSolverRf.hpp
@@ -54,6 +54,13 @@ namespace ReSolve
       int printCliParam(const std::string id) const override;
 
     private:
+      enum ParamaterIDs {ZERO_PIVOT=0, PIVOT_BOOST};
+      real_type zero_pivot_{0.0};  ///< The value below which zero pivot is flagged. 
+      real_type pivot_boost_{0.0}; ///< The value which is substituted for zero pivot.
+      
+    private:
+      void initParamList();
+
       cusolverRfHandle_t handle_cusolverrf_;
       cusolverStatus_t status_cusolverrf_;
       
@@ -62,9 +69,6 @@ namespace ReSolve
       real_type* d_T_{nullptr};
       bool setup_completed_{false};
 
-      real_type zero_pivot_{0.0}; ///< The value below which zero pivot is flagged. 
-      real_type pivot_boost_{0.0}; ///< The value which is substituted for zero pivot.
-      
       MemoryHandler mem_; ///< Device memory manager object
   };
 }

--- a/resolve/LinSolverDirectCuSolverRf.hpp
+++ b/resolve/LinSolverDirectCuSolverRf.hpp
@@ -42,8 +42,17 @@ namespace ReSolve
       int solve(vector_type* rhs, vector_type* x) override;
       int solve(vector_type* rhs) override; // rhs overwritten by solution
 
-      void setAlgorithms(cusolverRfFactorization_t fact_alg,  cusolverRfTriangularSolve_t solve_alg);
-      int setNumericalProperties(double nzero, double nboost);//these two NEED TO BE DOUBLE
+      void setAlgorithms(cusolverRfFactorization_t fact_alg,
+                        cusolverRfTriangularSolve_t solve_alg);
+      int setNumericalProperties(real_type nzero, real_type nboost);
+
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
+
     private:
       cusolverRfHandle_t handle_cusolverrf_;
       cusolverStatus_t status_cusolverrf_;
@@ -52,6 +61,9 @@ namespace ReSolve
       index_type* d_Q_{nullptr};
       real_type* d_T_{nullptr};
       bool setup_completed_{false};
+
+      real_type zero_pivot_{0.0}; ///< The value below which zero pivot is flagged. 
+      real_type pivot_boost_{0.0}; ///< The value which is substituted for zero pivot.
       
       MemoryHandler mem_; ///< Device memory manager object
   };

--- a/resolve/LinSolverDirectCuSparseILU0.cpp
+++ b/resolve/LinSolverDirectCuSparseILU0.cpp
@@ -313,7 +313,7 @@ namespace ReSolve
     return error_sum;
   }
 
-  int LinSolverDirectCuSparseILU0::setCliParam(const std::string id, const std::string value)
+  int LinSolverDirectCuSparseILU0::setCliParam(const std::string id, const std::string /* value */)
   {
     switch (getParamId(id))
     {

--- a/resolve/LinSolverDirectCuSparseILU0.cpp
+++ b/resolve/LinSolverDirectCuSparseILU0.cpp
@@ -5,6 +5,8 @@
 
 namespace ReSolve 
 {
+  using out = io::Logger;
+
   LinSolverDirectCuSparseILU0::LinSolverDirectCuSparseILU0(LinAlgWorkspaceCUDA* workspace)
   {
     workspace_ = workspace;
@@ -309,6 +311,67 @@ namespace ReSolve
     cusparseDestroyDnVec(vec_Y_);
 
     return error_sum;
+  }
+
+  int LinSolverDirectCuSparseILU0::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectCuSparseILU0::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectCuSparseILU0::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectCuSparseILU0::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectCuSparseILU0::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectCuSparseILU0::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
   }
 
 } // namespace resolve

--- a/resolve/LinSolverDirectCuSparseILU0.hpp
+++ b/resolve/LinSolverDirectCuSparseILU0.hpp
@@ -42,6 +42,12 @@ namespace ReSolve
       int solve(vector_type* rhs, vector_type* x) override;
       int solve(vector_type* rhs) override;
     
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
 
     private:
       cusparseStatus_t status_cusparse_;

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -286,4 +286,66 @@ namespace ReSolve
     klu_rcond(Symbolic_, Numeric_, &Common_);
     return Common_.rcond;
   }
+
+  int LinSolverDirectKLU::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectKLU::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectKLU::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectKLU::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectKLU::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectKLU::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -287,7 +287,7 @@ namespace ReSolve
     return Common_.rcond;
   }
 
-  int LinSolverDirectKLU::setCliParam(const std::string id, const std::string value)
+  int LinSolverDirectKLU::setCliParam(const std::string id, const std::string /* value */)
   {
     switch (getParamId(id))
     {

--- a/resolve/LinSolverDirectKLU.hpp
+++ b/resolve/LinSolverDirectKLU.hpp
@@ -51,6 +51,13 @@ namespace ReSolve
 
       virtual real_type getMatrixConditionNumber() override;
 
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
+
     private:
       bool factors_extracted_{false};
       klu_common Common_; //settings

--- a/resolve/LinSolverDirectKLU.hpp
+++ b/resolve/LinSolverDirectKLU.hpp
@@ -45,11 +45,11 @@ namespace ReSolve
       index_type*  getPOrdering() override;
       index_type*  getQOrdering() override;
 
-      virtual void setPivotThreshold(real_type tol) override;
-      virtual void setOrdering(int ordering) override;
-      virtual void setHaltIfSingular(bool isHalt) override;
+      virtual void setPivotThreshold(real_type tol);
+      virtual void setOrdering(int ordering);
+      virtual void setHaltIfSingular(bool isHalt);
 
-      virtual real_type getMatrixConditionNumber() override;
+      virtual real_type getMatrixConditionNumber();
 
       int setCliParam(const std::string id, const std::string value) override;
       std::string getCliParamString(const std::string id) const override;
@@ -59,6 +59,42 @@ namespace ReSolve
       int printCliParam(const std::string id) const override;
 
     private:
+      enum ParamaterIDs {PIVOT_TOL=0, ORDERING, HALT_IF_SINGULAR};
+
+      /**
+       * @brief Ordering type (during the analysis)
+       * 
+       * Available values are  0 = AMD, 1 = COLAMD, 2 = user provided P, Q.
+       * 
+       * Default is COLAMD.
+       */
+      int ordering_{1};
+
+      /**
+       * @brief Partial pivoing tolerance.
+       * 
+       * If the diagonal entry has a magnitude greater than or equal to tol
+       * times the largest magnitude of entries in the pivot column, then the
+       * diagonal entry is chosen.
+       */
+      real_type pivot_threshold_tol_{0.1};
+
+      /**
+       * @brief Halt if matrix is singular.
+       * 
+       * If false: keep going. Return a Numeric object with a zero U(k,k).
+       * A divide-by-zero may occur when computing L(:,k). The Numeric object
+       * can be passed to klu_solve (a divide-by-zero will occur). It can
+       * also be safely passed to refactorization methods.
+       * 
+       * If true: stop quickly. klu_factor will free the partially-constructed
+       * Numeric object. klu_refactor will not free it, but will leave the
+       * numerical values only partially defined.
+       */
+      bool halt_if_singular_{false};
+
+    private:
+      void initParamList();
       bool factors_extracted_{false};
       klu_common Common_; //settings
       klu_symbolic* Symbolic_{nullptr};

--- a/resolve/LinSolverDirectLUSOL.cpp
+++ b/resolve/LinSolverDirectLUSOL.cpp
@@ -473,6 +473,67 @@ namespace ReSolve
     return 0;
   }
 
+  int LinSolverDirectLUSOL::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectLUSOL::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectLUSOL::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectLUSOL::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectLUSOL::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectLUSOL::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
   //
   // Private Methods
   //

--- a/resolve/LinSolverDirectLUSOL.cpp
+++ b/resolve/LinSolverDirectLUSOL.cpp
@@ -473,7 +473,7 @@ namespace ReSolve
     return 0;
   }
 
-  int LinSolverDirectLUSOL::setCliParam(const std::string id, const std::string value)
+  int LinSolverDirectLUSOL::setCliParam(const std::string id, const std::string /* value */)
   {
     switch (getParamId(id))
     {

--- a/resolve/LinSolverDirectLUSOL.hpp
+++ b/resolve/LinSolverDirectLUSOL.hpp
@@ -64,6 +64,13 @@ namespace ReSolve
 
       virtual real_type getMatrixConditionNumber() override;
 
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
+
     private:
       int allocateSolverData();
       int freeSolverData();

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -6,6 +6,8 @@
 
 namespace ReSolve 
 {
+  using out = io::Logger;
+
   LinSolverDirectRocSolverRf::LinSolverDirectRocSolverRf(LinAlgWorkspaceHIP* workspace)
   {
     workspace_ = workspace;
@@ -377,6 +379,71 @@ namespace ReSolve
     return solve_mode_;
   }
 
+  int LinSolverDirectRocSolverRf::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectRocSolverRf::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectRocSolverRf::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectRocSolverRf::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectRocSolverRf::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectRocSolverRf::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
+  //
+  // Private methods
+  //
+  
   void LinSolverDirectRocSolverRf::addFactors(matrix::Sparse* L, matrix::Sparse* U)
   {
     // L and U need to be in CSC format

--- a/resolve/LinSolverDirectRocSolverRf.hpp
+++ b/resolve/LinSolverDirectRocSolverRf.hpp
@@ -47,6 +47,13 @@ namespace ReSolve
       int setSolveMode(int mode); // should probably be enum 
       int getSolveMode(); //should be enum too
 
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
+
     private:
       rocblas_status status_rocblas_; 
       rocsparse_status status_rocsparse_;

--- a/resolve/LinSolverDirectRocSolverRf.hpp
+++ b/resolve/LinSolverDirectRocSolverRf.hpp
@@ -38,14 +38,14 @@ namespace ReSolve
                 matrix::Sparse* U,
                 index_type*     P,
                 index_type*     Q,
-                vector_type*  rhs);
+                vector_type*  rhs) override;
        
-      int refactorize();
-      int solve(vector_type* rhs, vector_type* x);
-      int solve(vector_type* rhs);// the solution is returned IN RHS (rhs is overwritten)
+      int refactorize() override;
+      int solve(vector_type* rhs, vector_type* x) override;
+      int solve(vector_type* rhs) override; // the solution overwrites rhs
     
       int setSolveMode(int mode); // should probably be enum 
-      int getSolveMode(); //should be enum too
+      int getSolveMode() const; //should be enum too
 
       int setCliParam(const std::string id, const std::string value) override;
       std::string getCliParamString(const std::string id) const override;
@@ -55,6 +55,14 @@ namespace ReSolve
       int printCliParam(const std::string id) const override;
 
     private:
+      enum ParamaterIDs {SOLVE_MODE=0};
+      int solve_mode_{0}; // 0 - default; 1 - use rocparse trisolver
+
+    private:
+      // to be exported to matrix handler in a later time
+      void addFactors(matrix::Sparse* L, matrix::Sparse* U); //create L+U from sepeate L, U factors
+      void initParamList();
+
       rocblas_status status_rocblas_; 
       rocsparse_status status_rocsparse_;
       index_type* d_P_{nullptr};
@@ -63,11 +71,8 @@ namespace ReSolve
       MemoryHandler mem_; ///< Device memory manager object
       LinAlgWorkspaceHIP* workspace_; 
 
-      // to be exported to matrix handler in a later time
-      void addFactors(matrix::Sparse* L, matrix::Sparse* U); //create L+U from sepeate L, U factors
       rocsolver_rfinfo infoM_;
       matrix::Sparse* M_{nullptr};//the matrix that contains added factors
-      int solve_mode_; // 0 is default and 1 is fast
 
       // not used by default - for fast solve
       rocsparse_mat_descr descr_L_{nullptr};

--- a/resolve/LinSolverDirectRocSparseILU0.cpp
+++ b/resolve/LinSolverDirectRocSparseILU0.cpp
@@ -6,6 +6,8 @@
 
 namespace ReSolve 
 {
+  using out = io::Logger;
+
   LinSolverDirectRocSparseILU0::LinSolverDirectRocSparseILU0(LinAlgWorkspaceHIP* workspace)
   {
     workspace_ = workspace;
@@ -291,4 +293,65 @@ namespace ReSolve
     return error_sum;
   }
   
+  int LinSolverDirectRocSparseILU0::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectRocSparseILU0::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectRocSparseILU0::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectRocSparseILU0::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectRocSparseILU0::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectRocSparseILU0::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
 }// namespace resolve

--- a/resolve/LinSolverDirectRocSparseILU0.hpp
+++ b/resolve/LinSolverDirectRocSparseILU0.hpp
@@ -44,6 +44,12 @@ namespace ReSolve
       int solve(vector_type* rhs, vector_type* x) override;
       int solve(vector_type* rhs) override; // the solution is returned IN RHS (rhs is overwritten)
     
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
 
     private:
       rocsparse_status status_rocsparse_;

--- a/resolve/LinSolverDirectSerialILU0.cpp
+++ b/resolve/LinSolverDirectSerialILU0.cpp
@@ -7,6 +7,8 @@
 
 namespace ReSolve 
 {
+  using out = io::Logger;
+
   LinSolverDirectSerialILU0::LinSolverDirectSerialILU0(LinAlgWorkspaceCpu* workspace)
   {
     workspace_ = workspace;
@@ -236,4 +238,66 @@ namespace ReSolve
     //for (int ii=0; ii<10; ++ii) printf("(LU)^{-1}y[%d] = %16.16f \n ", ii,  x->getData(ReSolve::memory::HOST)[ii]); 
    return error_sum;
   }
+
+  int LinSolverDirectSerialILU0::setCliParam(const std::string id, const std::string value)
+  {
+    switch (getParamId(id))
+    {
+      default:
+        std::cout << "Setting parameter failed!\n";
+    }
+    return 0;
+  }
+
+  std::string LinSolverDirectSerialILU0::getCliParamString(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown string parameter " << id << "\n";
+    }
+    return "";
+  }
+
+  index_type LinSolverDirectSerialILU0::getCliParamInt(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown integer parameter " << id << "\n";
+    }
+    return -1;
+  }
+
+  real_type LinSolverDirectSerialILU0::getCliParamReal(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown real parameter " << id << "\n";
+    }
+    return std::numeric_limits<real_type>::quiet_NaN();
+  }
+
+  bool LinSolverDirectSerialILU0::getCliParamBool(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+      default:
+        out::error() << "Trying to get unknown boolean parameter " << id << "\n";
+    }
+    return false;
+  }
+
+  int LinSolverDirectSerialILU0::printCliParam(const std::string id) const
+  {
+    switch (getParamId(id))
+    {
+    default:
+      out::error() << "Trying to print unknown parameter " << id << "\n";
+      return 1;
+    }
+    return 0;
+  }
+
 } // namespace resolve

--- a/resolve/LinSolverDirectSerialILU0.cpp
+++ b/resolve/LinSolverDirectSerialILU0.cpp
@@ -239,7 +239,7 @@ namespace ReSolve
    return error_sum;
   }
 
-  int LinSolverDirectSerialILU0::setCliParam(const std::string id, const std::string value)
+  int LinSolverDirectSerialILU0::setCliParam(const std::string id, const std::string /* value */)
   {
     switch (getParamId(id))
     {

--- a/resolve/LinSolverDirectSerialILU0.hpp
+++ b/resolve/LinSolverDirectSerialILU0.hpp
@@ -33,12 +33,18 @@ namespace ReSolve
                 matrix::Sparse* U = nullptr,
                 index_type*     P = nullptr,
                 index_type*     Q = nullptr,
-                vector_type* rhs  = nullptr);
+                vector_type* rhs  = nullptr) override;
       int reset(matrix::Sparse* A);
        
-      int solve(vector_type* rhs, vector_type* x);
-      int solve(vector_type* rhs);// the solutuon is returned IN RHS (rhs is overwritten)
+      int solve(vector_type* rhs, vector_type* x) override;
+      int solve(vector_type* rhs) override; // the solutuon is returned IN RHS (rhs is overwritten)
     
+      int setCliParam(const std::string id, const std::string value) override;
+      std::string getCliParamString(const std::string id) const override;
+      index_type getCliParamInt(const std::string id) const override;
+      real_type getCliParamReal(const std::string id) const override;
+      bool getCliParamBool(const std::string id) const override;
+      int printCliParam(const std::string id) const override;
 
     private:
 

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -107,12 +107,12 @@ namespace ReSolve {
     assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
            "Matrix has to be in CSR format for matrix-vector product.\n");
 
-    real_type sum, nrm;
-    index_type i, j;
+    real_type sum = 0.0;
+    real_type nrm = 0.0;
 
-    for (i = 0; i < A->getNumRows(); ++i) {
+    for (index_type i = 0; i < A->getNumRows(); ++i) {
       sum = 0.0; 
-      for (j  = A->getRowData(memory::HOST)[i]; j < A->getRowData(memory::HOST)[i+1]; ++j) {
+      for (index_type j  = A->getRowData(memory::HOST)[i]; j < A->getRowData(memory::HOST)[i+1]; ++j) {
         sum += std::abs(A->getValues(memory::HOST)[j]);
       }
       if (i == 0) {

--- a/tests/functionality/testKLU.cpp
+++ b/tests/functionality/testKLU.cpp
@@ -131,8 +131,9 @@ int main(int argc, char *argv[])
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
  
   std::cout<<"Results (first matrix): "<<std::endl<<std::endl;
-  std::cout<<"\t ||b-A*x||_2                 : " << std::setprecision(16) << normRmatrix1    << " (residual norm)" << std::endl;
-  std::cout<<"\t ||b-A*x||_2  (CPU)          : " << std::setprecision(16) << normRmatrix1CPU << " (residual norm)" << std::endl;
+  std::cout << std::scientific << std::setprecision(16);
+  std::cout<<"\t ||b-A*x||_2                 : " << normRmatrix1          << " (residual norm)" << std::endl;
+  std::cout<<"\t ||b-A*x||_2  (CPU)          : " << normRmatrix1CPU       << " (residual norm)" << std::endl;
   std::cout<<"\t ||b-A*x||_2/||b||_2         : " << normRmatrix1/normB1   << " (scaled residual norm)"             << std::endl;
   std::cout<<"\t ||x-x_true||_2              : " << normDiffMatrix1       << " (solution error)"                   << std::endl;
   std::cout<<"\t ||x-x_true||_2/||x_true||_2 : " << normDiffMatrix1/normXtrue << " (scaled solution error)"        << std::endl;
@@ -190,6 +191,7 @@ int main(int argc, char *argv[])
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::HOST));
   
   std::cout<<"Results (second matrix): "<<std::endl<<std::endl;
+  std::cout << std::scientific << std::setprecision(16);
   std::cout<<"\t ||b-A*x||_2                 : "<<normRmatrix2<<" (residual norm)"<<std::endl;
   std::cout<<"\t ||b-A*x||_2/||b||_2         : "<<normRmatrix2/normB2<<" (scaled residual norm)"<<std::endl;
   std::cout<<"\t ||x-x_true||_2              : "<<normDiffMatrix2<<" (solution error)"<<std::endl;

--- a/tests/functionality/testKLU_RocSolver.cpp
+++ b/tests/functionality/testKLU_RocSolver.cpp
@@ -158,8 +158,9 @@ int main(int argc, char *argv[])
   real_type normRmatrix1CPU = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   std::cout<<"Results (first matrix): "<<std::endl<<std::endl;
-  std::cout<<"\t ||b-A*x||_2                 : " << std::setprecision(16) << normRmatrix1    << " (residual norm)" << std::endl;
-  std::cout<<"\t ||b-A*x||_2  (CPU)          : " << std::setprecision(16) << normRmatrix1CPU << " (residual norm)" << std::endl;
+  std::cout << std::scientific << std::setprecision(16);
+  std::cout<<"\t ||b-A*x||_2                 : " << normRmatrix1    << " (residual norm)" << std::endl;
+  std::cout<<"\t ||b-A*x||_2  (CPU)          : " << normRmatrix1CPU << " (residual norm)" << std::endl;
   std::cout<<"\t ||b-A*x||_2/||b||_2         : " << normRmatrix1/normB1   << " (scaled residual norm)"             << std::endl;
   std::cout<<"\t ||x-x_true||_2              : " << normDiffMatrix1       << " (solution error)"                   << std::endl;
   std::cout<<"\t ||x-x_true||_2/||x_true||_2 : " << normDiffMatrix1/normXtrue << " (scaled solution error)"        << std::endl;
@@ -220,6 +221,7 @@ int main(int argc, char *argv[])
   real_type exactSol_normRmatrix2 = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   std::cout<<"Results (second matrix): "<<std::endl<<std::endl;
+  std::cout << std::scientific << std::setprecision(16);
   std::cout<<"\t ||b-A*x||_2                 : "<<normRmatrix2<<" (residual norm)"<<std::endl;
   std::cout<<"\t ||b-A*x||_2/||b||_2         : "<<normRmatrix2/normB2<<" (scaled residual norm)"<<std::endl;
   std::cout<<"\t ||x-x_true||_2              : "<<normDiffMatrix2<<" (solution error)"<<std::endl;
@@ -235,9 +237,9 @@ int main(int argc, char *argv[])
     error_sum++;
   }
   if (error_sum == 0) {
-    std::cout << "Test KLU with cuSolverGLU refactorization " << GREEN << "PASSED" << CLEAR << std::endl;
+    std::cout << "Test KLU with rocsolverRf refactorization " << GREEN << "PASSED" << CLEAR << std::endl;
   } else {
-    std::cout << "Test KLU with cuSolverGLU refactorization " << RED << "FAILED" << CLEAR
+    std::cout << "Test KLU with rocsolverRf refactorization " << RED << "FAILED" << CLEAR
               << ", error sum: " << error_sum << std::endl;
   }
 

--- a/tests/functionality/testKLU_RocSolver_FGMRES.cpp
+++ b/tests/functionality/testKLU_RocSolver_FGMRES.cpp
@@ -168,15 +168,16 @@ int main(int argc, char *argv[])
 
   // Now prepare the Rf solver
 
-  ReSolve::matrix::Csc* L = (ReSolve::matrix::Csc*) KLU->getLFactor();
-  ReSolve::matrix::Csc* U = (ReSolve::matrix::Csc*) KLU->getUFactor();
+  ReSolve::matrix::Csc* L = static_cast<ReSolve::matrix::Csc*>(KLU->getLFactor());
+  ReSolve::matrix::Csc* U = static_cast<ReSolve::matrix::Csc*>(KLU->getUFactor());
 
   if (L == nullptr) {
     printf("ERROR");
   }
   index_type* P = KLU->getPOrdering();
   index_type* Q = KLU->getQOrdering();
-  Rf->setSolveMode(1);
+  Rf->setCliParam("solve_mode", "rocsparse_trisolve");
+  // Rf->setCliParam("solve_mode", "default");
   vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   error_sum += Rf->setup(A, L, U, P, Q, vec_rhs); 
   FGMRES->setMaxit(200); 
@@ -261,14 +262,14 @@ int main(int argc, char *argv[])
     error_sum++;
   }
   // TODO: 1e-9 is too lose acuracy!
-  if ((normRmatrix1/normB1 > 1e-12 ) || (normRmatrix2/normB2 > 1e-9)) {
+  if ((normRmatrix1/normB1 > 1e-12 ) || (normRmatrix2/normB2 > 1e-12)) {
     std::cout << "Result inaccurate!\n";
     error_sum++;
   }
   if (error_sum == 0) {
-    std::cout << "Test KLU with cuSolverGLU refactorization " << GREEN << "PASSED" << CLEAR << std::endl;
+    std::cout << "Test KLU with Rf refactorization and IR " << GREEN << "PASSED" << CLEAR << std::endl;
   } else {
-    std::cout << "Test KLU with cuSolverGLU refactorization " << RED << "FAILED" << CLEAR
+    std::cout << "Test KLU with Rf refactorization and IR " << RED << "FAILED" << CLEAR
               << ", error sum: " << error_sum << std::endl;
   }
 

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -142,7 +142,8 @@ int main(int argc, char* argv[])
   real_type exactSol_normRmatrix = sqrt(vector_handler.dot(&vec_r, &vec_r, ReSolve::memory::HOST));
 
   std::cout << "Results: \n";
-  std::cout << "\t ||b-A*x||_2                 : " << std::setprecision(16) << normRmatrix << " (residual norm)\n";
+  std::cout << std::scientific << std::setprecision(16);
+  std::cout << "\t ||b-A*x||_2                 : " << normRmatrix << " (residual norm)\n";
   std::cout << "\t ||b-A*x||_2/||b||_2         : " << normRmatrix / normB << " (scaled residual norm)\n";
   std::cout << "\t ||x-x_true||_2              : " << normDiffMatrix << " (solution error)\n";
   std::cout << "\t ||x-x_true||_2/||x_true||_2 : " << normDiffMatrix / normXtrue << " (scaled solution error)\n";
@@ -243,7 +244,8 @@ int main(int argc, char* argv[])
   exactSol_normRmatrix = sqrt(vector_handler.dot(&vec_r, &vec_r, ReSolve::memory::HOST));
 
   std::cout << "Results: \n";
-  std::cout << "\t ||b-A*x||_2                 : " << std::setprecision(16) << normRmatrix << " (residual norm)\n";
+  std::cout << std::scientific << std::setprecision(16);
+  std::cout << "\t ||b-A*x||_2                 : " << normRmatrix << " (residual norm)\n";
   std::cout << "\t ||b-A*x||_2/||b||_2         : " << normRmatrix / normB << " (scaled residual norm)\n";
   std::cout << "\t ||x-x_true||_2              : " << normDiffMatrix << " (solution error)\n";
   std::cout << "\t ||x-x_true||_2/||x_true||_2 : " << normDiffMatrix / normXtrue << " (scaled solution error)\n";

--- a/tests/functionality/testSysGLU.cpp
+++ b/tests/functionality/testSysGLU.cpp
@@ -180,7 +180,8 @@ int main(int argc, char *argv[])
   real_type rel_residual_norm = solver.getResidualNorm(vec_rhs, vec_x);
   error = std::abs(normB1 * rel_residual_norm - normRmatrix1)/normRmatrix1;
   if (error > 10.0*std::numeric_limits<real_type>::epsilon()) {
-    std::cout << "Relative residual norm computation failed:\n" << std::setprecision(16)
+    std::cout << "Relative residual norm computation failed:\n"
+              << std::scientific << std::setprecision(16)
               << "\tTest value            : " << normRmatrix1/normB1 << "\n"
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
@@ -271,13 +272,15 @@ int main(int argc, char *argv[])
   rel_residual_norm = solver.getResidualNorm(vec_rhs, vec_x);
   error = std::abs(normB2 * rel_residual_norm - normRmatrix2)/normRmatrix2;
   if (error > 10.0*std::numeric_limits<real_type>::epsilon()) {
-    std::cout << "Relative residual norm computation failed:\n" << std::setprecision(16)
+    std::cout << "Relative residual norm computation failed:\n"
+              << std::scientific << std::setprecision(16)
               << "\tTest value            : " << normRmatrix2/normB2 << "\n"
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
   }
  
   std::cout << "Results (second matrix): " << std::endl << std::endl;
+  std::cout << std::scientific << std::setprecision(16);
   std::cout << "\t ||b-A*x||_2                 : " << normRmatrix2              << " (residual norm)\n";
   std::cout << "\t ||b-A*x||_2/||b||_2         : " << normRmatrix2/normB2       << " (relative residual norm)\n";
   std::cout << "\t ||b-A*x||/(||A||*||x||)     : " << nsr_norm                  << " (norm of scaled residuals)\n";

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -197,7 +197,8 @@ int main(int argc, char *argv[])
   real_type rel_residual_norm = solver.getResidualNorm(vec_rhs, vec_x);
   error = std::abs(normB1 * rel_residual_norm - normRmatrix1)/normRmatrix1;
   if (error > 10.0*std::numeric_limits<real_type>::epsilon()) {
-    std::cout << "Relative residual norm computation failed:\n" << std::setprecision(16)
+    std::cout << "Relative residual norm computation failed:\n";
+    std::cout << std::scientific << std::setprecision(16)
               << "\tTest value            : " << normRmatrix1/normB1 << "\n"
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
@@ -291,7 +292,8 @@ int main(int argc, char *argv[])
   rel_residual_norm = solver.getResidualNorm(vec_rhs, vec_x);
   error = std::abs(normB2 * rel_residual_norm - normRmatrix2)/normRmatrix2;
   if (error > 10.0*std::numeric_limits<real_type>::epsilon()) {
-    std::cout << "Relative residual norm computation failed:\n" << std::setprecision(16)
+    std::cout << "Relative residual norm computation failed:\n";
+    std::cout << std::scientific << std::setprecision(16)
               << "\tTest value            : " << normRmatrix2/normB2 << "\n"
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
@@ -309,6 +311,7 @@ int main(int argc, char *argv[])
   
 
   std::cout << "Results (second matrix): " << std::endl << std::endl;
+  std::cout << std::scientific << std::setprecision(16);
   std::cout << "\t ||b-A*x||_2                 : " << normRmatrix2              << " (residual norm)\n";
   std::cout << "\t ||b-A*x||_2/||b||_2         : " << normRmatrix2/normB2       << " (relative residual norm)\n";
   std::cout << "\t ||x-x_true||_2              : " << normDiffMatrix2           << " (solution error)\n";


### PR DESCRIPTION
Implement generic functions for setting direct solvers configuration parameters. The parameters are expected to come from command line input. 

Several compiler warnings are fixed here, as well.

Closes #96 