### PR TITLE
Fix bug in Gram-Schmidt test

### DIFF
--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -113,9 +113,10 @@ namespace ReSolve
           nrm = 1.0 / nrm;
           handler_.scal(&nrm, &V, memspace_);
 
+          // Orthogonalize system and verify result
           GS.orthogonalize(N, &V, H, 0); 
           GS.orthogonalize(N, &V, H, 1); 
-          status *= verifyAnswer(V, 3);
+          status *= verifyAnswer(V, restart + 1);
 
           delete [] H;
           

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -45,6 +45,7 @@ namespace ReSolve
         {
           TestStatus status;
 
+          // Set test name
           std::string testname(__func__);
           switch(var)
           {
@@ -66,22 +67,29 @@ namespace ReSolve
               break;
           }
 
-          vector::Vector V(N, 3); // we will be using a space of 3 vectors
-          real_type* H = new real_type[6]; // In this case, Hessenberg matrix is NOT 3 x 2 ???
-          real_type* aux_data = nullptr; // needed for setup
+          // Answer key designed for restart = 2
+          index_type restart = 2;
+          
+          // Krylov space spanned by 3 vectors
+          vector::Vector V(N, restart + 1);
+          
+          // Hessenberg matrix size is 2 x 3
+          real_type* H = new real_type[restart * (restart + 1)];
 
+          // Allocate Krylov subspace
           V.allocate(memspace_);
           if (memspace_ == memory::DEVICE) {
             V.allocate(memory::HOST);
           }
 
+          // Create and allocate Gram-Schmidt orthogonalization
           ReSolve::GramSchmidt GS(&handler_, var);
-          GS.setup(N, 2);
+          GS.setup(N, restart);
           
-          //fill 2nd and 3rd vector with values
-          aux_data = V.getVectorData(1, memory::HOST);
+          // Fill 2nd and 3rd vector with values
+          real_type* aux_data = V.getVectorData(1, memory::HOST);
           for (int i = 0; i < N; ++i) {
-            if ( i % 2 == 0) {         
+            if (i % 2 == 0) {         
               aux_data[i] = constants::ONE;
             } else {
               aux_data[i] = var1;
@@ -89,7 +97,7 @@ namespace ReSolve
           }
           aux_data = V.getVectorData(2, memory::HOST);
           for (int i = 0; i < N; ++i) {
-            if ( i % 3 > 0) {         
+            if (i % 3 > 0) {         
               aux_data[i] = constants::ZERO;
             } else {
               aux_data[i] = var2;
@@ -98,7 +106,7 @@ namespace ReSolve
           V.setDataUpdated(memory::HOST); 
           V.syncData(memspace_);
 
-          //set the first vector to all 1s, normalize 
+          // Set the first vector to all 1s and normalize it. 
           V.setToConst(0, 1.0, memspace_);
           real_type nrm = handler_.dot(&V, &V, memspace_);
           nrm = sqrt(nrm);

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -67,7 +67,7 @@ namespace ReSolve
           }
 
           vector::Vector V(N, 3); // we will be using a space of 3 vectors
-          real_type* H = new real_type[9]; // In this case, Hessenberg matrix is NOT 3 x 2 ???
+          real_type* H = new real_type[6]; // In this case, Hessenberg matrix is NOT 3 x 2 ???
           real_type* aux_data = nullptr; // needed for setup
 
           V.allocate(memspace_);
@@ -76,7 +76,7 @@ namespace ReSolve
           }
 
           ReSolve::GramSchmidt GS(&handler_, var);
-          GS.setup(N, 3);
+          GS.setup(N, 2);
           
           //fill 2nd and 3rd vector with values
           aux_data = V.getVectorData(1, memory::HOST);

--- a/tests/unit/vector/runGramSchmidtTests.cpp
+++ b/tests/unit/vector/runGramSchmidtTests.cpp
@@ -3,64 +3,46 @@
 #include <fstream>
 #include "GramSchmidtTests.hpp"
 
+template <class workspace_type>
+static ReSolve::tests::TestingResults runTests();
+
 int main(int, char**)
 {
   ReSolve::tests::TestingResults result; 
 
-  {
-    std::cout << "Running tests on the CPU:\n";
-
-    ReSolve::LinAlgWorkspaceCpu workspace;
-    workspace.initializeHandles();
-    ReSolve::VectorHandler handler(&workspace);
-
-    ReSolve::tests::GramSchmidtTests test(handler);
-    result += test.GramSchmidtConstructor();
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS2);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_TWO_SYNC);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_PM);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS1);
-    std::cout << "\n";
-  }
+  std::cout << "\nRunning tests on a CPU device:\n";
+  result += runTests<ReSolve::LinAlgWorkspaceCpu>();
 
 #ifdef RESOLVE_USE_CUDA
-  {
-    std::cout << "Running tests with CUDA backend:\n";
-
-    ReSolve::LinAlgWorkspaceCUDA workspace;
-    workspace.initializeHandles();
-    ReSolve::VectorHandler handler(&workspace);
-
-    ReSolve::tests::GramSchmidtTests test(handler);
-    result += test.GramSchmidtConstructor();
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS2);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_TWO_SYNC);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_PM);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS1);
-    std::cout << "\n";
-  }
+  std::cout << "\nRunning tests on a CUDA device:\n";
+  result += runTests<ReSolve::LinAlgWorkspaceCUDA>();
 #endif
 
 #ifdef RESOLVE_USE_HIP
-  {
-    std::cout << "Running tests with HIP backend:\n";
-
-    ReSolve::LinAlgWorkspaceHIP workspace;
-    workspace.initializeHandles();
-    ReSolve::VectorHandler handler(&workspace);
-
-    ReSolve::tests::GramSchmidtTests test(handler);
-    result += test.GramSchmidtConstructor();
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS2);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_TWO_SYNC);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_PM);
-    result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS1);
-    std::cout << "\n";
-  }
+  std::cout << "\nRunning tests on a HIP device:\n";
+  result += runTests<ReSolve::LinAlgWorkspaceHIP>();
 #endif
 
   return result.summary();
+}
+
+template <class workspace_type>
+ReSolve::tests::TestingResults runTests()
+{
+  ReSolve::tests::TestingResults result; 
+
+
+  workspace_type workspace;
+  workspace.initializeHandles();
+  ReSolve::VectorHandler handler(&workspace);
+
+  ReSolve::tests::GramSchmidtTests test(handler);
+  result += test.GramSchmidtConstructor();
+  result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS);
+  result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS2);
+  result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_TWO_SYNC);
+  result += test.orthogonalize(5000, ReSolve::GramSchmidt::MGS_PM);
+  result += test.orthogonalize(5000, ReSolve::GramSchmidt::CGS1);
+
+  return result;
 }


### PR DESCRIPTION
In `GramSchmidtTests::orthogonalize`, the `GramSchmidt` class was set up as
```c++
          GS.setup(N, restart + 1);
```
instead of as
```c++
          GS.setup(N, restart);
```
That was causing the test to segfault. The workaround used before this PR was to allocate larger Hessenberg matrix. 

In this PR:
- `GramSchmidt` class is correctly set up.
- "Magic numbers" were replaced by variables with intuitive names to improve code readability.
- Additional comments were added to the code to explain what the test is doing.
- Test runner was refactored to remove unnecessary code duplication.

Verified:
- [x] Code builds without warnings with flags `-Wall -Wconversion -Wextra`
- [x] CPU tests pass
- [x] CUDA tests pass
- [ ] HIP tests pass
