### PR TITLE
Fixed error messages in Csc, Csr, Coo classes

### DIFF
--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -191,7 +191,12 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated	
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Coo::copyDataFrom one of host row or column data is null!\n";
+        if(h_row_data_ == nullptr) {
+          out::error() << "In Coo::copyDataFrom host row data is null, but col data is set!\n";
+        }
+        else {
+          out::error() << "In Coo::copyDataFrom host col data is null, but row data is set!\n";
+        }
       }
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[nnz_current];
@@ -207,7 +212,12 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Coo::copyDataFrom one of device row or column data is null!\n";
+        if(d_row_data_ == nullptr) {
+          out::error() << "In Coo::copyDataFrom device row data is null, but col data is set!\n";
+        }
+        else {
+          out::error() << "In Coo::copyDataFrom device col data is null, but row data is set!\n";
+        }
       }
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
@@ -239,7 +249,7 @@ namespace ReSolve
         mem_.copyArrayHostToDevice(d_val_data_, val_data, nnz_current);
         d_data_updated_ = true;
         break;
-      case 3://gpu->gpua
+      case 3://gpu->gpu
         mem_.copyArrayDeviceToDevice(d_row_data_, row_data, nnz_current);
         mem_.copyArrayDeviceToDevice(d_col_data_, col_data, nnz_current);
         mem_.copyArrayDeviceToDevice(d_val_data_, val_data, nnz_current);
@@ -308,15 +318,22 @@ namespace ReSolve
     switch (memspace) {
       case HOST:
         if (h_data_updated_) {
-          out::misc() << "In Coo::syncData trying to sync host, but host already up to date!\n";
+          out::misc() << "WARNING: In Coo::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device)\n";
           return 0;
         }
         if (!d_data_updated_) {
-          out::error() << "In Coo::syncData trying to sync host with device, but device is out of date!\n";
+          out::error() << "In Coo::syncData trying to sync host with device, but device is out of date!" <<
+          "If you have changed the data on purpose, update the device with: variableName->setUpdated(memory::DEVICE)."
+          << "If you did not mean to change the data on the device, check your code. \n";
           assert(d_data_updated_);
         }
         if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-          out::error() << "In Coo::syncData one of host row or column data is null!\n";
+          if(h_row_data_ == nullptr) {
+            out::error() << "In Coo::syncData host row data is null, but col data is set!\n";
+          }
+          else {
+            out::error() << "In Coo::syncData host col data is null, but row data is set!\n";
+          }
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
           h_row_data_ = new index_type[nnz_];      
@@ -334,15 +351,23 @@ namespace ReSolve
         return 0;
       case DEVICE:
         if (d_data_updated_) {
-          out::misc() << "In Coo::syncData trying to sync device, but device already up to date!\n";
+          out::misc() << "WARNING: In Coo::syncData trying to sync device, but device already up to date! This line is ignored. (Perhaps you meant to sync host)\n";
           return 0;
         }
         if (!h_data_updated_) {
-          out::error() << "In Coo::syncData trying to sync device with host, but host is out of date!\n";
+          out::error() << "In Coo::syncData trying to sync device with host, but host is out of date!" <<
+          "If you have changed the data on purpose, update the host with: variableName->setUpdated(memory::HOST)."
+          << "If you did not mean to change the data on the host, check your code. \n";
           assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-          out::error() << "In Coo::syncData one of device row or column data is null!\n";
+          if(d_row_data_ == nullptr) {
+            out::error() << "In Coo::syncData device row data is null, but col data is set!\n";
+          }
+          else {
+            out::error() << "In Coo::syncData device col data is null, but row data is set!\n";
+          }
+          
         }
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_row_data_, nnz_);

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -318,7 +318,8 @@ namespace ReSolve
     switch (memspace) {
       case HOST:
         if (h_data_updated_) {
-          out::misc() << "WARNING: In Coo::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device)\n";
+          out::misc() << "WARNING: In Coo::syncData trying to sync host, but host already up to date!"
+          << "This line is ignored. (Perhaps you meant to sync device)\n";
           return 0;
         }
         if (!d_data_updated_) {
@@ -351,7 +352,8 @@ namespace ReSolve
         return 0;
       case DEVICE:
         if (d_data_updated_) {
-          out::misc() << "WARNING: In Coo::syncData trying to sync device, but device already up to date! This line is ignored. (Perhaps you meant to sync host)\n";
+          out::misc() << "WARNING: In Coo::syncData trying to sync device, but device already up to date!"
+          << "This line is ignored. (Perhaps you meant to sync host)\n";
           return 0;
         }
         if (!h_data_updated_) {

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -93,7 +93,12 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csc::copyDataFrom one of host row or column data is null!\n";
+        if(h_row_data_ == nullptr) {
+          out::error() << "In Csc::copyDataFrom one of host row or column data is null!\n";
+        }
+        else {
+          out::error() << "In Csc::copyDataFrom one of host row or column data is null!\n";
+        }
       }
       if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
         this->h_col_data_ = new index_type[m_ + 1];
@@ -109,7 +114,12 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csc::copyDataFrom one of device row or column data is null!\n";
+        if(d_row_data_ == nullptr) {
+          out::error() << "In Csc::copyDataFrom one of device row or column data is null!\n";
+        }
+        else {
+          out::error() << "In Csc::copyDataFrom one of device row or column data is null!\n";
+        }
       }
       if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
@@ -211,15 +221,23 @@ namespace ReSolve
     switch(memspace) {
       case HOST:
         if (h_data_updated_) {
-          out::misc() << "In Csc::syncData trying to sync host, but host already up to date!\n";
+          out::misc() << "WARNING: In Csc::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device)\n";
           return 0;
         }
         if (!d_data_updated_) {
-          out::error() << "In Csc::syncData trying to sync host with device, but device is out of date!\n";
+          out::error() << "In Csc::syncData trying to sync host with device, but device is out of date!" <<
+          "If you have changed the data on purpose, update the device with: variableName->setUpdated(memory::DEVICE)."
+          << "If you did not mean to change the data on the device, check your code. \n";
           assert(d_data_updated_);
         }
         if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-          out::error() << "In Csc::syncData one of host row or column data is null!\n";
+          if (h_row_data_ == nullptr) {
+            out::error() << "In Csc::syncData host row data is null, but col data is set!\n";
+          }
+          else {
+            out::error() << "In Csc::syncData host col data is null, but row data is set!\n";
+          }
+          
         }
         if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
           h_col_data_ = new index_type[m_ + 1];      
@@ -237,15 +255,22 @@ namespace ReSolve
         return 0;   
       case DEVICE:
         if (d_data_updated_) {
-          out::misc() << "In Csc::syncData trying to sync device, but device already up to date!\n";
+          out::misc() << "WARNING: In Csc::syncData trying to sync device, but device already up to date! This line is ignored. (Perhaps you meant to sync host)\n";
           return 0;
         }
         if (!h_data_updated_) {
-          out::error() << "In Csc::syncData trying to sync device with host, but host is out of date!\n";
+          out::error() << "In Csc::syncData trying to sync device with host, but host is out of date!" <<
+          "If you have changed the data on purpose, update the host with: variableName->setUpdated(memory::HOST)."
+          << "If you did not mean to change the data on the host, check your code. \n";
           assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-          out::error() << "In Csc::syncData one of device row or column data is null!\n";
+          if (d_row_data_ == nullptr) {
+            out::error() << "In Csc::syncData device row data is null, but col data is set!\n";
+          }
+          else {
+            out::error() << "In Csc::syncData device col data is null, but row data is set!\n";
+          }
         }
         if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -221,7 +221,8 @@ namespace ReSolve
     switch(memspace) {
       case HOST:
         if (h_data_updated_) {
-          out::misc() << "WARNING: In Csc::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device)\n";
+          out::misc() << "WARNING: In Csc::syncData trying to sync host, but host already up to date!" 
+          << "This line is ignored. (Perhaps you meant to sync device)\n";
           return 0;
         }
         if (!d_data_updated_) {
@@ -255,7 +256,8 @@ namespace ReSolve
         return 0;   
       case DEVICE:
         if (d_data_updated_) {
-          out::misc() << "WARNING: In Csc::syncData trying to sync device, but device already up to date! This line is ignored. (Perhaps you meant to sync host)\n";
+          out::misc() << "WARNING: In Csc::syncData trying to sync device, but device already up to date!"
+          << "This line is ignored. (Perhaps you meant to sync host)\n";
           return 0;
         }
         if (!h_data_updated_) {

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -328,15 +328,22 @@ namespace ReSolve
       case HOST:
         //check if we need to copy or not
         if (h_data_updated_) {
-          out::misc() << "In Csr::syncData trying to sync host, but host already up to date!\n";
+          out::misc() << "WARNING: In Csr::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device\n";
           return 0;
         }
         if (!d_data_updated_) {
-          out::error() << "In Csr::syncData trying to sync host with device, but device is out of date!\n";
+          out::error() << "In Csr::syncData trying to sync host with device, but device is out of date! 
+          If you have changed the data on purpose, update the device with "variableName->setUpdated(memory::DEVICE)". 
+          If you did not mean to change the data on the device, check your code. \n";
           assert(d_data_updated_);
         }
         if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-          out::error() << "In Csr::syncData one of host row or column data is null!\n";
+          if(h_row_data_ == nullptr) {
+            out::error() << "In Csr::syncData host row data is null, but col data is set!\n";
+          }
+          else {
+            out::error() << "In Csr::syncData host col data is null, but row data is set!\n";
+          }
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
           h_row_data_ = new index_type[n_ + 1];

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -338,7 +338,8 @@ namespace ReSolve
       case HOST:
         //check if we need to copy or not
         if (h_data_updated_) {
-          out::misc() << "WARNING: In Csr::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device)\n";
+          out::misc() << "WARNING: In Csr::syncData trying to sync host, but host already up to date!"
+          << "This line is ignored. (Perhaps you meant to sync device)\n";
           return 0;
         }
         if (!d_data_updated_) {
@@ -371,7 +372,8 @@ namespace ReSolve
         return 0;
       case DEVICE:
         if (d_data_updated_) {
-          out::misc() << "WARNING: In Csr::syncData trying to sync device, but device already up to date! This line is ignored. (Perhaps you meant to sync host)\n";
+          out::misc() << "WARNING: In Csr::syncData trying to sync device, but device already up to date!"
+          << "This line is ignored. (Perhaps you meant to sync host)\n";
           return 0;
         }
         if (!h_data_updated_) {

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -208,7 +208,12 @@ namespace ReSolve
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csr::copyDataFrom one of host row or column data is null!\n";
+        if(h_row_data_ == nullptr) {
+          out::error() << "In Csr::syncData host row data is null, but col data is set!\n";
+        }
+        else {
+          out::error() << "In Csr::syncData host col data is null, but row data is set!\n";
+        }
       }
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[n_ + 1];
@@ -224,7 +229,12 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csr::copyDataFrom one of device row or column data is null!\n";
+        if(d_row_data_ == nullptr) {
+          out::error() << "In Csr::syncData device row data is null, but col data is set!\n";
+        }
+        else {
+          out::error() << "In Csr::syncData device col data is null, but row data is set!\n";
+        }
       }
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
@@ -328,13 +338,13 @@ namespace ReSolve
       case HOST:
         //check if we need to copy or not
         if (h_data_updated_) {
-          out::misc() << "WARNING: In Csr::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device\n";
+          out::misc() << "WARNING: In Csr::syncData trying to sync host, but host already up to date! This line is ignored. (Perhaps you meant to sync device)\n";
           return 0;
         }
         if (!d_data_updated_) {
-          out::error() << "In Csr::syncData trying to sync host with device, but device is out of date! 
-          If you have changed the data on purpose, update the device with "variableName->setUpdated(memory::DEVICE)". 
-          If you did not mean to change the data on the device, check your code. \n";
+          out::error() << "In Csr::syncData trying to sync host with device, but device is out of date!" <<
+          "If you have changed the data on purpose, update the device with: variableName->setUpdated(memory::DEVICE)." 
+          << "If you did not mean to change the data on the device, check your code. \n";
           assert(d_data_updated_);
         }
         if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
@@ -369,7 +379,12 @@ namespace ReSolve
           assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-          out::error() << "In Csr::syncData one of device row or column data is null!\n";
+          if(d_row_data_ == nullptr) {
+            out::error() << "In Csr::syncData device row data is null, but col data is set!\n";
+          }
+          else {
+            out::error() << "In Csr::syncData device col data is null, but row data is set!\n";
+          }
         }
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -209,10 +209,10 @@ namespace ReSolve
       //check if cpu data allocated
       if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
         if(h_row_data_ == nullptr) {
-          out::error() << "In Csr::syncData host row data is null, but col data is set!\n";
+          out::error() << "In Csr::copyDataFrom host row data is null, but col data is set!\n";
         }
         else {
-          out::error() << "In Csr::syncData host col data is null, but row data is set!\n";
+          out::error() << "In Csr::copyDataFrom host col data is null, but row data is set!\n";
         }
       }
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
@@ -230,10 +230,10 @@ namespace ReSolve
       //check if cuda data allocated
       if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
         if(d_row_data_ == nullptr) {
-          out::error() << "In Csr::syncData device row data is null, but col data is set!\n";
+          out::error() << "In Csr::copyDataFrom device row data is null, but col data is set!\n";
         }
         else {
-          out::error() << "In Csr::syncData device col data is null, but row data is set!\n";
+          out::error() << "In Csr::copyDataFrom device col data is null, but row data is set!\n";
         }
       }
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
@@ -371,11 +371,13 @@ namespace ReSolve
         return 0;
       case DEVICE:
         if (d_data_updated_) {
-          out::misc() << "In Csr::syncData trying to sync device, but device already up to date!\n";
+          out::misc() << "WARNING: In Csr::syncData trying to sync device, but device already up to date! This line is ignored. (Perhaps you meant to sync host)\n";
           return 0;
         }
         if (!h_data_updated_) {
-          out::error() << "In Csr::syncData trying to sync device with host, but host is out of date!\n";
+          out::error() << "In Csr::syncData trying to sync device with host, but host is out of date!" <<
+          "If you have changed the data on purpose, update the host with: variableName->setUpdated(memory::HOST)."
+          << "If you did not mean to change the data on the host, check your code. \n";
           assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {


### PR DESCRIPTION
Addresses [this issue](https://github.com/ORNL/ReSolve/issues/229).

- Alerted the use to the possibility that they are perhaps trying to sync the wrong space (host or device).
- Made the user aware of the need to call  `variableName->setUpdated(memory::DEVICE)` (or host).
- Specified which of column or row arrays is not allocated.

Closes #229