### PR TITLE
Fix bug where csc2csr method does not mark memory space updated

### DIFF
--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -8,7 +8,8 @@
 #include <resolve/matrix/Csr.hpp>
 #include "MatrixHandlerCpu.hpp"
 
-namespace ReSolve {
+namespace ReSolve
+{
   // Create a shortcut name for Logger static class
   using out = io::Logger;
   
@@ -20,7 +21,7 @@ namespace ReSolve {
   }
 
   /**
-   * @brief DEmpty dstructor for MatrixHandlerCpu object
+   * @brief Empty dstructor for MatrixHandlerCpu object
    */
   MatrixHandlerCpu::~MatrixHandlerCpu()
   {
@@ -86,7 +87,7 @@ namespace ReSolve {
     real_type t;
     real_type c;
 
-    //Kahan algorithm for stability; Kahan-Babushka version didnt make a difference   
+    // Kahan algorithm for stability
     for (int i = 0; i < A->getNumRows(); ++i) {
       sum = 0.0;
       c = 0.0;
@@ -95,7 +96,7 @@ namespace ReSolve {
         t = sum + y;
         c = (t - sum) - y;
         sum = t;
-        //  sum += ( a[j] * x_data[ja[j]]);
+        //  sum += (a[j] * x_data[ja[j]]);
       }
       sum *= (*alpha);
       result_data[i] = result_data[i]*(*beta) + sum;
@@ -120,6 +121,7 @@ namespace ReSolve {
    */
   int MatrixHandlerCpu::matrixInfNorm(matrix::Sparse* A, real_type* norm)
   {
+    using memory::HOST;
     assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
            "Matrix has to be in CSR format for matrix-vector product.\n");
 
@@ -128,8 +130,8 @@ namespace ReSolve {
 
     for (index_type i = 0; i < A->getNumRows(); ++i) {
       sum = 0.0; 
-      for (index_type j  = A->getRowData(memory::HOST)[i]; j < A->getRowData(memory::HOST)[i+1]; ++j) {
-        sum += std::abs(A->getValues(memory::HOST)[j]);
+      for (index_type j  = A->getRowData(HOST)[i]; j < A->getRowData(HOST)[i+1]; ++j) {
+        sum += std::abs(A->getValues(HOST)[j]);
       }
       if (i == 0 || sum > nrm) { 
         nrm = sum;
@@ -150,8 +152,6 @@ namespace ReSolve {
    */
   int MatrixHandlerCpu::csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr)
   {
-    // int error_sum = 0; TODO: Collect error output!
-    std::cout << "N: " << A_csc->getNumRows() << " M: " << A_csc->getNumColumns() << "\n";
     assert(A_csc->getNnz() == A_csr->getNnz());
     assert(A_csc->getNumRows() == A_csr->getNumRows());
     assert(A_csc->getNumColumns() == A_csr->getNumColumns());
@@ -200,13 +200,13 @@ namespace ReSolve {
       // Compute positions of column indices and values in CSR matrix and store them there
       // Overwrites CSR row pointers in the process
       for (index_type jj = colPtrCsc[col]; jj < colPtrCsc[col+1]; jj++) {
-          index_type row  = rowIdxCsc[jj];
-          index_type dest = rowPtrCsr[row];
+        index_type row  = rowIdxCsc[jj];
+        index_type dest = rowPtrCsr[row];
 
-          colIdxCsr[dest] = col;
-          valuesCsr[dest] = valuesCsc[jj];
+        colIdxCsr[dest] = col;
+        valuesCsr[dest] = valuesCsc[jj];
 
-          rowPtrCsr[row]++;
+        rowPtrCsr[row]++;
       }
     }
 
@@ -216,6 +216,10 @@ namespace ReSolve {
         rowPtrCsr[row] = last;
         last    = temp;
     }
+
+    // Values on the host are updated now -- mark them as such!
+    A_csr->setUpdated(memory::HOST);
+
     return 0;
   }
 

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -256,6 +256,10 @@ namespace ReSolve {
                    << "Last error code: " << mem_.getLastDeviceError() << ".\n";
     }
     mem_.deleteOnDevice(d_work);
+
+    // Values on the device are updated now -- mark them as such!
+    A_csr->setUpdated(memory::DEVICE);
+
     return error_sum;
   }
 

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -94,7 +94,7 @@ namespace ReSolve {
                                           descrA,
                                           A->getValues( memory::DEVICE), 
                                           A->getRowData(memory::DEVICE),
-                                          A->getColData(memory::DEVICE), // cuda is used as "device"
+                                          A->getColData(memory::DEVICE),
                                           infoA);
       error_sum += status;
       mem_.deviceSynchronize();
@@ -183,13 +183,13 @@ namespace ReSolve {
     return 0;
   }
 
-/*
-* @brief convert a CSC matrix to a CSR matrix in HIP
-* 
-* @param[in]  A_csc - input CSC matrix
-* @param[out] A_csr - output CSR matrix
-* @return int error_sum, 0 if successful
-*/
+  /**
+   * @brief convert a CSC matrix to a CSR matrix in HIP
+   * 
+   * @param[in]  A_csc - input CSC matrix
+   * @param[out] A_csr - output CSR matrix
+   * @return int error_sum, 0 if successful
+   */
   int MatrixHandlerHip::csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr)
   {
     index_type error_sum = 0;
@@ -230,6 +230,10 @@ namespace ReSolve {
                                 d_work);
     error_sum += status;
     mem_.deleteOnDevice(d_work);
+
+    // Values on the device are updated now -- mark them as such!
+    A_csr->setUpdated(memory::DEVICE);
+
     return error_sum;
   }
 

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -75,20 +75,23 @@ public:
 
     status *= verifyAnswer(y, 4.0);
 
-    //delete A;
+    delete A;
 
     return status.report(__func__);
   }
 
   TestOutcome csc2csr(index_type n, index_type m)
   {
-    TestStatus status=0;
-    matrix::Csc* A_csc = createRectangularCscMatrix(n, m);
-    // printMatrix(A_csc, "CSC matrix");
-    std::cout << "n: " << n << " m: " << m << "\n";
+    TestStatus status;
 
-    matrix::Csr* A_csr = new matrix::Csr(m, n, 2*std::min(n,m));
-    A_csr->allocateMatrixData(memory::HOST);
+    std::string testname(__func__);
+    std::stringstream matrix_size;
+    matrix_size << " for " << n << " x " << m << " matrix";
+    testname += matrix_size.str();
+
+    matrix::Csc* A_csc = createRectangularCscMatrix(n, m);
+    matrix::Csr* A_csr = new matrix::Csr(m, n, A_csc->getNnz());
+    A_csr->allocateMatrixData(memspace_);
 
     handler_.csc2csr(A_csc, A_csr, memspace_);
 
@@ -96,22 +99,17 @@ public:
     status *= (A_csr->getNumColumns() == A_csc->getNumColumns());
     status *= (A_csr->getNnz() == A_csc->getNnz());
 
+    // Move data to the host for the result verification
     if (memspace_ == memory::DEVICE) {
-      //update the data on the device
-      A_csr->setUpdated(memory::DEVICE);
       A_csr->syncData(memory::HOST);
     }
-
-    index_type* rowptr_csr = A_csr->getRowData(memory::HOST);
-    index_type* colidx_csr = A_csr->getColData(memory::HOST);
-    real_type* val_csr     = A_csr->getValues( memory::HOST);
 
     verifyCsrMatrix(A_csr, status);
 
     delete A_csr;
     delete A_csc;
 
-    return status.report(__func__);
+    return status.report(testname.c_str());
   }
 
 private:
@@ -135,6 +133,7 @@ private:
     }
     return status;
   }
+
   /** 
    * @brief Create a rectangular CSC matrix with preset sparsity structure
    * 
@@ -147,9 +146,9 @@ private:
    * @param[in] m number of rows
    * 
    * @return matrix::Csr* 
-  */
-  
-matrix::Csc* createRectangularCscMatrix(const index_type n, const index_type m) {
+   */
+  matrix::Csc* createRectangularCscMatrix(const index_type n, const index_type m)
+  {
     index_type nnz = 2 * std::min(n, m);
     matrix::Csc* A = new matrix::Csc(m, n, nnz);
     A->allocateMatrixData(memory::HOST);
@@ -161,143 +160,142 @@ matrix::Csc* createRectangularCscMatrix(const index_type n, const index_type m) 
     real_type counter = 1.0;
     colptr[0] = 0;
     if (n == m) {
-        for (index_type i = 0; i < n; ++i) {
-            colptr[i + 1] = colptr[i] + 2;
-            if (i == 0) {
-                rowidx[colptr[i]] = i;
-                val[colptr[i]] = counter++;
-                rowidx[colptr[i] + 1] = m / 2;
-                val[colptr[i] + 1] = counter++;
-            } else {
-                rowidx[colptr[i]] = i - 1;
-                val[colptr[i]] = counter++;
-                rowidx[colptr[i] + 1] = i;
-                val[colptr[i] + 1] = counter++;
-            }
+      for (index_type i = 0; i < n; ++i) {
+        colptr[i + 1] = colptr[i] + 2;
+        if (i == 0) {
+          rowidx[colptr[i]] = i;
+          val[colptr[i]] = counter++;
+          rowidx[colptr[i] + 1] = m / 2;
+          val[colptr[i] + 1] = counter++;
+        } else {
+          rowidx[colptr[i]] = i - 1;
+          val[colptr[i]] = counter++;
+          rowidx[colptr[i] + 1] = i;
+          val[colptr[i] + 1] = counter++;
         }
+      }
     } else if (n > m) {
-        for (index_type i = 0; i < n; ++i) {
-            colptr[i + 1] = colptr[i];
-            if (i >= n - m) {
-                rowidx[colptr[i + 1]] = i - n + m;
-                val[colptr[i + 1]] = counter++;
-                colptr[i + 1]++;
-            }
-            if (i < m) {
-                rowidx[colptr[i + 1]] = i;
-                val[colptr[i + 1]] = counter++;
-                colptr[i + 1]++;
-            }
+      for (index_type i = 0; i < n; ++i) {
+        colptr[i + 1] = colptr[i];
+        if (i >= n - m) {
+          rowidx[colptr[i + 1]] = i - n + m;
+          val[colptr[i + 1]] = counter++;
+          colptr[i + 1]++;
         }
+        if (i < m) {
+          rowidx[colptr[i + 1]] = i;
+          val[colptr[i + 1]] = counter++;
+          colptr[i + 1]++;
+        }
+      }
     } else {
-        for (index_type i = 0; i < n; ++i) {
-            colptr[i + 1] = colptr[i] + 2;
-            rowidx[colptr[i]] = i;
-            val[colptr[i]] = counter++;
-            rowidx[colptr[i] + 1] = i + m - n;
-            val[colptr[i] + 1] = counter++;
-        }
+      for (index_type i = 0; i < n; ++i) {
+        colptr[i + 1] = colptr[i] + 2;
+        rowidx[colptr[i]] = i;
+        val[colptr[i]] = counter++;
+        rowidx[colptr[i] + 1] = i + m - n;
+        val[colptr[i] + 1] = counter++;
+      }
     }
     A->setUpdated(memory::HOST);
     if (memspace_ == memory::DEVICE) {
-        A->syncData(memspace_);
+      A->syncData(memspace_);
     }
     return A;
 }
 
-/*
-  * @brief Verify structure of a CSR matrix with preset pattern.
-  * 
-  * The sparsity structure corresponds to the CSR representation of a rectangular matrix
-  * created by createRectangularCscMatrix.
-  * The sparisty structure is upper bidiagonal if n==m, 
-  * with an extra entry in the first column.
-  * If n>m an entry is nonzero iff i==j, or i+m==j+n 
-  * if n<m an entry is nonzero iff i==j, or i+n==j+m
-  * The values increase with a counter from 1.0 in column major order.
-  * 
-  * @param[in] A matrix::Csr* pointer to the matrix to be verified
-  * @param[out] status TestStatus& reference to the status of the test
-  */
-
-
-void verifyCsrMatrix(matrix::Csr* A, TestStatus& status) {
+  /**
+   * @brief Verify structure of a CSR matrix with preset pattern.
+   * 
+   * The sparsity structure corresponds to the CSR representation of a rectangular matrix
+   * created by createRectangularCscMatrix.
+   * The sparisty structure is upper bidiagonal if n==m, 
+   * with an extra entry in the first column.
+   * If n>m an entry is nonzero iff i==j, or i+m==j+n 
+   * if n<m an entry is nonzero iff i==j, or i+n==j+m
+   * The values increase with a counter from 1.0 in column major order.
+   * 
+   * @param[in] A matrix::Csr* pointer to the matrix to be verified
+   * @param[out] status TestStatus& reference to the status of the test
+   */
+  void verifyCsrMatrix(matrix::Csr* A, TestStatus& status)
+  {
     index_type* rowptr_csr = A->getRowData(memory::HOST);
     index_type* colidx_csr = A->getColData(memory::HOST);
     real_type* val_csr = A->getValues(memory::HOST);
     index_type n = A->getNumColumns();
     index_type m = A->getNumRows();
     if (n == m) {
-        for (index_type i = 0; i < m; ++i) {
-            if (i == m - 1) {
-                status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
-                status *= (colidx_csr[rowptr_csr[i]] == n - 1);
-                status *= (val_csr[rowptr_csr[i]] == 2.0 * n);
-            } else if (i == m / 2) {
-                status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 3);
-                status *= (colidx_csr[rowptr_csr[i]] == 0);
-                status *= (val_csr[rowptr_csr[i]] == 2.0);
-                status *= (colidx_csr[rowptr_csr[i] + 1] == n / 2);
-                status *= (colidx_csr[rowptr_csr[i] + 2] == n / 2 + 1);
-                status *= (val_csr[rowptr_csr[i] + 1] == 2.0 * (n / 2) + 2);
-                status *= (val_csr[rowptr_csr[i] + 2] == 2.0 * (n / 2) + 3);
-            } else {
-                status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
-                status *= (colidx_csr[rowptr_csr[i]] == i);
-                status *= (colidx_csr[rowptr_csr[i] + 1] == i + 1);
-                if (i == 0) {
-                    status *= (val_csr[rowptr_csr[i]] == 1.0);
-                    status *= (val_csr[rowptr_csr[i] + 1] == 3.0);
-                } else {
-                    status *= (val_csr[rowptr_csr[i]] == 2.0 * (i + 1));
-                    status *= (val_csr[rowptr_csr[i] + 1] == 2.0 * (i + 1) + 1.0);
-                }
-            }
+      for (index_type i = 0; i < m; ++i) {
+        if (i == m - 1) {
+          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
+          status *= (colidx_csr[rowptr_csr[i]] == n - 1);
+          status *= (val_csr[rowptr_csr[i]] == 2.0 * n);
+        } else if (i == m / 2) {
+          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 3);
+          status *= (colidx_csr[rowptr_csr[i]] == 0);
+          status *= (val_csr[rowptr_csr[i]] == 2.0);
+          status *= (colidx_csr[rowptr_csr[i] + 1] == n / 2);
+          status *= (colidx_csr[rowptr_csr[i] + 2] == n / 2 + 1);
+          status *= (val_csr[rowptr_csr[i] + 1] == 2.0 * (n / 2) + 2);
+          status *= (val_csr[rowptr_csr[i] + 2] == 2.0 * (n / 2) + 3);
+        } else {
+          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
+          status *= (colidx_csr[rowptr_csr[i]] == i);
+          status *= (colidx_csr[rowptr_csr[i] + 1] == i + 1);
+          if (i == 0) {
+            status *= (val_csr[rowptr_csr[i]] == 1.0);
+            status *= (val_csr[rowptr_csr[i] + 1] == 3.0);
+          } else {
+            status *= (val_csr[rowptr_csr[i]] == 2.0 * (i + 1));
+            status *= (val_csr[rowptr_csr[i] + 1] == 2.0 * (i + 1) + 1.0);
+          }
         }
+      }
     } else if (n > m) {
-        index_type main_diag_ind = 0;
-        index_type off_diag_ind = n - m;
-        real_type main_val = 1.0;
-        real_type off_val = n - m + 1.0;
-        for (index_type i = 0; i < m; ++i) {
-            status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
-            status *= (colidx_csr[rowptr_csr[i]] == main_diag_ind++);
-            status *= (colidx_csr[rowptr_csr[i] + 1] == off_diag_ind++);
-            status *= (val_csr[rowptr_csr[i]] == main_val++);
-            status *= (val_csr[rowptr_csr[i] + 1] == off_val++);
-            if (i >= n - m - 1) {
-                main_val++;
-            }
-            if (i < 2 * m - n) {
-                off_val++;
-            }
+      index_type main_diag_ind = 0;
+      index_type off_diag_ind = n - m;
+      real_type main_val = 1.0;
+      real_type off_val = n - m + 1.0;
+      for (index_type i = 0; i < m; ++i) {
+        status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
+        status *= (colidx_csr[rowptr_csr[i]] == main_diag_ind++);
+        status *= (colidx_csr[rowptr_csr[i] + 1] == off_diag_ind++);
+        status *= (val_csr[rowptr_csr[i]] == main_val++);
+        status *= (val_csr[rowptr_csr[i] + 1] == off_val++);
+        if (i >= n - m - 1) {
+            main_val++;
         }
+        if (i < 2 * m - n) {
+            off_val++;
+        }
+      }
     } else {
-        real_type main_val = 1.0;
-        real_type off_val = 2.0;
-        for (index_type i = 0; i < m; ++i) {
-            if (i < n && i < m - n) {
-                status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
-                status *= (colidx_csr[rowptr_csr[i]] == i);
-                status *= (val_csr[rowptr_csr[i]] == main_val);
-                main_val += 2.0;
-            } else if (i < n && i >= m - n) {
-                status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
-                status *= (colidx_csr[rowptr_csr[i] + 1] == i);
-                status *= (colidx_csr[rowptr_csr[i]] == i + n - m);
-                status *= (val_csr[rowptr_csr[i] + 1] == main_val);
-                status *= (val_csr[rowptr_csr[i]] == off_val);
-                main_val += 2.0;
-                off_val += 2.0;
-            } else {
-                status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
-                status *= (colidx_csr[rowptr_csr[i]] == i + n - m);
-                status *= (val_csr[rowptr_csr[i]] == off_val);
-                off_val += 2.0;
-            }
+      real_type main_val = 1.0;
+      real_type off_val = 2.0;
+      for (index_type i = 0; i < m; ++i) {
+        if (i < n && i < m - n) {
+          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
+          status *= (colidx_csr[rowptr_csr[i]] == i);
+          status *= (val_csr[rowptr_csr[i]] == main_val);
+          main_val += 2.0;
+        } else if (i < n && i >= m - n) {
+          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
+          status *= (colidx_csr[rowptr_csr[i] + 1] == i);
+          status *= (colidx_csr[rowptr_csr[i]] == i + n - m);
+          status *= (val_csr[rowptr_csr[i] + 1] == main_val);
+          status *= (val_csr[rowptr_csr[i]] == off_val);
+          main_val += 2.0;
+          off_val += 2.0;
+        } else {
+          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
+          status *= (colidx_csr[rowptr_csr[i]] == i + n - m);
+          status *= (val_csr[rowptr_csr[i]] == off_val);
+          off_val += 2.0;
         }
+      }
     }
-}
+  }
 
   /**
    * @brief Create a CSR matrix with preset sparsity structure
@@ -309,8 +307,8 @@ void verifyCsrMatrix(matrix::Csr* A, TestStatus& status) {
    * 
    * @return matrix::Csr* 
    */
-
-matrix::Csr* createCsrMatrix(const index_type n) {
+  matrix::Csr* createCsrMatrix(const index_type n)
+  {
     std::vector<real_type> r1 = {1., 5., 7., 8., 3., 2., 4.};
     std::vector<real_type> r2 = {1., 3., 2., 2., 1., 6., 7., 3., 2., 3.};
     std::vector<real_type> r3 = {11., 15., 4.};
@@ -321,8 +319,8 @@ matrix::Csr* createCsrMatrix(const index_type n) {
 
     index_type nnz = 0;
     for (index_type i = 0; i < n; ++i) {
-        size_t reminder = static_cast<size_t>(i % 5);
-        nnz += static_cast<index_type>(data[reminder].size());
+      size_t reminder = static_cast<size_t>(i % 5);
+      nnz += static_cast<index_type>(data[reminder].size());
     }
 
     matrix::Csr* A = new matrix::Csr(n, n, nnz);
@@ -334,24 +332,24 @@ matrix::Csr* createCsrMatrix(const index_type n) {
 
     rowptr[0] = 0;
     for (index_type i = 0; i < n; ++i) {
-        size_t reminder = static_cast<size_t>(i % 5);
-        const std::vector<real_type>& row_sample = data[reminder];
-        index_type nnz_per_row = static_cast<index_type>(row_sample.size());
+      size_t reminder = static_cast<size_t>(i % 5);
+      const std::vector<real_type>& row_sample = data[reminder];
+      index_type nnz_per_row = static_cast<index_type>(row_sample.size());
 
-        rowptr[i + 1] = rowptr[i] + nnz_per_row;
-        for (index_type j = rowptr[i]; j < rowptr[i + 1]; ++j) {
-            colidx[j] = (j - rowptr[i]) * n / nnz_per_row + (n % (n / nnz_per_row));
-            val[j] = row_sample[static_cast<size_t>(j - rowptr[i])];
-        }
+      rowptr[i + 1] = rowptr[i] + nnz_per_row;
+      for (index_type j = rowptr[i]; j < rowptr[i + 1]; ++j) {
+        colidx[j] = (j - rowptr[i]) * n / nnz_per_row + (n % (n / nnz_per_row));
+        val[j] = row_sample[static_cast<size_t>(j - rowptr[i])];
+      }
     }
     A->setUpdated(memory::HOST);
 
     if (memspace_ == memory::DEVICE) {
-        A->syncData(memspace_);
+      A->syncData(memspace_);
     }
 
     return A;
-}
+  }
 }; // class MatrixHandlerTests
 
 }} // namespace ReSolve::tests

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -7,50 +7,52 @@
 
 
 /** 
-  * @brief run tests with a given backend
-  *
-  * Checks correctness of the constructor, matrixInfNorm, matVec, csc2csr
-  * CPU, CUDA and HIP backends are supported
-  *
-  * @tparam WorkspaceType workspace type LinAlgWorkspace{Cpu, CUDA, HIP} supported
-  * @param[in] backendName - name of the backend
-  * @param[out] result - test results
-  */
+ * @brief run tests with a given backend
+ *
+ * Checks correctness of the constructor, matrixInfNorm, matVec, csc2csr
+ * CPU, CUDA and HIP backends are supported
+ *
+ * @tparam WorkspaceType workspace type LinAlgWorkspace{Cpu, CUDA, HIP} supported
+ * @param[in] backend - name of the hardware backend
+ * @param[out] result - test results
+ */
 template<typename WorkspaceType>
-void runTests(const std::string& backendName, ReSolve::tests::TestingResults& result) {
-    std::cout << "Running tests with " << backendName << ":\n";
-    
-    WorkspaceType workspace;
-    workspace.initializeHandles();
-    ReSolve::MatrixHandler handler(&workspace);
+void runTests(const std::string& backend, ReSolve::tests::TestingResults& result)
+{
+  std::cout << "Running tests on " << backend << " device:\n";
+  
+  WorkspaceType workspace;
+  workspace.initializeHandles();
+  ReSolve::MatrixHandler handler(&workspace);
 
-    ReSolve::tests::MatrixHandlerTests test(handler);
-    result += test.matrixHandlerConstructor();
-    result += test.matrixInfNorm(10000);
-    result += test.matVec(50);
-    result += test.csc2csr(3, 3);
-    result += test.csc2csr(5, 3);
-    result += test.csc2csr(3, 5);
-    result += test.csc2csr(1024, 1024);
-    result += test.csc2csr(1024, 2048);
-    result += test.csc2csr(2048, 1024);
-    result += test.csc2csr(1024, 1200);
-    result += test.csc2csr(1200, 1024);
-    std::cout << "\n";
+  ReSolve::tests::MatrixHandlerTests test(handler);
+  result += test.matrixHandlerConstructor();
+  result += test.matrixInfNorm(10000);
+  result += test.matVec(50);
+  result += test.csc2csr(3, 3);
+  result += test.csc2csr(5, 3);
+  result += test.csc2csr(3, 5);
+  result += test.csc2csr(1024, 1024);
+  result += test.csc2csr(1024, 2048);
+  result += test.csc2csr(2048, 1024);
+  result += test.csc2csr(1024, 1200);
+  result += test.csc2csr(1200, 1024);
+  std::cout << "\n";
 }
 
-int main(int, char**) {
-    ReSolve::tests::TestingResults result;
-    runTests<ReSolve::LinAlgWorkspaceCpu>("CPU", result);
+int main(int, char**)
+{
+  ReSolve::tests::TestingResults result;
+  runTests<ReSolve::LinAlgWorkspaceCpu>("CPU", result);
 
 #ifdef RESOLVE_USE_CUDA
-    runTests<ReSolve::LinAlgWorkspaceCUDA>("CUDA backend", result);
+  runTests<ReSolve::LinAlgWorkspaceCUDA>("CUDA", result);
 #endif
 
 #ifdef RESOLVE_USE_HIP
-    runTests<ReSolve::LinAlgWorkspaceHIP>("HIP backend", result);
+  runTests<ReSolve::LinAlgWorkspaceHIP>("HIP", result);
 #endif
 
-    return result.summary();
+  return result.summary();
 }
 


### PR DESCRIPTION
Method `csc2csr` sets CSR matrix data by accessing its raw data pointers. Therefore, when it changes the matrix data it should invoke method `setUpdated` to set the flag indicating that the matrix data is current. Otherwise, matrix will consider that data out of date and may overwrite it later. This PR fixes incorrectly set flags after `csc2csr` execution.

Also in this PR:
- Removed debugging outputs.
- Fixed code style.
- Updated formatting of matrix handler tests output

