### PR TITLE
Added feature: reusing transpose allocation

### DIFF
--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -1,9 +1,9 @@
 /**
  * @file cudaVectorKernels.cu
- * @author Slaven Peles (peless@ornl.gov)
+ * @author Slaven Peles (peless@ornl.gov), Shaked Regev (regevs@ornl.gov)
  * @brief Contains implementation of CUDA vector kernels and their wrappers.
  * @date 2023-12-08
- * 
+ *
  * @note Kernel wrappers implemented here are intended for use in hardware
  * agnostic code.
  */
@@ -23,7 +23,7 @@ namespace ReSolve
      * @param[in]  n   - length of the array
      * @param[in]  val - the value the array is set to
      * @param[out] arr - a pointer to the array
-     * 
+     *
      * @pre  `arr` is allocated to size `n`
      * @post `arr` elements are set to `val`
      */
@@ -36,6 +36,25 @@ namespace ReSolve
       }
     }
 
+    /**
+     * @brief CUDA kernel that adds a constant to each element of an array.
+     *
+     * @param[in, out]  arr - a pointer to the array
+     * @param[in]       val - the value to add to each element
+     * @param[in]       n   - length of the array
+     *
+     * @pre  `arr` is allocated to size `n`
+     * @post `val` is added to each element of `arr`
+     */
+    __global__ void addConst(real_type* arr, real_type val, index_type n)
+    {
+      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+      if(i < n)
+      {
+        arr[i] += val;
+      }
+    }
+
   } // namespace kernels
 
   void cuda_set_array_const(index_type n, real_type val, real_type* arr)
@@ -44,5 +63,13 @@ namespace ReSolve
     index_type block_size = 512;
     num_blocks = (n + block_size - 1) / block_size;
     kernels::set_const<<<num_blocks, block_size>>>(n, val, arr);
+  }
+
+  void cudaAddConst(real_type* arr, real_type val, index_type n)
+  {
+    index_type num_blocks;
+    index_type block_size = 512;
+    num_blocks = (n + block_size - 1) / block_size;
+    kernels::addConst<<<num_blocks, block_size>>>(arr, val, n);
   }
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -39,14 +39,14 @@ namespace ReSolve
     /**
      * @brief CUDA kernel that adds a constant to each element of an array.
      *
-     * @param[in, out]  arr - a pointer to the array
-     * @param[in]       val - the value to add to each element
      * @param[in]       n   - length of the array
+     * @param[in]       val - the value to add to each element
+     * @param[in, out]  arr - a pointer to the array
      *
      * @pre  `arr` is allocated to size `n`
      * @post `val` is added to each element of `arr`
      */
-    __global__ void addConst(real_type* arr, real_type val, index_type n)
+    __global__ void addConst(index_type n, real_type val, real_type* arr)
     {
       index_type i = blockIdx.x * blockDim.x + threadIdx.x;
       if(i < n)
@@ -65,11 +65,11 @@ namespace ReSolve
     kernels::set_const<<<num_blocks, block_size>>>(n, val, arr);
   }
 
-  void cudaAddConst(real_type* arr, real_type val, index_type n)
+  void cudaAddConst(index_type n, real_type val, real_type* arr)
   {
     index_type num_blocks;
     index_type block_size = 512;
     num_blocks = (n + block_size - 1) / block_size;
-    kernels::addConst<<<num_blocks, block_size>>>(arr, val, n);
+    kernels::addConst<<<num_blocks, block_size>>>(n, val, arr);
   }
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -14,5 +14,5 @@
 namespace ReSolve
 {
   void cuda_set_array_const(index_type n, real_type val, real_type* arr);
-  void cudaAddConst(real_type* arr, real_type val, index_type n);
+  void cudaAddConst(index_type n, real_type val, real_type* arr);
 }

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -3,7 +3,7 @@
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Contains declarations of CUDA vector kernel wrappers.
  * @date 2023-12-08
- * 
+ *
  * @note Kernel wrappers implemented here are intended for use in hardware
  * agnostic code.
  */
@@ -14,4 +14,5 @@
 namespace ReSolve
 {
   void cuda_set_array_const(index_type n, real_type val, real_type* arr);
+  void cudaAddConst(real_type* arr, real_type val, index_type n);
 }

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -14,4 +14,5 @@
 namespace ReSolve
 {
   void hip_set_array_const(index_type n, real_type c, real_type* v);
+  void hipAddConst(real_type* array, real_type val, index_type n);
 }

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -3,7 +3,7 @@
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Contains declaration of HIP vector kernels.
  * @date 2023-12-08
- * 
+ *
  * @note Kernel wrappers implemented here are intended for use in hardware
  * agnostic code.
  */
@@ -14,5 +14,5 @@
 namespace ReSolve
 {
   void hip_set_array_const(index_type n, real_type c, real_type* v);
-  void hipAddConst(real_type* array, real_type val, index_type n);
+  void hipAddConst(index_type n, real_type val, real_type* arr);
 }

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -3,7 +3,7 @@
  * @author Slaven Peles (peless@ornl.gov), Shaked Regev (regevs@ornl.gov)
  * @brief Contains implementation of HIP vector kernels.
  * @date 2023-12-08
- * 
+ *
  * @note Kernel wrappers implemented here are intended for use in hardware
  * agnostic code.
  */
@@ -30,14 +30,14 @@ namespace ReSolve {
     /**
      * @brief HIP kernel that adds a constant to each element of an array.
      *
-     * @param[in, out]  arr - a pointer to the array
-     * @param[in]       val - the value to add to each element
      * @param[in]       n   - length of the array
+     * @param[in]       val - the value to add to each element
+     * @param[in, out]  arr - a pointer to the array
      *
      * @pre  `arr` is allocated to size `n`
      * @post `val` is added to each element of `arr`
      */
-    __global__ void addConst(real_type* arr, real_type val, index_type n)
+    __global__ void addConst(index_type n, real_type val, real_type* arr)
     {
       index_type i = blockIdx.x * blockDim.x + threadIdx.x;
       if(i < n)
@@ -55,12 +55,12 @@ namespace ReSolve {
     hipLaunchKernelGGL(kernels::set_array_to_const, dim3(num_blocks), dim3(block_size), 0, 0, n, c, v);
   }
 
-  void hipAddConst(real_type* arr, real_type val, index_type n)
+  void hipAddConst(index_type n, real_type val, real_type* arr)
   {
     index_type num_blocks;
     index_type block_size = 512;
     num_blocks = (n + block_size - 1) / block_size;
-    hipLaunchKernelGGL(kernels::addConst, dim3(num_blocks), dim3(block_size), 0, 0, arr, val, n);
+    hipLaunchKernelGGL(kernels::addConst, dim3(num_blocks), dim3(block_size), 0, 0, n, val, arr);
   }
 
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -1,6 +1,7 @@
 /**
  * @file hipVectorKernels.hip
- * @author Slaven Peles (peless@ornl.gov), Shaked Regev (regevs@ornl.gov)
+ * @author Slaven Peles (peless@ornl.gov)
+ * @author Shaked Regev (regevs@ornl.gov)
  * @brief Contains implementation of HIP vector kernels.
  * @date 2023-12-08
  *

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -1,6 +1,6 @@
 /**
  * @file hipVectorKernels.hip
- * @author Slaven Peles (peless@ornl.gov)
+ * @author Slaven Peles (peless@ornl.gov), Shaked Regev (regevs@ornl.gov)
  * @brief Contains implementation of HIP vector kernels.
  * @date 2023-12-08
  * 
@@ -26,6 +26,25 @@ namespace ReSolve {
         i += blockDim.x * gridDim.x;
       }
     }
+
+    /**
+     * @brief HIP kernel that adds a constant to each element of an array.
+     *
+     * @param[in, out]  arr - a pointer to the array
+     * @param[in]       val - the value to add to each element
+     * @param[in]       n   - length of the array
+     *
+     * @pre  `arr` is allocated to size `n`
+     * @post `val` is added to each element of `arr`
+     */
+    __global__ void addConst(real_type* arr, real_type val, index_type n)
+    {
+      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+      if(i < n)
+      {
+        arr[i] += val;
+      }
+    }
   } // namespace kernels
 
   void hip_set_array_const(index_type n, real_type c, real_type* v)
@@ -34,6 +53,14 @@ namespace ReSolve {
     index_type block_size = 512;
     num_blocks = (n + block_size - 1) / block_size;
     hipLaunchKernelGGL(kernels::set_array_to_const, dim3(num_blocks), dim3(block_size), 0, 0, n, c, v);
+  }
+
+  void hipAddConst(real_type* arr, real_type val, index_type n)
+  {
+    index_type num_blocks;
+    index_type block_size = 512;
+    num_blocks = (n + block_size - 1) / block_size;
+    hipLaunchKernelGGL(kernels::addConst, dim3(num_blocks), dim3(block_size), 0, 0, arr, val, n);
   }
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -214,38 +214,18 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandler::transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace, bool allocated)
+  int MatrixHandler::transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->transpose(A, At, allocated);
+        return cpuImpl_->transpose(A, At);
         break;
       case DEVICE:
-        return devImpl_->transpose(A, At, allocated);
+        return devImpl_->transpose(A, At);
         break;
     }
     return 1;
-  }
-
-  /**
-   * @brief Add a constant to the nonzero values of a csr matrix.
-   * @param[in,out] A - Sparse matrix
-   * @param[in] alpha - scalar parameter
-   * @param[in] memspace - Device where the operation is computed
-   * @return 0 if successful, 1 otherwise
-   */
-  void MatrixHandler::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace)
-  {
-    using namespace ReSolve::memory;
-    switch (memspace) {
-      case HOST:
-        cpuImpl_->addConstantToNonzeroValues(A, alpha);
-        break;
-      case DEVICE:
-        devImpl_->addConstantToNonzeroValues(A, alpha);
-        break;
-    }
   }
 
   /**

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -214,15 +214,15 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandler::transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace)
+  int MatrixHandler::transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace, bool allocated)
   {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->transpose(A, At);
+        return cpuImpl_->transpose(A, At, allocated);
         break;
       case DEVICE:
-        return devImpl_->transpose(A, At);
+        return devImpl_->transpose(A, At, allocated);
         break;
     }
     return 1;

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -229,6 +229,26 @@ namespace ReSolve {
   }
 
   /**
+   * @brief Add a constant to the nonzero values of a csr matrix.
+   * @param[in,out] A - Sparse matrix
+   * @param[in] alpha - scalar parameter
+   * @param[in] memspace - Device where the operation is computed
+   * @return 0 if successful, 1 otherwise
+   */
+  void MatrixHandler::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace)
+  {
+    using namespace ReSolve::memory;
+    switch (memspace) {
+      case HOST:
+        cpuImpl_->addConstantToNonzeroValues(A, alpha);
+        break;
+      case DEVICE:
+        devImpl_->addConstantToNonzeroValues(A, alpha);
+        break;
+    }
+  }
+
+  /**
    * @brief If CUDA support is enabled in the handler.
    *
    * @return true

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -217,19 +217,27 @@ namespace ReSolve {
   int MatrixHandler::transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
+    // check dimensions of A and At and if both are allocated
+    assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
+    assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
+    assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
+    assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+          "Matrix has to be in CSR format for transpose.\n");
+    assert(At->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+          "Matrix has to be in CSR format for transpose.\n");
     switch (memspace) {
       case HOST:
+        if(A->getValues(memory::HOST) == nullptr) {
+          out::error() << "In MatrixHandler::transpose, A->getValues(memory::HOST) is null!\n";
+          return 1;
+        }
+        if(At->getValues(memory::HOST) == nullptr) {
+          out::error() << "In MatrixHandler::transpose, At->getValues(memory::HOST) is null!\n";
+          return 1;
+        }
         return cpuImpl_->transpose(A, At);
         break;
       case DEVICE:
-            // check dimensions of A and At and if both are allocated
-        assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
-        assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
-        assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
-        assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
-              "Matrix has to be in CSR format for transpose.\n");
-        assert(At->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
-              "Matrix has to be in CSR format for transpose.\n");
         if(A->getValues(memory::DEVICE) == nullptr) {
           out::error() << "In MatrixHandlerCuda::transpose, A->getValues(memory::DEVICE) is null!\n";
           return 1;

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -1,5 +1,5 @@
 #include <algorithm>
-
+#include <cassert>
 #include <resolve/utilities/logger/Logger.hpp>
 #include <resolve/vector/Vector.hpp>
 #include <resolve/matrix/Coo.hpp>
@@ -222,6 +222,22 @@ namespace ReSolve {
         return cpuImpl_->transpose(A, At);
         break;
       case DEVICE:
+            // check dimensions of A and At and if both are allocated
+        assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
+        assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
+        assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
+        assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+              "Matrix has to be in CSR format for transpose.\n");
+        assert(At->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
+              "Matrix has to be in CSR format for transpose.\n");
+        if(A->getValues(memory::DEVICE) == nullptr) {
+          out::error() << "In MatrixHandlerCuda::transpose, A->getValues(memory::DEVICE) is null!\n";
+          return 1;
+        }
+        if(At->getValues(memory::DEVICE) == nullptr) {
+          out::error() << "In MatrixHandlerCuda::transpose, At->getValues(memory::DEVICE) is null!\n";
+          return 1;
+        }
         return devImpl_->transpose(A, At);
         break;
     }

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -214,15 +214,15 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandler::transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace, bool allocated)
+  int MatrixHandler::transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->transpose(A, At, allocated);
+        return cpuImpl_->transpose(A, At);
         break;
       case DEVICE:
-        return devImpl_->transpose(A, At, allocated);
+        return devImpl_->transpose(A, At);
         break;
     }
     return 1;

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -186,7 +186,7 @@ namespace ReSolve {
    * @pre `A_csr` is allocated (but not prefilled) and has the correct CSR format.
    * @pre `A_csc` and `A_csr` are of the same size and have the same number of
    * nonzeros.
-   * 
+   *
    * @post `A_csr` is filled with the values from `A_csc`
    *
    * @return 0 if successful, 1 otherwise
@@ -235,15 +235,15 @@ namespace ReSolve {
    * @param[in] memspace - Device where the operation is computed
    * @return 0 if successful, 1 otherwise
    */
-  void MatrixHandler::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace)
+  void MatrixHandler::addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        cpuImpl_->addConstantToNonzeroValues(A, alpha);
+        cpuImpl_->addConst(A, alpha);
         break;
       case DEVICE:
-        devImpl_->addConstantToNonzeroValues(A, alpha);
+        devImpl_->addConst(A, alpha);
         break;
     }
   }

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -56,7 +56,7 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace);
 
-      void addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
+      void addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
 
       /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped
       int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -56,6 +56,8 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace, bool allocated = false);
 
+      void addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
+
       /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped
       int matvec(matrix::Sparse* A,
                  vector_type* vec_x,

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -54,9 +54,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr, memory::MemorySpace memspace);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace, bool allocated = false);
-
-      void addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
+      int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace);
 
       /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped
       int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -54,7 +54,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr, memory::MemorySpace memspace);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace, bool allocated = false);
+      int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace);
 
       void addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
 

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -54,7 +54,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr, memory::MemorySpace memspace);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace);
+      int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace, bool allocated = false);
 
       /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped
       int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -233,6 +233,8 @@ namespace ReSolve
    */
   int MatrixHandlerCpu::transpose(matrix::Csr* A, matrix::Csr* At)
   {
+    assert(A->getValues(memory::HOST) != nullptr && "Matrix A is not allocated on host.\n");
+    assert(At->getValues(memory::HOST) != nullptr && "Matrix At is not allocated on host.\n");
     index_type n = A->getNumRows();
     index_type m = A->getNumColumns();
     index_type nnz = A->getNnz();
@@ -242,6 +244,10 @@ namespace ReSolve
     index_type* rowPtrAt = At->getRowData(memory::HOST);
     index_type* colIdxAt = At->getColData(memory::HOST);
     real_type*  valuesAt = At->getValues( memory::HOST);
+    // Check dimensions of A and At
+    assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
+    assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
+    assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
     // Set all CSR row pointers to zero
     for (index_type i = 0; i <= m; ++i) {
       rowPtrAt[i] = 0;

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -244,10 +244,6 @@ namespace ReSolve
     index_type* rowPtrAt = At->getRowData(memory::HOST);
     index_type* colIdxAt = At->getColData(memory::HOST);
     real_type*  valuesAt = At->getValues( memory::HOST);
-    // Check dimensions of A and At
-    assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
-    assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
-    assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
     // Set all CSR row pointers to zero
     for (index_type i = 0; i <= m; ++i) {
       rowPtrAt[i] = 0;

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -231,26 +231,30 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCpu::transpose(matrix::Csr* A, matrix::Csr* At)
+  int MatrixHanlderCpu::transpose(matrix::Csr* A, matrix::Csr* At)
   {
-    assert(A->getNnz() == At->getNnz());
     assert(A->getNumRows() == At->getNumColumns());
     assert(A->getNumColumns() == At->getNumRows());
+    assert(A->getNnz() == At->getNnz());
+
+    index_type* rowPtrA = A->getRowData(memory::HOST);
+    index_type* colIdxA = A->getColData(memory::HOST);
+    real_type*  valuesA = A->getValues(memory::HOST);
+
+    index_type* rowPtrAt = At->getRowData(memory::HOST);
+    index_type* colIdxAt = At->getColData(memory::HOST);
+    real_type*  valuesAt = At->getValues(memory::HOST);
 
     index_type n = A->getNumRows();
     index_type m = A->getNumColumns();
     index_type nnz = A->getNnz();
-    index_type* rowPtrA = A->getRowData(memory::HOST);
-    index_type* colIdxA = A->getColData(memory::HOST);
-    real_type*  valuesA = A->getValues( memory::HOST);
-    index_type* rowPtrAt = At->getRowData(memory::HOST);
-    index_type* colIdxAt = At->getColData(memory::HOST);
-    real_type*  valuesAt = At->getValues( memory::HOST);
-    // Set all CSR row pointers to zero
+
+    // Set all At row pointers to zero
     for (index_type i = 0; i <= m; ++i) {
       rowPtrAt[i] = 0;
     }
-    // Set all CSR values and column indices to zero
+
+    // Set all At values and column indices to zero
     for (index_type i = 0; i < nnz; ++i) {
       colIdxAt[i] = 0;
       valuesAt[i] = 0.0;
@@ -260,6 +264,7 @@ namespace ReSolve
     for (index_type i = 0; i < nnz; ++i) {
       rowPtrAt[colIdxA[i]]++;
     }
+
     // Compute cumualtive sum of nnz per row
     for (index_type row = 0, rowsum = 0; row < m; ++row) {
       // Store value in row pointer to temp
@@ -272,28 +277,30 @@ namespace ReSolve
       rowsum += temp;
     }
     rowPtrAt[m] = nnz;
+
     for (index_type col = 0; col < n; ++col) {
       // Compute positions of column indices and values in CSR matrix and store them there
       // Overwrites CSR row pointers in the process
       for (index_type jj = rowPtrA[col]; jj < rowPtrA[col+1]; jj++) {
         index_type row  = colIdxA[jj];
         index_type dest = rowPtrAt[row];
-
         colIdxAt[dest] = col;
         valuesAt[dest] = valuesA[jj];
-
         rowPtrAt[row]++;
       }
     }
+
     // Restore CSR row pointer values
     for (index_type row = 0, last = 0; row <= m; row++) {
         index_type temp  = rowPtrAt[row];
         rowPtrAt[row] = last;
         last    = temp;
     }
+
     // Values on the host are updated now -- mark them as such!
     At->setUpdated(memory::HOST);
 
     return 0;
   }
+
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -305,7 +305,7 @@ namespace ReSolve
    *
    * @return int error code, 0 if successful
    */
-  int MatrixHandlerCpu::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
+  int MatrixHandlerCpu::addConst(matrix::Sparse* A, real_type alpha)
   {
     real_type* values = A->getValues(memory::HOST);
     index_type nnz = A->getNnz();

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -231,93 +231,76 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCpu::transpose(matrix::Csr* A, matrix::Csr* At, bool allocated)
+  int MatrixHanlderCpu::transpose(matrix::Csr* A, matrix::Csr* At)
   {
-    if (!allocated) {
-      assert(A->getNnz() == At->getNnz());
-      assert(A->getNumRows() == At->getNumColumns());
-      assert(A->getNumColumns() == At->getNumRows());
-    }
+    assert(A->getNumRows() == At->getNumColumns());
+    assert(A->getNumColumns() == At->getNumRows());
+    assert(A->getNnz() == At->getNnz());
+
+    index_type* rowPtrA = A->getRowData(memory::HOST);
+    index_type* colIdxA = A->getColData(memory::HOST);
+    real_type*  valuesA = A->getValues(memory::HOST);
+
+    index_type* rowPtrAt = At->getRowData(memory::HOST);
+    index_type* colIdxAt = At->getColData(memory::HOST);
+    real_type*  valuesAt = At->getValues(memory::HOST);
 
     index_type n = A->getNumRows();
     index_type m = A->getNumColumns();
     index_type nnz = A->getNnz();
 
-    index_type* rowPtrA = A->getRowData(memory::HOST);
-    index_type* colIdxA = A->getColData(memory::HOST);
-    real_type* valuesA = A->getValues(memory::HOST);
-
-    index_type* rowPtrAt = At->getRowData(memory::HOST);
-    index_type* colIdxAt = At->getColData(memory::HOST);
-    real_type* valuesAt = At->getValues(memory::HOST);
-
-    if (!allocated) {
-        // Set all CSR row pointers to zero
-        for (index_type i = 0; i <= m; ++i) {
-            rowPtrAt[i] = 0;
-        }
-
-        // Set all CSR values and column indices to zero
-        for (index_type i = 0; i < nnz; ++i) {
-            colIdxAt[i] = 0;
-            valuesAt[i] = 0.0;
-        }
-
-        // Compute number of entries per row
-        for (index_type i = 0; i < nnz; ++i) {
-            rowPtrAt[colIdxA[i]]++;
-        }
-
-        // Compute cumulative sum of nnz per row
-        for (index_type row = 0, rowsum = 0; row < m; ++row) {
-            // Store value in row pointer to temp
-            index_type temp = rowPtrAt[row];
-            // Copy cumulative sum to the row pointer
-            rowPtrAt[row] = rowsum;
-            // Update row sum
-            rowsum += temp;
-        }
-        rowPtrAt[m] = nnz;
-    }
-
-    // Create a copy of rowPtrAt for iterating through the matrix
-    std::vector<index_type> rowPtrCopy(m + 1);
+    // Set all At row pointers to zero
     for (index_type i = 0; i <= m; ++i) {
-        rowPtrCopy[i] = rowPtrAt[i];
+      rowPtrAt[i] = 0;
     }
+
+    // Set all At values and column indices to zero
+    for (index_type i = 0; i < nnz; ++i) {
+      colIdxAt[i] = 0;
+      valuesAt[i] = 0.0;
+    }
+
+    // Compute number of entries per row
+    for (index_type i = 0; i < nnz; ++i) {
+      rowPtrAt[colIdxA[i]]++;
+    }
+
+    // Compute cumualtive sum of nnz per row
+    for (index_type row = 0, rowsum = 0; row < m; ++row) {
+      // Store value in row pointer to temp
+      index_type temp  = rowPtrAt[row];
+
+      // Copy cumulative sum to the row pointer
+      rowPtrAt[row] = rowsum;
+
+      // Update row sum
+      rowsum += temp;
+    }
+    rowPtrAt[m] = nnz;
 
     for (index_type col = 0; col < n; ++col) {
-        // Compute positions of column indices and values in CSR matrix and store them there
-        for (index_type jj = rowPtrA[col]; jj < rowPtrA[col+1]; jj++) {
-            index_type row = colIdxA[jj];
-            index_type dest = rowPtrCopy[row];
-            if (!allocated) {
-              colIdxAt[dest] = col;
-            }
-            valuesAt[dest] = valuesA[jj];
-            rowPtrCopy[row]++;
-        }
+      // Compute positions of column indices and values in CSR matrix and store them there
+      // Overwrites CSR row pointers in the process
+      for (index_type jj = rowPtrA[col]; jj < rowPtrA[col+1]; jj++) {
+        index_type row  = colIdxA[jj];
+        index_type dest = rowPtrAt[row];
+        colIdxAt[dest] = col;
+        valuesAt[dest] = valuesA[jj];
+        rowPtrAt[row]++;
+      }
+    }
+
+    // Restore CSR row pointer values
+    for (index_type row = 0, last = 0; row <= m; row++) {
+        index_type temp  = rowPtrAt[row];
+        rowPtrAt[row] = last;
+        last    = temp;
     }
 
     // Values on the host are updated now -- mark them as such!
     At->setUpdated(memory::HOST);
+
     return 0;
   }
 
-  /**
-   * @brief Add a constant to the nonzero values of a matrix
-   *
-   * @param[in, out] A - matrix
-   * @param[in] alpha - constant to add
-   */
-  int MatrixHandlerCpu::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
-  {
-    using memory::HOST;
-    real_type* values = A->getValues(HOST);
-    for (index_type i = 0; i < A->getNnz(); ++i) {
-      values[i] += alpha;
-    }
-    A->setUpdated(HOST);
-    return 0;
-  }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -260,7 +260,6 @@ namespace ReSolve
     for (index_type i = 0; i < nnz; ++i) {
       rowPtrAt[colIdxA[i]]++;
     }
-    std::cout << "Computed number of entries per row\n";
     // Compute cumualtive sum of nnz per row
     for (index_type row = 0, rowsum = 0; row < m; ++row) {
       // Store value in row pointer to temp
@@ -273,7 +272,6 @@ namespace ReSolve
       rowsum += temp;
     }
     rowPtrAt[m] = nnz;
-    std::cout << "Resulting rowPtrAt: \n";
     for (index_type col = 0; col < n; ++col) {
       // Compute positions of column indices and values in CSR matrix and store them there
       // Overwrites CSR row pointers in the process
@@ -287,14 +285,12 @@ namespace ReSolve
         rowPtrAt[row]++;
       }
     }
-    std::cout<< "Resulting rowPtrAt: \n";
     // Restore CSR row pointer values
     for (index_type row = 0, last = 0; row <= m; row++) {
         index_type temp  = rowPtrAt[row];
         rowPtrAt[row] = last;
         last    = temp;
     }
-    std::cout << "Transposed matrix:\n";
     // Values on the host are updated now -- mark them as such!
     At->setUpdated(memory::HOST);
 

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -233,10 +233,6 @@ namespace ReSolve
    */
   int MatrixHandlerCpu::transpose(matrix::Csr* A, matrix::Csr* At)
   {
-    assert(A->getNnz() == At->getNnz());
-    assert(A->getNumRows() == At->getNumColumns());
-    assert(A->getNumColumns() == At->getNumRows());
-
     index_type n = A->getNumRows();
     index_type m = A->getNumColumns();
     index_type nnz = A->getNnz();

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -231,69 +231,76 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCpu::transpose(matrix::Csr* A, matrix::Csr* At)
+  int MatrixHandlerCpu::transpose(matrix::Csr* A, matrix::Csr* At, bool allocated)
   {
-    assert(A->getNnz() == At->getNnz());
-    assert(A->getNumRows() == At->getNumColumns());
-    assert(A->getNumColumns() == At->getNumRows());
+    if (!allocated) {
+      assert(A->getNnz() == At->getNnz());
+      assert(A->getNumRows() == At->getNumColumns());
+      assert(A->getNumColumns() == At->getNumRows());
+    }
 
     index_type n = A->getNumRows();
     index_type m = A->getNumColumns();
     index_type nnz = A->getNnz();
+
     index_type* rowPtrA = A->getRowData(memory::HOST);
     index_type* colIdxA = A->getColData(memory::HOST);
-    real_type*  valuesA = A->getValues( memory::HOST);
+    real_type* valuesA = A->getValues(memory::HOST);
+
     index_type* rowPtrAt = At->getRowData(memory::HOST);
     index_type* colIdxAt = At->getColData(memory::HOST);
-    real_type*  valuesAt = At->getValues( memory::HOST);
-    // Set all CSR row pointers to zero
+    real_type* valuesAt = At->getValues(memory::HOST);
+
+    if (!allocated) {
+        // Set all CSR row pointers to zero
+        for (index_type i = 0; i <= m; ++i) {
+            rowPtrAt[i] = 0;
+        }
+
+        // Set all CSR values and column indices to zero
+        for (index_type i = 0; i < nnz; ++i) {
+            colIdxAt[i] = 0;
+            valuesAt[i] = 0.0;
+        }
+
+        // Compute number of entries per row
+        for (index_type i = 0; i < nnz; ++i) {
+            rowPtrAt[colIdxA[i]]++;
+        }
+
+        // Compute cumulative sum of nnz per row
+        for (index_type row = 0, rowsum = 0; row < m; ++row) {
+            // Store value in row pointer to temp
+            index_type temp = rowPtrAt[row];
+            // Copy cumulative sum to the row pointer
+            rowPtrAt[row] = rowsum;
+            // Update row sum
+            rowsum += temp;
+        }
+        rowPtrAt[m] = nnz;
+    }
+
+    // Create a copy of rowPtrAt for iterating through the matrix
+    std::vector<index_type> rowPtrCopy(m + 1);
     for (index_type i = 0; i <= m; ++i) {
-      rowPtrAt[i] = 0;
-    }
-    // Set all CSR values and column indices to zero
-    for (index_type i = 0; i < nnz; ++i) {
-      colIdxAt[i] = 0;
-      valuesAt[i] = 0.0;
+        rowPtrCopy[i] = rowPtrAt[i];
     }
 
-    // Compute number of entries per row
-    for (index_type i = 0; i < nnz; ++i) {
-      rowPtrAt[colIdxA[i]]++;
-    }
-    // Compute cumualtive sum of nnz per row
-    for (index_type row = 0, rowsum = 0; row < m; ++row) {
-      // Store value in row pointer to temp
-      index_type temp  = rowPtrAt[row];
-
-      // Copy cumulative sum to the row pointer
-      rowPtrAt[row] = rowsum;
-
-      // Update row sum
-      rowsum += temp;
-    }
-    rowPtrAt[m] = nnz;
     for (index_type col = 0; col < n; ++col) {
-      // Compute positions of column indices and values in CSR matrix and store them there
-      // Overwrites CSR row pointers in the process
-      for (index_type jj = rowPtrA[col]; jj < rowPtrA[col+1]; jj++) {
-        index_type row  = colIdxA[jj];
-        index_type dest = rowPtrAt[row];
-
-        colIdxAt[dest] = col;
-        valuesAt[dest] = valuesA[jj];
-
-        rowPtrAt[row]++;
-      }
+        // Compute positions of column indices and values in CSR matrix and store them there
+        for (index_type jj = rowPtrA[col]; jj < rowPtrA[col+1]; jj++) {
+            index_type row = colIdxA[jj];
+            index_type dest = rowPtrCopy[row];
+            if (!allocated) {
+              colIdxAt[dest] = col;
+            }
+            valuesAt[dest] = valuesA[jj];
+            rowPtrCopy[row]++;
+        }
     }
-    // Restore CSR row pointer values
-    for (index_type row = 0, last = 0; row <= m; row++) {
-        index_type temp  = rowPtrAt[row];
-        rowPtrAt[row] = last;
-        last    = temp;
-    }
+
     // Values on the host are updated now -- mark them as such!
     At->setUpdated(memory::HOST);
-
     return 0;
   }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -231,30 +231,26 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHanlderCpu::transpose(matrix::Csr* A, matrix::Csr* At)
+  int MatrixHandlerCpu::transpose(matrix::Csr* A, matrix::Csr* At)
   {
+    assert(A->getNnz() == At->getNnz());
     assert(A->getNumRows() == At->getNumColumns());
     assert(A->getNumColumns() == At->getNumRows());
-    assert(A->getNnz() == At->getNnz());
-
-    index_type* rowPtrA = A->getRowData(memory::HOST);
-    index_type* colIdxA = A->getColData(memory::HOST);
-    real_type*  valuesA = A->getValues(memory::HOST);
-
-    index_type* rowPtrAt = At->getRowData(memory::HOST);
-    index_type* colIdxAt = At->getColData(memory::HOST);
-    real_type*  valuesAt = At->getValues(memory::HOST);
 
     index_type n = A->getNumRows();
     index_type m = A->getNumColumns();
     index_type nnz = A->getNnz();
-
-    // Set all At row pointers to zero
+    index_type* rowPtrA = A->getRowData(memory::HOST);
+    index_type* colIdxA = A->getColData(memory::HOST);
+    real_type*  valuesA = A->getValues( memory::HOST);
+    index_type* rowPtrAt = At->getRowData(memory::HOST);
+    index_type* colIdxAt = At->getColData(memory::HOST);
+    real_type*  valuesAt = At->getValues( memory::HOST);
+    // Set all CSR row pointers to zero
     for (index_type i = 0; i <= m; ++i) {
       rowPtrAt[i] = 0;
     }
-
-    // Set all At values and column indices to zero
+    // Set all CSR values and column indices to zero
     for (index_type i = 0; i < nnz; ++i) {
       colIdxAt[i] = 0;
       valuesAt[i] = 0.0;
@@ -264,7 +260,7 @@ namespace ReSolve
     for (index_type i = 0; i < nnz; ++i) {
       rowPtrAt[colIdxA[i]]++;
     }
-
+    std::cout << "Computed number of entries per row\n";
     // Compute cumualtive sum of nnz per row
     for (index_type row = 0, rowsum = 0; row < m; ++row) {
       // Store value in row pointer to temp
@@ -277,30 +273,31 @@ namespace ReSolve
       rowsum += temp;
     }
     rowPtrAt[m] = nnz;
-
+    std::cout << "Resulting rowPtrAt: \n";
     for (index_type col = 0; col < n; ++col) {
       // Compute positions of column indices and values in CSR matrix and store them there
       // Overwrites CSR row pointers in the process
       for (index_type jj = rowPtrA[col]; jj < rowPtrA[col+1]; jj++) {
         index_type row  = colIdxA[jj];
         index_type dest = rowPtrAt[row];
+
         colIdxAt[dest] = col;
         valuesAt[dest] = valuesA[jj];
+
         rowPtrAt[row]++;
       }
     }
-
+    std::cout<< "Resulting rowPtrAt: \n";
     // Restore CSR row pointer values
     for (index_type row = 0, last = 0; row <= m; row++) {
         index_type temp  = rowPtrAt[row];
         rowPtrAt[row] = last;
         last    = temp;
     }
-
+    std::cout << "Transposed matrix:\n";
     // Values on the host are updated now -- mark them as such!
     At->setUpdated(memory::HOST);
 
     return 0;
   }
-
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -303,4 +303,21 @@ namespace ReSolve
     At->setUpdated(memory::HOST);
     return 0;
   }
+
+  /**
+   * @brief Add a constant to the nonzero values of a matrix
+   *
+   * @param[in, out] A - matrix
+   * @param[in] alpha - constant to add
+   */
+  int MatrixHandlerCpu::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
+  {
+    using memory::HOST;
+    real_type* values = A->getValues(HOST);
+    for (index_type i = 0; i < A->getNnz(); ++i) {
+      values[i] += alpha;
+    }
+    A->setUpdated(HOST);
+    return 0;
+  }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -37,7 +37,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
+      int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
       int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
 

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -39,6 +39,8 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
 
+      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
+
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -39,7 +39,7 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
-      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
+      int addConst(matrix::Sparse* A, real_type alpha);
 
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -37,9 +37,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
-
-      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
+      int transpose(matrix::Csr* A, matrix::Csr* At);
 
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -37,7 +37,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At);
+      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
 
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -287,11 +287,7 @@ namespace ReSolve {
       assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
       assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
 
-      At->allocateMatrixData(memory::DEVICE);
-
       size_t bufferSize;
-
-
       status = cusparseCsr2cscEx2_bufferSize(workspace_->getCusparseHandle(),
                                              m,
                                              n,

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -275,8 +275,8 @@ namespace ReSolve {
     index_type error_sum = 0;
 
     At->allocateMatrixData(memory::DEVICE);
-    index_type m = A->getNumRows();
-    index_type n = A->getNumColumns();
+    index_type m = A->getNumColumns();
+    index_type n = A->getNumRows();
     index_type nnz = A->getNnz();
 
     // check dimensions of A and At
@@ -290,11 +290,11 @@ namespace ReSolve {
                                                             n,
                                                             nnz,
                                                             A->getValues( memory::DEVICE),
-                                                            A->getRowData(memory::DEVICE),
                                                             A->getColData(memory::DEVICE),
+                                                            A->getRowData(memory::DEVICE),
                                                             At->getValues( memory::DEVICE),
-                                                            At->getRowData(memory::DEVICE),
                                                             At->getColData(memory::DEVICE),
+                                                            At->getRowData(memory::DEVICE),
                                                             CUDA_R_64F,
                                                             CUSPARSE_ACTION_NUMERIC,
                                                             CUSPARSE_INDEX_BASE_ZERO,
@@ -302,17 +302,16 @@ namespace ReSolve {
                                                             &bufferSize);
     error_sum += status;
     mem_.allocateBufferOnDevice(&d_work, bufferSize);
-
     status = cusparseCsr2cscEx2(workspace_->getCusparseHandle(),
                                 m,
                                 n,
                                 nnz,
                                 A->getValues( memory::DEVICE),
-                                A->getRowData(memory::DEVICE),
                                 A->getColData(memory::DEVICE),
+                                A->getRowData(memory::DEVICE),
                                 At->getValues( memory::DEVICE),
-                                At->getRowData(memory::DEVICE),
                                 At->getColData(memory::DEVICE),
+                                At->getRowData(memory::DEVICE),
                                 CUDA_R_64F,
                                 CUSPARSE_ACTION_NUMERIC,
                                 CUSPARSE_INDEX_BASE_ZERO,
@@ -329,7 +328,6 @@ namespace ReSolve {
     At->setUpdated(memory::DEVICE);
 
     return error_sum;
-
   }
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -270,17 +270,17 @@ namespace ReSolve {
    *
    * @param[in, out]  A - Sparse matrix
    * @param[out] At - Transposed matrix
-   * @param[in]  allocated - flag indicating if At is already allocated
    *
    * @return int error_sum, 0 if successful
    */
-  int MatrixHandlerCuda::transpose(matrix::Csr* A, matrix::Csr* At, bool allocated)
+  int MatrixHandlerCuda::transpose(matrix::Csr* A, matrix::Csr* At)
   {
     index_type error_sum = 0;
     index_type m = A->getNumRows();
     index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
     cusparseStatus_t status;
+    bool allocated = workspace_->isTransposeAllocated();
     void* buffer_transpose = workspace_->getTransposeWorkspace();
     if (!allocated) {
       // check dimensions of A and At
@@ -309,6 +309,7 @@ namespace ReSolve {
                                              &bufferSize);
       error_sum += status;
       mem_.allocateBufferOnDevice(&buffer_transpose, bufferSize);
+      workspace_->setTransposeAllocated();
     }
     status = cusparseCsr2cscEx2(workspace_->getCusparseHandle(),
                                 m,

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -267,11 +267,11 @@ namespace ReSolve {
    * @brief Transpose a sparse CSR matrix.
    *
    * Transpose a sparse CSR matrix A. Only allocates At if not already allocated.
-   * 
+   *
    * @param[in, out]  A - Sparse matrix
    * @param[out] At - Transposed matrix
    * @param[in]  allocated - flag indicating if At is already allocated
-   * 
+   *
    * @return int error_sum, 0 if successful
    */
   int MatrixHandlerCuda::transpose(matrix::Csr* A, matrix::Csr* At, bool allocated)
@@ -333,17 +333,17 @@ namespace ReSolve {
 
   /**
    * @brief Add a constant to all nonzero values in the matrix
-   * 
+   *
    * @param[in, out] A - matrix
    * @param[in] alpha - constant to be added
-   * 
+   *
    * @return int error code, 0 if successful
    */
   int MatrixHandlerCuda::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();
-    cudaAddConst(values, alpha, nnz);
+    cudaAddConst(nnz, alpha, values);
     return 0;
   }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -266,8 +266,12 @@ namespace ReSolve {
   /**
    * @brief Transpose a sparse CSR matrix.
    *
-   * @param[in]  A - Sparse matrix
+   * Transpose a sparse CSR matrix A. Only allocates At if not already allocated.
+   * 
+   * @param[in, out]  A - Sparse matrix
    * @param[out] At - Transposed matrix
+   * @param[in]  allocated - flag indicating if At is already allocated
+   * 
    * @return int error_sum, 0 if successful
    */
   int MatrixHandlerCuda::transpose(matrix::Csr* A, matrix::Csr* At, bool allocated)
@@ -326,6 +330,15 @@ namespace ReSolve {
 
     return error_sum;
   }
+
+  /**
+   * @brief Add a constant to all nonzero values in the matrix
+   * 
+   * @param[in, out] A - matrix
+   * @param[in] alpha - constant to be added
+   * 
+   * @return int error code, 0 if successful
+   */
   int MatrixHandlerCuda::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
   {
     real_type* values = A->getValues(memory::DEVICE);

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -275,8 +275,8 @@ namespace ReSolve {
     index_type error_sum = 0;
 
     At->allocateMatrixData(memory::DEVICE);
-    index_type m = A->getNumColumns();
-    index_type n = A->getNumRows();
+    index_type m = A->getNumRows();
+    index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
 
     // check dimensions of A and At
@@ -290,11 +290,11 @@ namespace ReSolve {
                                                             n,
                                                             nnz,
                                                             A->getValues( memory::DEVICE),
-                                                            A->getColData(memory::DEVICE),
                                                             A->getRowData(memory::DEVICE),
+                                                            A->getColData(memory::DEVICE),
                                                             At->getValues( memory::DEVICE),
-                                                            At->getColData(memory::DEVICE),
                                                             At->getRowData(memory::DEVICE),
+                                                            At->getColData(memory::DEVICE),
                                                             CUDA_R_64F,
                                                             CUSPARSE_ACTION_NUMERIC,
                                                             CUSPARSE_INDEX_BASE_ZERO,
@@ -302,16 +302,17 @@ namespace ReSolve {
                                                             &bufferSize);
     error_sum += status;
     mem_.allocateBufferOnDevice(&d_work, bufferSize);
+
     status = cusparseCsr2cscEx2(workspace_->getCusparseHandle(),
                                 m,
                                 n,
                                 nnz,
                                 A->getValues( memory::DEVICE),
-                                A->getColData(memory::DEVICE),
                                 A->getRowData(memory::DEVICE),
+                                A->getColData(memory::DEVICE),
                                 At->getValues( memory::DEVICE),
-                                At->getColData(memory::DEVICE),
                                 At->getRowData(memory::DEVICE),
+                                At->getColData(memory::DEVICE),
                                 CUDA_R_64F,
                                 CUSPARSE_ACTION_NUMERIC,
                                 CUSPARSE_INDEX_BASE_ZERO,
@@ -328,6 +329,7 @@ namespace ReSolve {
     At->setUpdated(memory::DEVICE);
 
     return error_sum;
+
   }
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -280,7 +280,7 @@ namespace ReSolve {
     index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
     cusparseStatus_t status;
-    bool allocated = workspace_->isTransposeAllocated();
+    bool allocated = workspace_->isTransposeBufferAllocated();
     void* buffer_transpose = workspace_->getTransposeWorkspace();
     if (!allocated) {
       // check dimensions of A and At
@@ -341,7 +341,7 @@ namespace ReSolve {
    *
    * @return int error code, 0 if successful
    */
-  int MatrixHandlerCuda::addConstantToNonzeros(matrix::Sparse* A, real_type alpha)
+  int MatrixHandlerCuda::addConst(matrix::Sparse* A, real_type alpha)
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -275,8 +275,6 @@ namespace ReSolve {
    */
   int MatrixHandlerCuda::transpose(matrix::Csr* A, matrix::Csr* At)
   {
-    assert(A->getValues(memory::DEVICE) != nullptr && "Matrix A is not allocated on device.\n");
-    assert(At->getValues(memory::DEVICE) != nullptr && "Matrix At is not allocated on device.\n");
     index_type error_sum = 0;
     index_type m = A->getNumRows();
     index_type n = A->getNumColumns();
@@ -284,9 +282,6 @@ namespace ReSolve {
     cusparseStatus_t status;
     bool allocated = workspace_->isTransposeBufferAllocated();
     // check dimensions of A and At
-    assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
-    assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
-    assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
     if (!allocated) {
       // allocate transpose buffer
       size_t bufferSize;

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -281,7 +281,7 @@ namespace ReSolve {
     index_type nnz = A->getNnz();
     cusparseStatus_t status;
     bool allocated = workspace_->isTransposeBufferAllocated();
-    void* buffer_transpose = workspace_->getTransposeWorkspace();
+    void* buffer_transpose = workspace_->getTransposeBufferWorkspace();
     if (!allocated) {
       // check dimensions of A and At
       assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -326,7 +326,11 @@ namespace ReSolve {
 
     return error_sum;
   }
-
-
-
+  int MatrixHandlerCuda::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
+  {
+    // real_type* values = A->getValues(memory::DEVICE);
+    // index_type nnz = A->getNnz();
+    // addConstantToNonzeroValuesKernel<<<(nnz + 255) / 256, 256>>>(values, alpha, nnz);
+    return 0;
+  }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -281,6 +281,7 @@ namespace ReSolve {
     index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
     cusparseStatus_t status;
+    void* buffer_transpose = workspace_->getTransposeWorkspace();
     if (!allocated) {
       // check dimensions of A and At
       assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
@@ -307,7 +308,7 @@ namespace ReSolve {
                                              CUSPARSE_CSR2CSC_ALG1,
                                              &bufferSize);
       error_sum += status;
-      mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
+      mem_.allocateBufferOnDevice(&buffer_transpose, bufferSize);
     }
     status = cusparseCsr2cscEx2(workspace_->getCusparseHandle(),
                                 m,
@@ -323,7 +324,7 @@ namespace ReSolve {
                                 CUSPARSE_ACTION_NUMERIC,
                                 CUSPARSE_INDEX_BASE_ZERO,
                                 CUSPARSE_CSR2CSC_ALG1,
-                                transpose_workspace_);
+                                buffer_transpose);
     error_sum += status;
     // Values on the device are updated now -- mark them as such!
     At->setUpdated(memory::DEVICE);

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -327,4 +327,6 @@ namespace ReSolve {
     return error_sum;
   }
 
+
+
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -328,9 +328,9 @@ namespace ReSolve {
   }
   int MatrixHandlerCuda::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
   {
-    // real_type* values = A->getValues(memory::DEVICE);
-    // index_type nnz = A->getNnz();
-    // addConstantToNonzeroValuesKernel<<<(nnz + 255) / 256, 256>>>(values, alpha, nnz);
+    real_type* values = A->getValues(memory::DEVICE);
+    index_type nnz = A->getNnz();
+    cudaAddConst(values, alpha, nnz);
     return 0;
   }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -341,7 +341,7 @@ namespace ReSolve {
    *
    * @return int error code, 0 if successful
    */
-  int MatrixHandlerCuda::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
+  int MatrixHandlerCuda::addConstantToNonzeros(matrix::Sparse* A, real_type alpha)
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -288,10 +288,7 @@ namespace ReSolve {
     assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
     assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
     if (!allocated) {
-      // check dimensions of A and At
-      assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
-      assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
-
+      // allocate transpose buffer
       size_t bufferSize;
       status = cusparseCsr2cscEx2_bufferSize(workspace_->getCusparseHandle(),
                                              m,

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -35,7 +35,7 @@ namespace ReSolve {
       virtual ~MatrixHandlerCuda();
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
-      int transpose(matrix::Csr* A, matrix::Csr* At);
+      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,
@@ -49,6 +49,8 @@ namespace ReSolve {
       bool values_changed_{true}; ///< needed for matvec
 
       MemoryHandler mem_; ///< Device memory manager object
+      void* transpose_workspace_{nullptr};
+
   };
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -35,7 +35,7 @@ namespace ReSolve {
       virtual ~MatrixHandlerCuda();
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
-      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
+      int transpose(matrix::Csr* A, matrix::Csr* At) override;
       int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
@@ -50,7 +50,7 @@ namespace ReSolve {
       bool values_changed_{true}; ///< needed for matvec
 
       MemoryHandler mem_; ///< Device memory manager object
-      void* transpose_workspace_{nullptr};
+
 
   };
 

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -35,8 +35,7 @@ namespace ReSolve {
       virtual ~MatrixHandlerCuda();
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
-      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
-      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
+      int transpose(matrix::Csr* A, matrix::Csr* At);
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -35,7 +35,7 @@ namespace ReSolve {
       virtual ~MatrixHandlerCuda();
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
-      int transpose(matrix::Csr* A, matrix::Csr* At) override;
+      int transpose(matrix::Csr* A, matrix::Csr* At);
       int addConst(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -36,6 +36,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
       int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
+      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -36,7 +36,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
       int transpose(matrix::Csr* A, matrix::Csr* At) override;
-      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
+      int addConst(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -35,7 +35,7 @@ namespace ReSolve {
       virtual ~MatrixHandlerCuda();
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
-      int transpose(matrix::Csr* A, matrix::Csr* At);
+      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -257,7 +257,7 @@ namespace ReSolve {
     index_type nnz = A->getNnz();
     rocsparse_status status;
     void* buffer_transpose = workspace_->getTransposeWorkspace();
-    bool allocated = workspace_->isTransposeAllocated();
+    bool allocated = workspace_->isTransposeBufferAllocated();
     if (!allocated) {
       // check dimensions of A and At
       assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
@@ -306,7 +306,7 @@ namespace ReSolve {
    *
    * @return int error code, 0 if successful
    */
-  int MatrixHandlerHip::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
+  int MatrixHandlerHip::addConst(matrix::Sparse* A, real_type alpha)
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -256,7 +256,7 @@ namespace ReSolve {
     index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
     rocsparse_status status;
-    void* buffer_transpose = workspace_->getTransposeWorkspace();
+    void* buffer_transpose = workspace_->getTransposeBufferWorkspace();
     bool allocated = workspace_->isTransposeBufferAllocated();
     if (!allocated) {
       // check dimensions of A and At

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -251,8 +251,6 @@ namespace ReSolve {
    */
   int MatrixHandlerHip::transpose(matrix::Csr* A, matrix::Csr* At)
   {
-    assert(A->getValues(memory::DEVICE) != nullptr && "Matrix A is not allocated on device.\n");
-    assert(At->getValues(memory::DEVICE) != nullptr && "Matrix At is not allocated on device.\n");
     index_type error_sum = 0;
     index_type m = A->getNumRows();
     index_type n = A->getNumColumns();
@@ -260,10 +258,6 @@ namespace ReSolve {
     rocsparse_status status;
     void* buffer_transpose = workspace_->getTransposeBufferWorkspace();
     bool allocated = workspace_->isTransposeBufferAllocated();
-    // check dimensions of A and At
-    assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
-    assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
-    assert(A->getNnz() == At->getNnz() && "Number of nonzeros in A must be equal to number of nonzeros in At");
     if (!allocated) {
       // allocate transpose buffer
       size_t bufferSize;

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -238,34 +238,26 @@ namespace ReSolve {
   }
 
   /**
-   * @brief Transpose a sparse CSR matrix.
-   * 
-   * Transpose a sparse CSR matrix A. Only allocates At if not already allocated.
-   * 
-   * @param[in, out]  A - Sparse matrix
-   * @param[out]      At - Transposed matrix
-   * @param[in]       allocated - flag indicating if At is already allocated
-   * 
-   * @return int error_sum, 0 if successful
+   * @brief Transpose a sparse CSR matrix in HIP
    *
-   * @warning This method works only for `real_type == double`.
+   * @param[in]  A - Sparse matrix
+   * @param[out] At - Transposed matrix
+   * @return int error_sum, 0 if successful
    */
-  int MatrixHandlerHip::transpose(matrix::Csr* A, matrix::Csr* At, bool allocated)
+  int MatrixHandlerHip::transpose(matrix::Csr* A, matrix::Csr* At)
   {
     index_type error_sum = 0;
+
+    rocsparse_status status;
+    
+    At->allocateMatrixData(memory::DEVICE);
     index_type m = A->getNumRows();
     index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
-    rocsparse_status status;
-    if (!allocated) {
-      // check dimensions of A and At
-      assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
-      assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
+    size_t bufferSize;
+    void* d_work;
 
-      At->allocateMatrixData(memory::DEVICE);
-
-      size_t bufferSize;
-      status = rocsparse_csr2csc_buffer_size(workspace_->getRocsparseHandle(),
+    status = rocsparse_csr2csc_buffer_size(workspace_->getRocsparseHandle(),
                                            m,
                                            n,
                                            nnz,
@@ -273,9 +265,10 @@ namespace ReSolve {
                                            A->getColData(memory::DEVICE), 
                                            rocsparse_action_numeric,
                                            &bufferSize);
-      error_sum += status;
-      mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
-    }
+
+    error_sum += status;
+    mem_.allocateBufferOnDevice(&d_work, bufferSize);
+    
     status = rocsparse_dcsr2csc(workspace_->getRocsparseHandle(),
                                 m,
                                 n,
@@ -288,28 +281,14 @@ namespace ReSolve {
                                 At->getRowData(memory::DEVICE), 
                                 rocsparse_action_numeric,
                                 rocsparse_index_base_zero,
-                                transpose_workspace_);
+                                d_work);
     error_sum += status;
+    mem_.deleteOnDevice(d_work);
+
     // Values on the device are updated now -- mark them as such!
     At->setUpdated(memory::DEVICE);
 
     return error_sum;
-  }
-
-  /**
-   * @brief Add a constant to all nonzero values in the matrix
-   * 
-   * @param[in, out] A - matrix
-   * @param[in] alpha - constant to be added
-   * 
-   * @return int error code, 0 if successful
-   */
-  int MatrixHandlerHip::addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha)
-  {
-    real_type* values = A->getValues(memory::DEVICE);
-    index_type nnz = A->getNnz();
-    hipAddConst(values, alpha, nnz);
-    return 0;
   }
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -243,8 +243,6 @@ namespace ReSolve {
    * @param[in]  A - Sparse matrix
    * @param[out] At - Transposed matrix
    * @return int error_sum, 0 if successful
-   *
-   * @warning This method works only for `real_type == double`.
    */
   int MatrixHandlerHip::transpose(matrix::Csr* A, matrix::Csr* At)
   {

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -257,6 +257,7 @@ namespace ReSolve {
     index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
     rocsparse_status status;
+    void* buffer_transpose = workspace_->getTransposeWorkspace();
     if (!allocated) {
       // check dimensions of A and At
       assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
@@ -274,7 +275,7 @@ namespace ReSolve {
                                            rocsparse_action_numeric,
                                            &bufferSize);
       error_sum += status;
-      mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
+      mem_.allocateBufferOnDevice(&buffer_transpose, bufferSize);
     }
     status = rocsparse_dcsr2csc(workspace_->getRocsparseHandle(),
                                 m,
@@ -288,7 +289,7 @@ namespace ReSolve {
                                 At->getRowData(memory::DEVICE),
                                 rocsparse_action_numeric,
                                 rocsparse_index_base_zero,
-                                transpose_workspace_);
+                                buffer_transpose);
     error_sum += status;
     // Values on the device are updated now -- mark them as such!
     At->setUpdated(memory::DEVICE);

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -238,7 +238,7 @@ namespace ReSolve {
   }
 
   /**
-   * @brief Transpose a sparse CSR matrix.
+   * @brief Transpose a sparse CSR matrix (HIP backend).
    *
    * Transpose a sparse CSR matrix A. Only allocates At if not already allocated.
    *

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -243,6 +243,8 @@ namespace ReSolve {
    * @param[in]  A - Sparse matrix
    * @param[out] At - Transposed matrix
    * @return int error_sum, 0 if successful
+   *
+   * @warning This method works only for `real_type == double`.
    */
   int MatrixHandlerHip::transpose(matrix::Csr* A, matrix::Csr* At)
   {

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -244,13 +244,12 @@ namespace ReSolve {
    *
    * @param[in, out]  A - Sparse matrix
    * @param[out]      At - Transposed matrix
-   * @param[in]       allocated - flag indicating if At is already allocated
    *
    * @return int error_sum, 0 if successful
    *
    * @warning This method works only for `real_type == double`.
    */
-  int MatrixHandlerHip::transpose(matrix::Csr* A, matrix::Csr* At, bool allocated)
+  int MatrixHandlerHip::transpose(matrix::Csr* A, matrix::Csr* At)
   {
     index_type error_sum = 0;
     index_type m = A->getNumRows();
@@ -258,6 +257,7 @@ namespace ReSolve {
     index_type nnz = A->getNnz();
     rocsparse_status status;
     void* buffer_transpose = workspace_->getTransposeWorkspace();
+    bool allocated = workspace_->isTransposeAllocated();
     if (!allocated) {
       // check dimensions of A and At
       assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
@@ -276,6 +276,7 @@ namespace ReSolve {
                                            &bufferSize);
       error_sum += status;
       mem_.allocateBufferOnDevice(&buffer_transpose, bufferSize);
+      workspace_->setTransposeAllocated();
     }
     status = rocsparse_dcsr2csc(workspace_->getRocsparseHandle(),
                                 m,

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -263,8 +263,6 @@ namespace ReSolve {
       assert(A->getNumRows() == At->getNumColumns() && "Number of rows in A must be equal to number of columns in At");
       assert(A->getNumColumns() == At->getNumRows() && "Number of columns in A must be equal to number of rows in At");
 
-      At->allocateMatrixData(memory::DEVICE);
-
       size_t bufferSize;
       status = rocsparse_csr2csc_buffer_size(workspace_->getRocsparseHandle(),
                                            m,

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -37,9 +37,8 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
-
-      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
+      int transpose(matrix::Csr* A, matrix::Csr* At);
+      
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,
                          vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -56,7 +56,6 @@ namespace ReSolve {
       bool values_changed_{true}; ///< needed for matvec
 
       MemoryHandler mem_; ///< Device memory manager object
-      void* transpose_workspace_{nullptr};
   };
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -4,7 +4,7 @@
 #include <resolve/matrix/MatrixHandlerImpl.hpp>
 
 namespace ReSolve
-{ 
+{
   namespace vector
   {
     class Vector;
@@ -23,15 +23,15 @@ namespace ReSolve
 namespace ReSolve {
   /**
    * @class MatrixHandlerHip
-   * 
+   *
    * @brief HIP implementation of the matrix handler.
    */
   class MatrixHandlerHip : public MatrixHandlerImpl
   {
     using vector_type = vector::Vector;
-    
+
     public:
-      
+
       MatrixHandlerHip(LinAlgWorkspaceHIP* workspace);
       virtual ~MatrixHandlerHip();
 
@@ -39,19 +39,19 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
-      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
+      int addConst(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,
                          vector_type* vec_result,
                          const real_type* alpha,
                          const real_type* beta);
-      
+
       virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm);
-      
-      void setValuesChanged(bool isValuesChanged); 
-    
-    private: 
-      
+
+      void setValuesChanged(bool isValuesChanged);
+
+    private:
+
       LinAlgWorkspaceHIP* workspace_{nullptr};
       bool values_changed_{true}; ///< needed for matvec
 

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -37,8 +37,9 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At);
-      
+      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
+
+      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,
                          vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -37,7 +37,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
+      int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
       int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -37,8 +37,9 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At);
-      
+      int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) override;
+
+      int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,
                          vector_type* vec_result,
@@ -55,6 +56,7 @@ namespace ReSolve {
       bool values_changed_{true}; ///< needed for matvec
 
       MemoryHandler mem_; ///< Device memory manager object
+      void* transpose_workspace_{nullptr};
   };
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -37,7 +37,7 @@ namespace ReSolve {
 
       int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
 
-      int transpose(matrix::Csr* A, matrix::Csr* At) override;
+      int transpose(matrix::Csr* A, matrix::Csr* At);
 
       int addConst(matrix::Sparse* A, real_type alpha);
       virtual int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -34,7 +34,7 @@ namespace ReSolve {
 
       virtual int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr) = 0;
 
-      virtual int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) = 0;
+      virtual int transpose(matrix::Csr* A, matrix::Csr* At) = 0;
 
       virtual int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha) = 0;
 

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -36,6 +36,8 @@ namespace ReSolve {
 
       virtual int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) = 0;
 
+      virtual int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha) = 0;
+
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,
                          vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -34,7 +34,7 @@ namespace ReSolve {
 
       virtual int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr) = 0;
 
-      virtual int transpose(matrix::Csr* A, matrix::Csr* At) = 0;
+      virtual int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) = 0;
 
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -34,9 +34,7 @@ namespace ReSolve {
 
       virtual int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr) = 0;
 
-      virtual int transpose(matrix::Csr* A, matrix::Csr* At, bool allocated = false) = 0;
-
-      virtual int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha) = 0;
+      virtual int transpose(matrix::Csr* A, matrix::Csr* At) = 0;
 
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -36,7 +36,7 @@ namespace ReSolve {
 
       virtual int transpose(matrix::Csr* A, matrix::Csr* At) = 0;
 
-      virtual int addConstantToNonzeroValues(matrix::Sparse* A, real_type alpha) = 0;
+      virtual int addConst(matrix::Sparse* A, real_type alpha) = 0;
 
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -29,6 +29,9 @@ namespace ReSolve
     if (matvec_setup_done_) {
       cusparseDestroySpMat(mat_A_);
     }
+    if (transpose_workspace_ready_) {
+      mem_.deleteOnDevice(transpose_workspace_);
+    }
   }
 
   void* LinAlgWorkspaceCUDA::getSpmvBuffer()
@@ -55,7 +58,7 @@ namespace ReSolve
       transpose_workspace_ready_ = true;
     return;
   }
-  
+
   bool LinAlgWorkspaceCUDA::isTransposeBufferAllocated()
   {
     return transpose_workspace_ready_;

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -55,8 +55,7 @@ namespace ReSolve
       transpose_workspace_ready_ = true;
     return;
   }
-
-
+  
   bool LinAlgWorkspaceCUDA::isTransposeBufferAllocated()
   {
     return transpose_workspace_ready_;

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -46,14 +46,20 @@ namespace ReSolve
     return transpose_workspace_;
   }
 
+  void LinAlgWorkspaceCUDA::setTransposeBufferWorkspace(size_t bufferSize)
+  {
+    if (transpose_workspace_ != nullptr) {
+      mem_.deleteOnDevice(transpose_workspace_);
+    }
+      mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
+      transpose_workspace_ready_ = true;
+    return;
+  }
+
+
   bool LinAlgWorkspaceCUDA::isTransposeBufferAllocated()
   {
     return transpose_workspace_ready_;
-  }
-
-  void LinAlgWorkspaceCUDA::setTransposeAllocated()
-  {
-    transpose_workspace_ready_ = true;
   }
 
   bool  LinAlgWorkspaceCUDA::getNormBufferState()

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -22,7 +22,6 @@ namespace ReSolve
     if (buffer_spmv_ != nullptr)  mem_.deleteOnDevice(buffer_spmv_);
     if (d_r_size_ != 0)  mem_.deleteOnDevice(d_r_);
     if (norm_buffer_ready_) mem_.deleteOnDevice(buffer_1norm_);
-    if (transpose_workspace_ != nullptr) mem_.deleteOnDevice(transpose_workspace_);
     cusparseDestroy(handle_cusparse_);
     cusolverSpDestroy(handle_cusolversp_);
     cublasDestroy(handle_cublas_);

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -41,7 +41,7 @@ namespace ReSolve
     return buffer_1norm_;
   }
 
-  void* LinAlgWorkspaceCUDA::getTransposeWorkspace()
+  void* LinAlgWorkspaceCUDA::getTransposeBufferWorkspace()
   {
     return transpose_workspace_;
   }

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -8,9 +8,10 @@ namespace ReSolve
     handle_cusparse_   = nullptr;
     handle_cublas_     = nullptr;
     buffer_spmv_       = nullptr;
-    buffer_1norm_      = nullptr;    
+    buffer_1norm_      = nullptr;
+    transpose_workspace_ = nullptr;
     d_r_               = nullptr;
-    d_r_size_          = 0; 
+    d_r_size_          = 0;
     matvec_setup_done_ = false;
     norm_buffer_ready_ = false;
   }
@@ -37,7 +38,12 @@ namespace ReSolve
   {
     return buffer_1norm_;
   }
-  
+
+  void* LinAlgWorkspaceCUDA::getTransposeWorkspace()
+  {
+    return transpose_workspace_;
+  }
+
   bool  LinAlgWorkspaceCUDA::getNormBufferState()
   {
     return norm_buffer_ready_;
@@ -52,7 +58,7 @@ namespace ReSolve
   {
     buffer_1norm_ =  buffer;
   }
-  
+
   void LinAlgWorkspaceCUDA::setNormBufferState(bool r)
   {
     norm_buffer_ready_ = r;
@@ -72,7 +78,7 @@ namespace ReSolve
   {
     d_r_size_ = new_sz;
   }
-  
+
   void LinAlgWorkspaceCUDA::setDr(double* new_dr)
   {
     d_r_ = new_dr;

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -46,7 +46,7 @@ namespace ReSolve
     return transpose_workspace_;
   }
 
-  bool LinAlgWorkspaceCUDA::isTransposeAllocated()
+  bool LinAlgWorkspaceCUDA::isTransposeBufferAllocated()
   {
     return transpose_workspace_ready_;
   }

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -50,9 +50,9 @@ namespace ReSolve
 
   void LinAlgWorkspaceCUDA::setTransposeBufferWorkspace(size_t bufferSize)
   {
-    if (transpose_workspace_ != nullptr) {
-      mem_.deleteOnDevice(transpose_workspace_);
-    }
+      if (transpose_workspace_ready_) {
+        mem_.deleteOnDevice(transpose_workspace_);
+      }
       mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
       transpose_workspace_ready_ = true;
     return;

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -10,6 +10,7 @@ namespace ReSolve
     buffer_spmv_       = nullptr;
     buffer_1norm_      = nullptr;
     transpose_workspace_ = nullptr;
+    transpose_workspace_ready_ = false;
     d_r_               = nullptr;
     d_r_size_          = 0;
     matvec_setup_done_ = false;
@@ -21,6 +22,7 @@ namespace ReSolve
     if (buffer_spmv_ != nullptr)  mem_.deleteOnDevice(buffer_spmv_);
     if (d_r_size_ != 0)  mem_.deleteOnDevice(d_r_);
     if (norm_buffer_ready_) mem_.deleteOnDevice(buffer_1norm_);
+    if (transpose_workspace_ != nullptr) mem_.deleteOnDevice(transpose_workspace_);
     cusparseDestroy(handle_cusparse_);
     cusolverSpDestroy(handle_cusolversp_);
     cublasDestroy(handle_cublas_);
@@ -42,6 +44,16 @@ namespace ReSolve
   void* LinAlgWorkspaceCUDA::getTransposeWorkspace()
   {
     return transpose_workspace_;
+  }
+
+  bool LinAlgWorkspaceCUDA::isTransposeAllocated()
+  {
+    return transpose_workspace_ready_;
+  }
+
+  void LinAlgWorkspaceCUDA::setTransposeAllocated()
+  {
+    transpose_workspace_ready_ = true;
   }
 
   bool  LinAlgWorkspaceCUDA::getNormBufferState()

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -68,7 +68,7 @@ namespace ReSolve
       bool matvec_setup_done_{false}; //check if setup is done for matvec i.e. if buffer is allocated, csr structure is set etc.
 
       void* transpose_workspace_{nullptr}; // needed for transpose
-      bool transpose_allocated_{false}; // to track if allocated
+      bool transpose_buffer_ready_{false}; // to track if allocated
 
       real_type* d_r_{nullptr}; // needed for one-norm
       index_type d_r_size_{0};

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -19,7 +19,7 @@ namespace ReSolve
       //accessors
       void* getSpmvBuffer();
       void* getNormBuffer();
-      void* getTransposeWorkspace();
+      void* getTransposeBufferWorkspace();
       bool isTransposeBufferAllocated();
       void setTransposeAllocated();
 

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -20,6 +20,8 @@ namespace ReSolve
       void* getSpmvBuffer();
       void* getNormBuffer();
       void* getTransposeWorkspace();
+      bool isTransposeAllocated();
+      void setTransposeAllocated();
 
       void setSpmvBuffer(void* buffer);
       void setNormBuffer(void* buffer);
@@ -68,7 +70,7 @@ namespace ReSolve
       bool matvec_setup_done_{false}; //check if setup is done for matvec i.e. if buffer is allocated, csr structure is set etc.
 
       void* transpose_workspace_{nullptr}; // needed for transpose
-      bool transpose_buffer_ready_{false}; // to track if allocated
+      bool transpose_workspace_ready_{false}; // to track if allocated
 
       real_type* d_r_{nullptr}; // needed for one-norm
       index_type d_r_size_{0};

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -20,7 +20,7 @@ namespace ReSolve
       void* getSpmvBuffer();
       void* getNormBuffer();
       void* getTransposeWorkspace();
-      bool isTransposeAllocated();
+      bool isTransposeBufferAllocated();
       void setTransposeAllocated();
 
       void setSpmvBuffer(void* buffer);

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -19,13 +19,14 @@ namespace ReSolve
       //accessors
       void* getSpmvBuffer();
       void* getNormBuffer();
+      void* getTransposeWorkspace();
 
       void setSpmvBuffer(void* buffer);
       void setNormBuffer(void* buffer);
 
       cublasHandle_t getCublasHandle();
       cusolverSpHandle_t getCusolverSpHandle(); //needed for 1-norms etc
-      cusparseHandle_t getCusparseHandle();      
+      cusparseHandle_t getCusparseHandle();
       cusparseSpMatDescr_t getSpmvMatrixDescriptor();
       cusparseDnVecDescr_t getVecX();
       cusparseDnVecDescr_t  getVecY();
@@ -54,7 +55,7 @@ namespace ReSolve
       cusparseHandle_t handle_cusparse_;
 
       //matrix descriptors
-      cusparseSpMatDescr_t mat_A_; 
+      cusparseSpMatDescr_t mat_A_;
 
       //vector descriptors
       cusparseDnVecDescr_t vec_x_;
@@ -65,11 +66,14 @@ namespace ReSolve
       void* buffer_1norm_{nullptr};
 
       bool matvec_setup_done_{false}; //check if setup is done for matvec i.e. if buffer is allocated, csr structure is set etc.
-      
+
+      void* transpose_workspace_{nullptr}; // needed for transpose
+      bool transpose_allocated_{false}; // to track if allocated
+
       real_type* d_r_{nullptr}; // needed for one-norm
       index_type d_r_size_{0};
-      bool norm_buffer_ready_{false};// to track if allocated 
-    
+      bool norm_buffer_ready_{false};// to track if allocated
+
       MemoryHandler mem_;
   };
 

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -20,9 +20,8 @@ namespace ReSolve
       void* getSpmvBuffer();
       void* getNormBuffer();
       void* getTransposeBufferWorkspace();
+      void setTransposeBufferWorkspace(size_t bufferSize);
       bool isTransposeBufferAllocated();
-      void setTransposeAllocated();
-
       void setSpmvBuffer(void* buffer);
       void setNormBuffer(void* buffer);
 

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -122,7 +122,7 @@ namespace ReSolve
     return norm_buffer_;
   }
 
-  real_type*  LinAlgWorkspaceHIP::getTransposeWorkspace()
+  void*  LinAlgWorkspaceHIP::getTransposeWorkspace()
   {
     return transpose_workspace_;
   }

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -23,8 +23,15 @@ namespace ReSolve
     if (matvec_setup_done_) {
       rocsparse_destroy_mat_descr(mat_A_);
     }
-    if (d_r_size_ != 0)  mem_.deleteOnDevice(d_r_);
-    if (norm_buffer_ready_ == true)  mem_.deleteOnDevice(norm_buffer_);
+    if (d_r_size_ != 0) {
+      mem_.deleteOnDevice(d_r_);
+    }
+    if (norm_buffer_ready_ == true) {
+      mem_.deleteOnDevice(norm_buffer_);
+    }
+    if (transpose_workspace_ready_) {
+      mem_.deleteOnDevice(transpose_workspace_);
+    }
   }
 
   rocsparse_handle LinAlgWorkspaceHIP::getRocsparseHandle()

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -128,13 +128,17 @@ namespace ReSolve
     return transpose_workspace_;
   }
 
+  void LinAlgWorkspaceHIP::setTransposeBufferWorkspace(size_t bufferSize)
+  {
+    if (transpose_workspace_ != nullptr) {
+      mem_.deleteOnDevice(transpose_workspace_);
+    }
+    mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
+    transpose_workspace_ready_ = true;
+  }
+
   bool LinAlgWorkspaceHIP::isTransposeBufferAllocated()
   {
     return transpose_workspace_ready_;
-  }
-
-  void LinAlgWorkspaceHIP::setTransposeAllocated()
-  {
-    transpose_workspace_ready_ = true;
   }
 } // namespace ReSolve

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -137,7 +137,7 @@ namespace ReSolve
 
   void LinAlgWorkspaceHIP::setTransposeBufferWorkspace(size_t bufferSize)
   {
-    if (transpose_workspace_ != nullptr) {
+    if (transpose_workspace_ready_) {
       mem_.deleteOnDevice(transpose_workspace_);
     }
     mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -13,6 +13,7 @@ namespace ReSolve
     norm_buffer_       = nullptr;
     norm_buffer_ready_ = false;
     transpose_workspace_ = nullptr;
+    transpose_workspace_ready_ = false;
   }
 
   LinAlgWorkspaceHIP::~LinAlgWorkspaceHIP()
@@ -125,5 +126,15 @@ namespace ReSolve
   void*  LinAlgWorkspaceHIP::getTransposeWorkspace()
   {
     return transpose_workspace_;
+  }
+
+  bool LinAlgWorkspaceHIP::isTransposeAllocated()
+  {
+    return transpose_workspace_ready_;
+  }
+
+  void LinAlgWorkspaceHIP::setTransposeAllocated()
+  {
+    transpose_workspace_ready_ = true;
   }
 } // namespace ReSolve

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -9,9 +9,10 @@ namespace ReSolve
 
     matvec_setup_done_ = false;
     d_r_               = nullptr;
-    d_r_size_          = 0; 
+    d_r_size_          = 0;
     norm_buffer_       = nullptr;
     norm_buffer_ready_ = false;
+    transpose_workspace_ = nullptr;
   }
 
   LinAlgWorkspaceHIP::~LinAlgWorkspaceHIP()
@@ -69,22 +70,22 @@ namespace ReSolve
   {
     d_r_size_ = new_sz;
   }
-  
+
   void LinAlgWorkspaceHIP::setDr(double* new_dr)
   {
     d_r_ = new_dr;
   }
-  
+
   void LinAlgWorkspaceHIP::setNormBuffer(double* nb)
   {
     norm_buffer_ = nb;
   }
-  
+
   void LinAlgWorkspaceHIP::setNormBufferState(bool r)
   {
     norm_buffer_ready_ = r;
   }
-  
+
   bool LinAlgWorkspaceHIP::matvecSetup()
   {
     return matvec_setup_done_;
@@ -100,7 +101,7 @@ namespace ReSolve
     rocsparse_create_handle(&handle_rocsparse_);
     rocblas_create_handle(&handle_rocblas_);
   }
-  
+
   index_type  LinAlgWorkspaceHIP::getDrSize()
   {
     return d_r_size_;
@@ -110,14 +111,19 @@ namespace ReSolve
   {
     return d_r_;
   }
-  
+
   bool  LinAlgWorkspaceHIP::getNormBufferState()
   {
     return norm_buffer_ready_;
   }
-  
+
   real_type*  LinAlgWorkspaceHIP::getNormBuffer()
   {
     return norm_buffer_;
+  }
+
+  real_type*  LinAlgWorkspaceHIP::getTransposeWorkspace()
+  {
+    return transpose_workspace_;
   }
 } // namespace ReSolve

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -128,7 +128,7 @@ namespace ReSolve
     return transpose_workspace_;
   }
 
-  bool LinAlgWorkspaceHIP::isTransposeAllocated()
+  bool LinAlgWorkspaceHIP::isTransposeBufferAllocated()
   {
     return transpose_workspace_ready_;
   }

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -123,7 +123,7 @@ namespace ReSolve
     return norm_buffer_;
   }
 
-  void*  LinAlgWorkspaceHIP::getTransposeWorkspace()
+  void*  LinAlgWorkspaceHIP::getTransposeBufferWorkspace()
   {
     return transpose_workspace_;
   }

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -63,7 +63,7 @@ namespace ReSolve
 
       real_type* d_r_{nullptr}; // needed for inf-norm
       real_type* norm_buffer_{nullptr}; // needed for inf-norm
-      real_type* transpose_workspace_{nullptr}; // needed for transpose
+      void* transpose_workspace_{nullptr}; // needed for transpose
       bool transpose_workspace_ready_{false}; // to track if allocated
       index_type d_r_size_{0};
       bool norm_buffer_ready_{false};// to track if allocated

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -25,6 +25,8 @@ namespace ReSolve
       real_type* getNormBuffer();
       void* getTransposeWorkspace();
       bool getNormBufferState();
+      bool isTransposeAllocated();
+      void setTransposeAllocated();
 
       void setRocblasHandle(rocblas_handle handle);
       void setRocsparseHandle(rocsparse_handle handle);

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -23,6 +23,7 @@ namespace ReSolve
       index_type getDrSize();
       real_type* getDr();
       real_type* getNormBuffer();
+      void* getTransposeWorkspace();
       bool getNormBufferState();
 
       void setRocblasHandle(rocblas_handle handle);

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -17,7 +17,7 @@ namespace ReSolve
       ~LinAlgWorkspaceHIP();
 
       rocblas_handle getRocblasHandle();
-      rocsparse_handle getRocsparseHandle();      
+      rocsparse_handle getRocsparseHandle();
       rocsparse_mat_descr getSpmvMatrixDescriptor();
       rocsparse_mat_info getSpmvMatrixInfo();
       index_type getDrSize();
@@ -34,12 +34,12 @@ namespace ReSolve
 
       bool matvecSetup();
       void matvecSetupDone();
-      
+
       void setDrSize(index_type new_sz);
       void setDr(real_type* new_dr);
       void setNormBuffer(real_type* nb);
       void setNormBufferState(bool r);
-      
+
 
     private:
       //handles
@@ -47,7 +47,7 @@ namespace ReSolve
       rocsparse_handle handle_rocsparse_;
 
       //matrix descriptors
-      rocsparse_mat_descr  mat_A_; 
+      rocsparse_mat_descr  mat_A_;
 
       //vector descriptors not needed, rocsparse uses RAW pointers.
 
@@ -57,11 +57,13 @@ namespace ReSolve
 
       //info - but we need info
       rocsparse_mat_info info_A_;
-      
+
       real_type* d_r_{nullptr}; // needed for inf-norm
       real_type* norm_buffer_{nullptr}; // needed for inf-norm
+      real_type* transpose_workspace_{nullptr}; // needed for transpose
+      bool transpose_workspace_ready_{false}; // to track if allocated
       index_type d_r_size_{0};
-      bool norm_buffer_ready_{false};// to track if allocated 
+      bool norm_buffer_ready_{false};// to track if allocated
       MemoryHandler mem_; ///< Memory handler not needed for now
   };
 

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -24,9 +24,9 @@ namespace ReSolve
       real_type* getDr();
       real_type* getNormBuffer();
       void* getTransposeBufferWorkspace();
+      void setTransposeBufferWorkspace(size_t bufferSize);
       bool getNormBufferState();
       bool isTransposeBufferAllocated();
-      void setTransposeAllocated();
 
       void setRocblasHandle(rocblas_handle handle);
       void setRocsparseHandle(rocsparse_handle handle);

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -23,7 +23,7 @@ namespace ReSolve
       index_type getDrSize();
       real_type* getDr();
       real_type* getNormBuffer();
-      void* getTransposeWorkspace();
+      void* getTransposeBufferWorkspace();
       bool getNormBufferState();
       bool isTransposeBufferAllocated();
       void setTransposeAllocated();

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -25,7 +25,7 @@ namespace ReSolve
       real_type* getNormBuffer();
       void* getTransposeWorkspace();
       bool getNormBufferState();
-      bool isTransposeAllocated();
+      bool isTransposeBufferAllocated();
       void setTransposeAllocated();
 
       void setRocblasHandle(rocblas_handle handle);

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -127,14 +127,14 @@ public:
           if (val == 0.0) {
               A = createRectangularCsrMatrix(n, m);
               At->allocateMatrixData(memspace_);
-              handler_.transpose(A, At, memspace_, false);
+              handler_.transpose(A, At, memspace_);
 
               status *= (At->getNumRows() == A->getNumColumns());
               status *= (At->getNumColumns() == A->getNumRows());
               status *= (At->getNnz() == A->getNnz());
           } else {
               handler_.addConstantToNonzeroValues(A, val, memspace_);
-              handler_.transpose(A, At, memspace_, true);
+              handler_.transpose(A, At, memspace_);
           }
 
           if (memspace_ == memory::DEVICE) {

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -117,7 +117,6 @@ public:
     TestStatus status;
     std::string testname(__func__);
     std::stringstream matrix_size;
-    matrix_size << " for " << n << " x " << m << " matrix";
     testname += matrix_size.str();
     matrix::Csr* A = createRectangularCsrMatrix(n, m);
     matrix::Csr* At = new matrix::Csr(m, n, A->getNnz());
@@ -132,7 +131,7 @@ public:
       At->syncData(memory::HOST);
     }
 
-    verifyCsrMatrix(At);
+    verifyCsrMatrix(At, status);
 
     delete A;
     delete At;
@@ -315,9 +314,6 @@ private:
    * If n>m A_{ij} is nonzero iff i==j, or i+m==j+n
    * if n<m A_{ij} is nonzero iff i==j, or i+m==j+n
    * The values increase with a counter from 1.0 in column major order.
-   *
-   * @pre A is a valid, allocated CSR matrix
-   * @invariant A
    *
    * @param[in] A matrix::Csr* pointer to the matrix to be verified
    *

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -141,7 +141,7 @@ public:
               At->syncData(memory::HOST);
           }
 
-          verifyCsrMatrix(At, status, val);
+          verifyCsrMatrix(At, val);
       }
 
       delete A;  // Delete after loop
@@ -333,101 +333,30 @@ private:
    *
    * @return bool true if the matrix is valid, false otherwise
    */
-  void verifyCsrMatrix(matrix::Csr* A, TestStatus& status, real_type val = 0.0)
+  bool verifyCsrMatrix(matrix::Csr* A, real_type val = 0.0)
   {
     index_type* rowptr_csr = A->getRowData(memory::HOST);
     index_type* colidx_csr = A->getColData(memory::HOST);
     real_type* val_csr = A->getValues(memory::HOST);
     index_type n = A->getNumColumns();
     index_type m = A->getNumRows();
-    if (n == m) {
-      for (index_type i = 0; i < m; ++i) {
-        if (i == m - 1) {
-          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
-          status *= (colidx_csr[rowptr_csr[i]] == n - 1);
-          status *= (val_csr[rowptr_csr[i]] == 2.0 * n + val);
-        } else if (i == m / 2) {
-          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 3);
-          status *= (colidx_csr[rowptr_csr[i]] == 0);
-          status *= (val_csr[rowptr_csr[i]] == 2.0 + val);
-          status *= (colidx_csr[rowptr_csr[i] + 1] == n / 2);
-          status *= (colidx_csr[rowptr_csr[i] + 2] == n / 2 + 1);
-          status *= (val_csr[rowptr_csr[i] + 1] == 2.0 * (n / 2) + 2 + val);
-          status *= (val_csr[rowptr_csr[i] + 2] == 2.0 * (n / 2) + 3 + val);
-        } else {
-          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
-          status *= (colidx_csr[rowptr_csr[i]] == i);
-          status *= (colidx_csr[rowptr_csr[i] + 1] == i + 1);
-          if (i == 0) {
-            status *= (val_csr[rowptr_csr[i]] == 1.0 + val);
-            status *= (val_csr[rowptr_csr[i] + 1] == 3.0 + val);
-          } else {
-            status *= (val_csr[rowptr_csr[i]] == 2.0 * (i + 1) + val);
-            status *= (val_csr[rowptr_csr[i] + 1] == 2.0 * (i + 1) + 1.0 + val);
-          }
-        }
-      }
-    } else if (n > m) {
-      index_type main_diag_ind = 0;
-      index_type off_diag_ind = n - m;
-      real_type main_val = 1.0 + val;
-      real_type off_val = n - m + 1.0 + val;
-      for (index_type i = 0; i < m; ++i) {
-        status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
-        status *= (colidx_csr[rowptr_csr[i]] == main_diag_ind++);
-        status *= (colidx_csr[rowptr_csr[i] + 1] == off_diag_ind++);
-        status *= (val_csr[rowptr_csr[i]] == main_val++);
-        status *= (val_csr[rowptr_csr[i] + 1] == off_val++);
-        if (i >= n - m - 1) {
-            main_val++;
-        }
-        if (i < 2 * m - n) {
-            off_val++;
-        }
-      }
-    } else {
-      real_type main_val = 1.0 + val;
-      real_type off_val = 2.0 + val;
-      for (index_type i = 0; i < m; ++i) {
-        if (i < n && i < m - n) {
-          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
-          status *= (colidx_csr[rowptr_csr[i]] == i);
-          status *= (val_csr[rowptr_csr[i]] == main_val);
-          main_val += 2.0;
-        } else if (i < n && i >= m - n) {
-          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 2);
-          status *= (colidx_csr[rowptr_csr[i] + 1] == i);
-          status *= (colidx_csr[rowptr_csr[i]] == i + n - m);
-          status *= (val_csr[rowptr_csr[i] + 1] == main_val);
-          status *= (val_csr[rowptr_csr[i]] == off_val);
-          main_val += 2.0;
-          off_val += 2.0;
-        } else {
-          status *= (rowptr_csr[i + 1] == rowptr_csr[i] + 1);
-          status *= (colidx_csr[rowptr_csr[i]] == i + n - m);
-          status *= (val_csr[rowptr_csr[i]] == off_val);
-          off_val += 2.0;
-        }
-      }
-    }
-  }
 
     if (n == m) {
         for (index_type i = 0; i < m; ++i) {
             if (i == m - 1) {
                 if (rowptr_csr[i + 1] != rowptr_csr[i] + 1 ||
                     colidx_csr[rowptr_csr[i]] != n - 1 ||
-                    val_csr[rowptr_csr[i]] != 2.0 * n) {
+                    val_csr[rowptr_csr[i]] != 2.0 * n + val) {
                     return false;
                 }
             } else if (i == m / 2) {
                 if (rowptr_csr[i + 1] != rowptr_csr[i] + 3 ||
                     colidx_csr[rowptr_csr[i]] != 0 ||
-                    val_csr[rowptr_csr[i]] != 2.0 ||
+                    val_csr[rowptr_csr[i]] != 2.0 + val ||
                     colidx_csr[rowptr_csr[i] + 1] != n / 2 ||
                     colidx_csr[rowptr_csr[i] + 2] != n / 2 + 1 ||
-                    val_csr[rowptr_csr[i] + 1] != 2.0 * (n / 2) + 2 ||
-                    val_csr[rowptr_csr[i] + 2] != 2.0 * (n / 2) + 3) {
+                    val_csr[rowptr_csr[i] + 1] != 2.0 * (n / 2) + 2 + val ||
+                    val_csr[rowptr_csr[i] + 2] != 2.0 * (n / 2) + 3 + val) {
                     return false;
                 }
             } else {
@@ -437,12 +366,12 @@ private:
                     return false;
                 }
                 if (i == 0) {
-                    if (val_csr[rowptr_csr[i]] != 1.0 || val_csr[rowptr_csr[i] + 1] != 3.0) {
+                    if (val_csr[rowptr_csr[i]] != 1.0 + val || val_csr[rowptr_csr[i] + 1] != 3.0 + val) {
                         return false;
                     }
                 } else {
-                    if (val_csr[rowptr_csr[i]] != 2.0 * (i + 1) ||
-                        val_csr[rowptr_csr[i] + 1] != 2.0 * (i + 1) + 1.0) {
+                    if (val_csr[rowptr_csr[i]] != 2.0 * (i + 1) + val ||
+                        val_csr[rowptr_csr[i] + 1] != 2.0 * (i + 1) + 1.0 + val) {
                         return false;
                     }
                 }
@@ -451,8 +380,8 @@ private:
     } else if (n > m) {
         index_type main_diag_ind = 0;
         index_type off_diag_ind = n - m;
-        real_type main_val = 1.0;
-        real_type off_val = n - m + 1.0;
+        real_type main_val = 1.0 + val;
+        real_type off_val = n - m + 1.0 + val;
         for (index_type i = 0; i < m; ++i) {
             if (rowptr_csr[i + 1] != rowptr_csr[i] + 2 ||
                 colidx_csr[rowptr_csr[i]] != main_diag_ind++ ||
@@ -465,8 +394,8 @@ private:
             if (i < 2 * m - n) off_val++;
         }
     } else {
-        real_type main_val = 1.0;
-        real_type off_val = 2.0;
+        real_type main_val = 1.0 + val;
+        real_type off_val = 2.0 + val;
         for (index_type i = 0; i < m; ++i) {
             if (i < n && i < m - n) {
                 if (rowptr_csr[i + 1] != rowptr_csr[i] + 1 ||
@@ -497,6 +426,8 @@ private:
     }
     return true;
   }
+
+
   /**
    * @brief Create a CSR matrix with preset sparsity structure
    *

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -133,7 +133,7 @@ public:
               status *= (At->getNumColumns() == A->getNumRows());
               status *= (At->getNnz() == A->getNnz());
           } else {
-              handler_.addConstantToNonzeroValues(A, val, memspace_);
+              handler_.addConst(A, val, memspace_);
               handler_.transpose(A, At, memspace_);
           }
 

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -117,6 +117,7 @@ public:
     TestStatus status;
     std::string testname(__func__);
     std::stringstream matrix_size;
+    matrix_size << " for " << n << " x " << m << " matrix";
     testname += matrix_size.str();
     matrix::Csr* A = createRectangularCsrMatrix(n, m);
     matrix::Csr* At = new matrix::Csr(m, n, A->getNnz());

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -132,7 +132,7 @@ public:
       At->syncData(memory::HOST);
     }
 
-    verifyCsrMatrix(At, status);
+    verifyCsrMatrix(At);
 
     delete A;
     delete At;
@@ -316,11 +316,14 @@ private:
    * if n<m A_{ij} is nonzero iff i==j, or i+m==j+n
    * The values increase with a counter from 1.0 in column major order.
    *
+   * @pre A is a valid, allocated CSR matrix
+   * @invariant A
+   *
    * @param[in] A matrix::Csr* pointer to the matrix to be verified
    *
    * @return bool true if the matrix is valid, false otherwise
    */
-  bool verifyCsrMatrix(matrix::Csr* A, real_type val = 0.0)
+  bool verifyCsrMatrix(matrix::Csr* A)
   {
     index_type* rowptr_csr = A->getRowData(memory::HOST);
     index_type* colidx_csr = A->getColData(memory::HOST);
@@ -333,17 +336,17 @@ private:
             if (i == m - 1) {
                 if (rowptr_csr[i + 1] != rowptr_csr[i] + 1 ||
                     colidx_csr[rowptr_csr[i]] != n - 1 ||
-                    val_csr[rowptr_csr[i]] != 2.0 * n + val) {
+                    val_csr[rowptr_csr[i]] != 2.0 * n) {
                     return false;
                 }
             } else if (i == m / 2) {
                 if (rowptr_csr[i + 1] != rowptr_csr[i] + 3 ||
                     colidx_csr[rowptr_csr[i]] != 0 ||
-                    val_csr[rowptr_csr[i]] != 2.0 + val ||
+                    val_csr[rowptr_csr[i]] != 2.0 ||
                     colidx_csr[rowptr_csr[i] + 1] != n / 2 ||
                     colidx_csr[rowptr_csr[i] + 2] != n / 2 + 1 ||
-                    val_csr[rowptr_csr[i] + 1] != 2.0 * (n / 2) + 2 + val ||
-                    val_csr[rowptr_csr[i] + 2] != 2.0 * (n / 2) + 3 + val) {
+                    val_csr[rowptr_csr[i] + 1] != 2.0 * (n / 2) + 2 ||
+                    val_csr[rowptr_csr[i] + 2] != 2.0 * (n / 2) + 3) {
                     return false;
                 }
             } else {
@@ -353,12 +356,12 @@ private:
                     return false;
                 }
                 if (i == 0) {
-                    if (val_csr[rowptr_csr[i]] != 1.0 + val || val_csr[rowptr_csr[i] + 1] != 3.0 + val) {
+                    if (val_csr[rowptr_csr[i]] != 1.0 || val_csr[rowptr_csr[i] + 1] != 3.0) {
                         return false;
                     }
                 } else {
-                    if (val_csr[rowptr_csr[i]] != 2.0 * (i + 1) + val ||
-                        val_csr[rowptr_csr[i] + 1] != 2.0 * (i + 1) + 1.0 + val) {
+                    if (val_csr[rowptr_csr[i]] != 2.0 * (i + 1) ||
+                        val_csr[rowptr_csr[i] + 1] != 2.0 * (i + 1) + 1.0) {
                         return false;
                     }
                 }
@@ -367,8 +370,8 @@ private:
     } else if (n > m) {
         index_type main_diag_ind = 0;
         index_type off_diag_ind = n - m;
-        real_type main_val = 1.0 + val;
-        real_type off_val = n - m + 1.0 + val;
+        real_type main_val = 1.0;
+        real_type off_val = n - m + 1.0;
         for (index_type i = 0; i < m; ++i) {
             if (rowptr_csr[i + 1] != rowptr_csr[i] + 2 ||
                 colidx_csr[rowptr_csr[i]] != main_diag_ind++ ||
@@ -381,8 +384,8 @@ private:
             if (i < 2 * m - n) off_val++;
         }
     } else {
-        real_type main_val = 1.0 + val;
-        real_type off_val = 2.0 + val;
+        real_type main_val = 1.0;
+        real_type off_val = 2.0;
         for (index_type i = 0; i < m; ++i) {
             if (i < n && i < m - n) {
                 if (rowptr_csr[i + 1] != rowptr_csr[i] + 1 ||
@@ -413,8 +416,6 @@ private:
     }
     return true;
   }
-
-
   /**
    * @brief Create a CSR matrix with preset sparsity structure
    *

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -144,6 +144,7 @@ public:
           }
 
           verifyCsrMatrix(At, status, val);
+          std::cout << "Transpose test passed for val = " << val << "\n";
       }
 
       delete A;  // Delete after loop

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -133,9 +133,7 @@ public:
               status *= (At->getNumColumns() == A->getNumRows());
               status *= (At->getNnz() == A->getNnz());
           } else {
-              for (index_type i = 0; i < A->getNnz(); ++i) {
-                  A->getValues(memspace_)[i] += val;
-              }
+              handler_.addConstantToNonzeroValues(A, val, memspace_);
               handler_.transpose(A, At, memspace_, true);
           }
 

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -134,7 +134,7 @@ public:
               status *= (At->getNnz() == A->getNnz());
           } else {
               for (index_type i = 0; i < A->getNnz(); ++i) {
-                  A->getValues(memory::HOST)[i] += val;
+                  A->getValues(memspace_)[i] += val;
               }
               handler_.transpose(A, At, memspace_, true);
           }
@@ -144,7 +144,6 @@ public:
           }
 
           verifyCsrMatrix(At, status, val);
-          std::cout << "Transpose test passed for val = " << val << "\n";
       }
 
       delete A;  // Delete after loop

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -132,7 +132,7 @@ public:
       At->syncData(memory::HOST);
     }
 
-    verifyCsrMatrix(At, status);
+    verifyCsrMatrix(At);
 
     delete A;
     delete At;
@@ -315,6 +315,9 @@ private:
    * If n>m A_{ij} is nonzero iff i==j, or i+m==j+n
    * if n<m A_{ij} is nonzero iff i==j, or i+m==j+n
    * The values increase with a counter from 1.0 in column major order.
+   *
+   * @pre A is a valid, allocated CSR matrix
+   * @invariant A
    *
    * @param[in] A matrix::Csr* pointer to the matrix to be verified
    *

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -38,13 +38,13 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.csc2csr(1024, 1200);
   result += test.csc2csr(1200, 1024);
   result += test.transpose(3, 3);
-  result += test.transpose(5, 3);
-  result += test.transpose(3, 5);
-  result += test.transpose(1024, 1024);
-  result += test.transpose(1024, 2048);
-  result += test.transpose(2048, 1024);
-  result += test.transpose(1024, 1200);
-  result += test.transpose(1200, 1024);
+  // result += test.transpose(5, 3);
+  // result += test.transpose(3, 5);
+  // result += test.transpose(1024, 1024);
+  // result += test.transpose(1024, 2048);
+  // result += test.transpose(2048, 1024);
+  // result += test.transpose(1024, 1200);
+  // result += test.transpose(1200, 1024);
   std::cout << "\n";
 }
 

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -38,13 +38,13 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.csc2csr(1024, 1200);
   result += test.csc2csr(1200, 1024);
   result += test.transpose(3, 3);
-  // result += test.transpose(5, 3);
-  // result += test.transpose(3, 5);
-  // result += test.transpose(1024, 1024);
-  // result += test.transpose(1024, 2048);
-  // result += test.transpose(2048, 1024);
-  // result += test.transpose(1024, 1200);
-  // result += test.transpose(1200, 1024);
+  result += test.transpose(5, 3);
+  result += test.transpose(3, 5);
+  result += test.transpose(1024, 1024);
+  result += test.transpose(1024, 2048);
+  result += test.transpose(2048, 1024);
+  result += test.transpose(1024, 1200);
+  result += test.transpose(1200, 1024);
   std::cout << "\n";
 }
 


### PR DESCRIPTION
Added the ability to reuse a transpose allocation by passing a corresponding `allocated_` flag.

This feature fits nicely with the working thesis of ReSolve, that memory should not be allocated unnecessarily, and reused between in subsequent linear iterations in the solution of the same nonlinear system.
This is crucial for HyKKT, which requires explicit access to the transpose of some matrices, and may be useful for other methods.

Added tests for CPU, CUDA, and HIP and all tests pass. 