### PR TITLE
Extend the csc2csr function to work for rectangular matrices, added tests

### DIFF
--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -136,10 +136,10 @@ namespace ReSolve {
   int MatrixHandlerCpu::csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr)
   {
     // int error_sum = 0; TODO: Collect error output!
+    std::cout << "N: " << A_csc->getNumRows() << " M: " << A_csc->getNumColumns() << "\n";
     assert(A_csc->getNnz() == A_csr->getNnz());
     assert(A_csc->getNumRows() == A_csr->getNumRows());
     assert(A_csc->getNumColumns() == A_csr->getNumColumns());
-
     index_type nnz = A_csc->getNnz();
     index_type n   = A_csc->getNumRows();
     index_type m   = A_csc->getNumColumns();

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -137,11 +137,12 @@ namespace ReSolve {
   {
     // int error_sum = 0; TODO: Collect error output!
     assert(A_csc->getNnz() == A_csr->getNnz());
-    assert(A_csc->getNumRows() == A_csr->getNumColumns());
-    assert(A_csr->getNumRows() == A_csc->getNumColumns());
+    assert(A_csc->getNumRows() == A_csr->getNumRows());
+    assert(A_csc->getNumColumns() == A_csr->getNumColumns());
 
     index_type nnz = A_csc->getNnz();
-    index_type n   = A_csc->getNumColumns();
+    index_type n   = A_csc->getNumRows();
+    index_type m   = A_csc->getNumColumns();
 
     index_type* rowIdxCsc = A_csc->getRowData(memory::HOST);
     index_type* colPtrCsc = A_csc->getColData(memory::HOST);
@@ -181,7 +182,7 @@ namespace ReSolve {
     }
     rowPtrCsr[n] = nnz;
 
-    for (index_type col = 0; col < n; ++col)
+    for (index_type col = 0; col < m; ++col)
     {
       // Compute positions of column indices and values in CSR matrix and store them there
       // Overwrites CSR row pointers in the process

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -196,6 +196,7 @@ namespace ReSolve {
     
     // check dimensions of A_csc and A_csr
     assert(A_csc->getNumRows() == A_csr->getNumRows() && "Number of rows in A_csc must be equal to number of rows in A_csr");
+    assert(A_csc->getNumColumns() == A_csr->getNumColumns() && "Number of columns in A_csc must be equal to number of columns in A_csr");
 
     size_t bufferSize;
     void* d_work;
@@ -215,6 +216,7 @@ namespace ReSolve {
                                                             CUSPARSE_CSR2CSC_ALG1, 
                                                             &bufferSize);
     error_sum += status;
+    std::cout << "bufferSize: " << bufferSize << " status " << status << "\n";
     mem_.allocateBufferOnDevice(&d_work, bufferSize);
     status = cusparseCsr2cscEx2(workspace_->getCusparseHandle(),
                                 m, 
@@ -232,6 +234,9 @@ namespace ReSolve {
                                 CUSPARSE_CSR2CSC_ALG1,
                                 d_work);
     error_sum += status;
+    if (status)
+      out::error() << "CSC2CSR status: "   << status                    << ". "
+                   << "Last error code: " << mem_.getLastDeviceError() << ".\n";
     return error_sum;
     mem_.deleteOnDevice(d_work);
   }

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -190,7 +190,7 @@ namespace ReSolve {
     index_type error_sum = 0;
 
     A_csr->allocateMatrixData(memory::DEVICE);
-    index_type m = A_csc->getNumCols();
+    index_type m = A_csc->getNumColumns();
     index_type n = A_csc->getNumRows();
     index_type nnz = A_csc->getNnz();
     size_t bufferSize;

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -190,14 +190,14 @@ namespace ReSolve {
     index_type error_sum = 0;
 
     A_csr->allocateMatrixData(memory::DEVICE);
+    index_type m = A_csc->getNumCols();
     index_type n = A_csc->getNumRows();
-    index_type m = A_csc->getNumRows();
     index_type nnz = A_csc->getNnz();
     size_t bufferSize;
     void* d_work;
     cusparseStatus_t status = cusparseCsr2cscEx2_bufferSize(workspace_->getCusparseHandle(),
-                                                            n, 
                                                             m, 
+                                                            n, 
                                                             nnz, 
                                                             A_csc->getValues( memory::DEVICE), 
                                                             A_csc->getColData(memory::DEVICE), 
@@ -213,8 +213,8 @@ namespace ReSolve {
     error_sum += status;
     mem_.allocateBufferOnDevice(&d_work, bufferSize);
     status = cusparseCsr2cscEx2(workspace_->getCusparseHandle(),
-                                n, 
                                 m, 
+                                n, 
                                 nnz, 
                                 A_csc->getValues( memory::DEVICE), 
                                 A_csc->getColData(memory::DEVICE), 

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -193,6 +193,10 @@ namespace ReSolve {
     index_type m = A_csc->getNumColumns();
     index_type n = A_csc->getNumRows();
     index_type nnz = A_csc->getNnz();
+    
+    // check dimensions of A_csc and A_csr
+    assert(A_csc->getNumRows() == A_csr->getNumRows() && "Number of rows in A_csc must be equal to number of rows in A_csr");
+
     size_t bufferSize;
     void* d_work;
     cusparseStatus_t status = cusparseCsr2cscEx2_bufferSize(workspace_->getCusparseHandle(),

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -176,7 +176,7 @@ namespace ReSolve {
     rocsparse_status status;
     
     A_csr->allocateMatrixData(memory::DEVICE);
-    index_type m = A_csc->getNumCols();
+    index_type m = A_csc->getNumColumns();
     index_type n = A_csc->getNumRows();
     index_type nnz = A_csc->getNnz();
     size_t bufferSize;

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -176,15 +176,15 @@ namespace ReSolve {
     rocsparse_status status;
     
     A_csr->allocateMatrixData(memory::DEVICE);
+    index_type m = A_csc->getNumCols();
     index_type n = A_csc->getNumRows();
-    index_type m = A_csc->getNumRows();
     index_type nnz = A_csc->getNnz();
     size_t bufferSize;
     void* d_work;
 
     status = rocsparse_csr2csc_buffer_size(workspace_->getRocsparseHandle(),
-                                           n,
                                            m,
+                                           n,
                                            nnz,
                                            A_csc->getColData(memory::DEVICE), 
                                            A_csc->getRowData(memory::DEVICE), 
@@ -195,8 +195,8 @@ namespace ReSolve {
     mem_.allocateBufferOnDevice(&d_work, bufferSize);
     
     status = rocsparse_dcsr2csc(workspace_->getRocsparseHandle(),
-                                n,
                                 m,
+                                n,
                                 nnz,
                                 A_csc->getValues( memory::DEVICE), 
                                 A_csc->getColData(memory::DEVICE), 

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -62,7 +62,7 @@ public:
     vector::Vector y(N);
     x.allocate(memspace_);
     if (x.getData(memspace_) == NULL) 
-      std::cout << "Oups we have an issue \n";
+      std::cout << "The memory space was not allocated \n" << std::endl;
     y.allocate(memspace_);
 
     x.setToConst(1.0, memspace_);
@@ -75,7 +75,7 @@ public:
 
     status *= verifyAnswer(y, 4.0);
 
-    delete A;
+    //delete A;
 
     return status.report(__func__);
   }
@@ -84,7 +84,8 @@ public:
   {
     TestStatus status=0;
     matrix::Csc* A_csc = createRectangularCscMatrix(N, M);
-    matrix::Csr* A_csr = new matrix::Csr(N, M, 2*std::min(N,M));
+    std::cout << "N: " << N << " M: " << M << "\n";
+    matrix::Csr* A_csr = new matrix::Csr(M, N, 2*std::min(N,M));
     A_csr->allocateMatrixData(memory::HOST);
 
     handler_.csc2csr(A_csc, A_csr, memspace_);
@@ -152,19 +153,19 @@ private:
     matrix::Csc* A = new matrix::Csc(M, N, NNZ); //indices are deliberately swapped so N+1 is the length of the pointer array
     A->allocateMatrixData(memory::HOST);
 
-    index_type* colptr = A->getRowData(memory::HOST);
-    index_type* rowidx = A->getColData(memory::HOST);
+    index_type* colptr = A->getColData(memory::HOST);
+    index_type* rowidx = A->getRowData(memory::HOST);
     real_type* val     = A->getValues( memory::HOST);
 
     real_type counter = 1.0;
-
+    colptr[0] = 0;
+    std::cout << "N: " << N << " M: " << M << "\n";
     if(N==M) //square case
     {
-      colptr[0] = 0;
       for (index_type i=0; i < N; ++i)
       {
         colptr[i+1] = colptr[i] + 2;
-        if(i==0) //first row
+        if(i==0) //first column
         {
           rowidx[colptr[i]] = i;
           val[colptr[i]] = counter++;
@@ -182,7 +183,6 @@ private:
     }
     else if (N>M)
     {
-      colptr[0] = 0;
       for (index_type i=0; i < N; ++i)
       {
         colptr[i+1] = colptr[i];
@@ -202,7 +202,6 @@ private:
     }
     else //N<M
     {
-      colptr[0] = 0;
       for (index_type i=0; i < N; ++i)
       {
         colptr[i+1] = colptr[i]+2;

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -98,9 +98,67 @@ public:
     index_type* colidx_csr = A_csr->getColData(memory::HOST);
     real_type* val_csr     = A_csr->getValues( memory::HOST);
 
-    index_type* colptr_csc = A_csc->getRowData(memory::HOST);
-    index_type* rowidx_csc = A_csc->getColData(memory::HOST);
-    real_type* val_csc     = A_csc->getValues( memory::HOST);
+    index_type* colptr_csc = A_csc->getColData(memory::HOST);
+    index_type* rowidx_csc = A_csc->getRowData(memory::HOST);
+    real_type* val_csc     = A_csc->getValues(memory::HOST);
+
+    // check dimensions
+    status *= (A_csr->getNumRows() == A_csc->getNumRows());
+    status *= (A_csr->getNumColumns() == A_csc->getNumColumns());
+    status *= (A_csr->getNnz() == A_csc->getNnz());
+    
+    // print the matrix
+    for (index_type i=0; i < M; ++i)
+    {
+      std::cout << "rowptr_csr[" << i << "] = " << rowptr_csr[i] << "\n";
+      for (index_type j = rowptr_csr[i]; j < rowptr_csr[i+1]; ++j)
+      {
+        std::cout << "colidx_csr[" << j << "] = " << colidx_csr[j] << " val_csr[" << j << "] = " << val_csr[j] << "\n";
+      }
+    }
+
+    if(N==M)
+    {
+      for (index_type i = 0; i < A_csr->getNumRows(); ++i) {
+        if (i==N-1) //last row should have one value
+        {
+          status *= (rowptr_csr[i+1] == rowptr_csr[i] + 1);
+          std::cout << "rowptr_csr[" << i+1 << "] = " << rowptr_csr[i+1] << "\n";
+          status *= (colidx_csr[rowptr_csr[i]] == N-1);
+          std::cout << "colidx_csr[" << rowptr_csr[i] << "] = " << colidx_csr[rowptr_csr[i]] << "\n";
+          status *= (val_csr[rowptr_csr[i]] == 2.0*N);
+          std::cout << "val_csr[" << rowptr_csr[i] << "] = " << val_csr[rowptr_csr[i]] << "\n";
+        }
+        else if(i==N/2) //this row should have 3 values
+        {
+          status *= (rowptr_csr[i+1] == rowptr_csr[i] + 3);
+          status *= (colidx_csr[rowptr_csr[i]] == 0);
+          status *= (val_csr[rowptr_csr[i]] == 2.0);
+          status *= (colidx_csr[rowptr_csr[i]+1] == N/2);
+          status *= (colidx_csr[rowptr_csr[i]+2] == N/2+1);
+          status *= (val_csr[rowptr_csr[i]+1] == 2.0*(N/2)+2);
+          status *= (val_csr[rowptr_csr[i]+2] == 2.0*(N/2)+3);
+        }
+        else // all other rows have two values
+        {
+          status *= (rowptr_csr[i+1] == rowptr_csr[i] + 2);
+          status *= (colidx_csr[rowptr_csr[i]] == i);
+          status *= (colidx_csr[rowptr_csr[i]+1] == i+1);
+          if(i==0)
+          {
+            status *= (val_csr[rowptr_csr[i]] == 1.0);
+            status *= (val_csr[rowptr_csr[i]+1] == 3.0);
+          }
+          else
+          {
+            status *= (val_csr[rowptr_csr[i]] == 2.0*(i+1));
+            status *= (val_csr[rowptr_csr[i]+1] == 2.0*(i+1)+1.0);
+          }
+
+        }
+      }
+    }
+
 
 
 
@@ -212,7 +270,15 @@ private:
       }
     }
     A->setUpdated(memory::HOST);
-
+    // // print the matrix
+    // for (index_type i=0; i < M; ++i)
+    // {
+    //   std::cout << "colptr[" << i << "] = " << colptr[i] << "\n";
+    //   for (index_type j = colptr[i]; j < colptr[i+1]; ++j)
+    //   {
+    //     std::cout << "rowidx[" << j << "] = " << rowidx[j] << " val[" << j << "] = " << val[j] << "\n";
+    //   }
+    // }
     if (memspace_ == memory::DEVICE) {
       A->syncData(memspace_);
     }

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -18,8 +18,13 @@ void runTests(const std::string& backendName, ReSolve::tests::TestingResults& re
     result += test.matrixInfNorm(1000000);
     result += test.matVec(50);
     result += test.csc2csr(5, 5);
-    // result += test.csc2csr(1024, 2048);
-    // result += test.csc2csr(2048, 1024);
+    result += test.csc2csr(5, 3);
+    result += test.csc2csr(3, 5);
+    result += test.csc2csr(1024, 1024);
+    result += test.csc2csr(1024, 2048);
+    result += test.csc2csr(2048, 1024);
+    result += test.csc2csr(1024, 1200);
+    result += test.csc2csr(1200, 1024);
     std::cout << "\n";
 }
 

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -35,7 +35,9 @@ int main(int, char**)
     result += test.matrixHandlerConstructor();
     result += test.matrixInfNorm(1000000);
     result += test.matVec(50);
-
+    result += test.csc2csr(2,3);
+    result += test.csc2csr(3,2);
+    result += test.csc2csr(3,3);
     std::cout << "\n";
   }
 #endif
@@ -57,3 +59,4 @@ int main(int, char**)
 #endif
   return result.summary();
 }
+

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -5,34 +5,37 @@
 #include <resolve/matrix/io.hpp>
 #include "MatrixHandlerTests.hpp"
 
-#if defined (RESOLVE_USE_CUDA)
-  ReSolve::LinAlgWorkspaceCUDA workspace;
-#elif defined (RESOLVE_USE_HIP)
-  ReSolve::LinAlgWorkspaceHIP workspace;
-#else
-  ReSolve::LinAlgWorkspaceCpu workspace;
+template<typename WorkspaceType>
+void runTests(const std::string& backendName, ReSolve::tests::TestingResults& result) {
+    std::cout << "Running tests with " << backendName << ":\n";
+    
+    WorkspaceType workspace;
+    workspace.initializeHandles();
+    ReSolve::MatrixHandler handler(&workspace);
+
+    ReSolve::tests::MatrixHandlerTests test(handler);
+    result += test.matrixHandlerConstructor();
+    result += test.matrixInfNorm(1000000);
+    result += test.matVec(50);
+    result += test.csc2csr(1024, 1024);
+    result += test.csc2csr(1024, 2048);
+    result += test.csc2csr(2048, 1024);
+    std::cout << "\n";
+}
+
+int main(int, char**) {
+    ReSolve::tests::TestingResults result;
+
+    runTests<ReSolve::LinAlgWorkspaceCpu>("CPU", result);
+
+#ifdef RESOLVE_USE_CUDA
+    runTests<ReSolve::LinAlgWorkspaceCUDA>("CUDA backend", result);
 #endif
 
-int main(int, char**)
-{
-  #if defined (RESOLVE_USE_CUDA)
-    std::cout << "Running tests with CUDA backend:\n";
-  #elif defined (RESOLVE_USE_HIP)
-    std::cout << "Running tests with HIP backend:\n";
-  #else
-    std::cout << "Running tests on CPU:\n";
-  #endif
-  ReSolve::tests::TestingResults result; 
-  workspace.initializeHandles();
-  ReSolve::MatrixHandler handler(&workspace);
-  ReSolve::tests::MatrixHandlerTests test(handler);
-  result += test.matrixHandlerConstructor();
-  result += test.matrixInfNorm(1000000);
-  result += test.matVec(50);
-  result += test.csc2csr(1024, 1024);
-  result += test.csc2csr(1024, 2048);
-  result += test.csc2csr(2048, 1024);
-  std::cout << "\n";
-  return result.summary();
+#ifdef RESOLVE_USE_HIP
+    runTests<ReSolve::LinAlgWorkspaceHIP>("HIP backend", result);
+#endif
+
+    return result.summary();
 }
 

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -29,6 +29,9 @@ int main(int, char**)
   result += test.matrixHandlerConstructor();
   result += test.matrixInfNorm(1000000);
   result += test.matVec(50);
+  result += test.csc2csr(1024, 1024);
+  result += test.csc2csr(1024, 2048);
+  result += test.csc2csr(2048, 1024);
   std::cout << "\n";
   return result.summary();
 }

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -17,9 +17,9 @@ void runTests(const std::string& backendName, ReSolve::tests::TestingResults& re
     result += test.matrixHandlerConstructor();
     result += test.matrixInfNorm(1000000);
     result += test.matVec(50);
-    result += test.csc2csr(1024, 1024);
-    result += test.csc2csr(1024, 2048);
-    result += test.csc2csr(2048, 1024);
+    result += test.csc2csr(5, 5);
+    // result += test.csc2csr(1024, 2048);
+    // result += test.csc2csr(2048, 1024);
     std::cout << "\n";
 }
 

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -5,58 +5,31 @@
 #include <resolve/matrix/io.hpp>
 #include "MatrixHandlerTests.hpp"
 
+#if defined (RESOLVE_USE_CUDA)
+  ReSolve::LinAlgWorkspaceCUDA workspace;
+#elif defined (RESOLVE_USE_HIP)
+  ReSolve::LinAlgWorkspaceHIP workspace;
+#else
+  ReSolve::LinAlgWorkspaceCpu workspace;
+#endif
+
 int main(int, char**)
 {
-  ReSolve::tests::TestingResults result; 
-
-  {
-    std::cout << "Running tests on CPU:\n";
-
-    ReSolve::LinAlgWorkspaceCpu workspace;
-    workspace.initializeHandles();
-    ReSolve::MatrixHandler handler(&workspace);
-
-    ReSolve::tests::MatrixHandlerTests test(handler);
-    result += test.matrixHandlerConstructor();
-    result += test.matrixInfNorm(10000);
-    result += test.matVec(50);
-
-    std::cout << "\n";
-  }
-
-#ifdef RESOLVE_USE_CUDA
-  {
+  #if defined (RESOLVE_USE_CUDA)
     std::cout << "Running tests with CUDA backend:\n";
-    ReSolve::LinAlgWorkspaceCUDA workspace;
-    workspace.initializeHandles();
-    ReSolve::MatrixHandler handler(&workspace);
-
-    ReSolve::tests::MatrixHandlerTests test(handler);
-    result += test.matrixHandlerConstructor();
-    result += test.matrixInfNorm(1000000);
-    result += test.matVec(50);
-    result += test.csc2csr(2,3);
-    result += test.csc2csr(3,2);
-    result += test.csc2csr(3,3);
-    std::cout << "\n";
-  }
-#endif
-
-#ifdef RESOLVE_USE_HIP
-  {
+  #elif defined (RESOLVE_USE_HIP)
     std::cout << "Running tests with HIP backend:\n";
-    ReSolve::LinAlgWorkspaceHIP workspace;
-    workspace.initializeHandles();
-    ReSolve::MatrixHandler handler(&workspace);
-
-    ReSolve::tests::MatrixHandlerTests test(handler);
-    result += test.matrixHandlerConstructor();
-    result += test.matrixInfNorm(1000000);
-    result += test.matVec(50);
-
-    std::cout << "\n";
-  }
-#endif
+  #else
+    std::cout << "Running tests on CPU:\n";
+  #endif
+  ReSolve::tests::TestingResults result; 
+  workspace.initializeHandles();
+  ReSolve::MatrixHandler handler(&workspace);
+  ReSolve::tests::MatrixHandlerTests test(handler);
+  result += test.matrixHandlerConstructor();
+  result += test.matrixInfNorm(1000000);
+  result += test.matVec(50);
+  std::cout << "\n";
   return result.summary();
 }
 


### PR DESCRIPTION
- Added functionality for rectangular matrices for csr2csc
- Removed implicit square assumptions, wrong dimensions, misleading names
- Added tests for large and small matrices with `$N>M$`, `$N==M$`, and `N$<M$` (tests of arbitrary size of this format can be created)
- For rectangular matrices, the nonzero entries are the diagonal starting from the top left and the diagonal from the lower right. Values are increasing in column major order.
- For square matrices, the nonzero entries are upper bidiagonal, with one additional nonzero in the first column. Values increase in column major order.
- Fixed occasional typos