### PR TITLE
Fixed indenting errors for templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/build_error.yml
+++ b/.github/ISSUE_TEMPLATE/build_error.yml
@@ -1,14 +1,13 @@
 name: "\U0001F4A5 Build error"
-description: Unable to build ReSolve
+description: "Unable to build ReSolve"
 title: "Build issue: "
 labels: [build-error]
 body:
   - type: textarea
     id: reproduce
     attributes:
-      label: CMake error message(s)
-      description: |
-        Fill in the console output when you try to build.
+      label: "CMake error message(s)"
+      description: "Fill in the console output when you try to build."
       value: |
         ```console
         $ make
@@ -16,21 +15,27 @@ body:
         ```
     validations:
       required: true
+
   - type: textarea
     id: information
     attributes:
-      label: Information on your system or the test runner
-      description: Please include your system information, including operating system,
-      compilers, hardware backends (CUDA, HIP), dependencies, and required package versions.
+      label: "System and environment details"
+      description: |
+        Please include details about your system, such as:
+        - Operating system  
+        - Compilers  
+        - Hardware backends (CUDA, HIP)  
+        - Dependencies and package versions  
     validations:
       required: true
+
   - type: markdown
     attributes:
       value: |
-        If you have any relevant configuration detail (custom `packages.yaml` or `modules.yaml`, etc.) you can add that here as well.
+        If you have relevant configuration details (e.g., custom `packages.yaml` or `modules.yaml`), you can add them below.
+
   - type: textarea
     id: additional_information
     attributes:
-      label: Additional information
-      description: |
-        Please upload test logs or any additional information about the problem.
+      label: "Additional information"
+      description: "Upload test logs or provide any additional context about the issue."

--- a/.github/ISSUE_TEMPLATE/test_error.yml
+++ b/.github/ISSUE_TEMPLATE/test_error.yml
@@ -1,14 +1,14 @@
 name: "\U0001F4A5 Tests error"
-description: Some ReSolve tests are failing
+description: "Some ReSolve tests are failing"
 title: "Testing issue: "
 labels: [test-error]
 body:
   - type: textarea
     id: reproduce
     attributes:
-      label: Failed test outputs or steps to reproduce the failure(s)
+      label: "Failed test outputs or steps to reproduce the failure(s)"
       description: |
-        Fill in the failing test output, errors,
+        Fill in the failing test output, errors,  
         or steps to reproduce the failure(s).
       value: |
         ```console
@@ -17,21 +17,27 @@ body:
         ```
     validations:
       required: true
+
   - type: textarea
     id: information
     attributes:
-      label: Information on your system or the test runner
-      description: Please include your system information, including operating system,
-      compilers, hardware backends (CUDA, HIP), dependencies, and required package versions.
+      label: "System and environment details"
+      description: |
+        Please include details about your system, such as:
+        - Operating system  
+        - Compilers  
+        - Hardware backends (CUDA, HIP)  
+        - Dependencies and package versions  
     validations:
       required: true
+
   - type: markdown
     attributes:
       value: |
-        If you have any relevant configuration detail (custom `packages.yaml` or `modules.yaml`, etc.) you can add that here as well.
+        If you have relevant configuration details (e.g., custom `packages.yaml` or `modules.yaml`), you can add them below.
+
   - type: textarea
     id: additional_information
     attributes:
-      label: Additional information
-      description: |
-        Please upload test logs or any additional information about the problem.
+      label: "Additional information"
+      description: "Upload test logs or provide any additional context about the issue."


### PR DESCRIPTION
The build error and test error templates were not compiling or rendering on github due to an indenting error in each one of them. I fixed this error.