### PR TITLE
Fixed LinSolverDirectKLU incorrectly assuming CSC format

### DIFF
--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -10,7 +10,7 @@ namespace ReSolve {
 
   // TODO: these should be dropped
   constexpr double EPSILON = 1.0e-18;
-  constexpr double EPSMAC  = 1.0e-16;
+  constexpr double EPSMAC  = 1.11e-16;
 
 
   /// @todo Provide CMake option to se these types at config time

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -1,13 +1,19 @@
 #include <cstring> // includes memcpy
 #include <resolve/vector/Vector.hpp>
 #include <resolve/matrix/Csc.hpp>
+#include <resolve/matrix/Csr.hpp>
 #include <resolve/utilities/logger/Logger.hpp>
 #include "LinSolverDirectKLU.hpp"
+#include <resolve/matrix/Sparse.hpp>
 
-namespace ReSolve 
+namespace ReSolve
 {
   using out = io::Logger;
-
+  /**
+   * @brief Constructor for LinSolverDirectKLU
+   *
+   * Initializes the KLU solver with default parameters.
+   */
   LinSolverDirectKLU::LinSolverDirectKLU()
   {
     Symbolic_ = nullptr;
@@ -33,8 +39,18 @@ namespace ReSolve
                    << "\tordering         = " << Common_.ordering         << "\n"
                    << "\tpivot threshold  = " << Common_.tol              << "\n"
                    << "\thalt if singular = " << Common_.halt_if_singular << "\n";
-  } 
+  }
 
+  /**
+   * @brief Destructor for LinSolverDirectKLU
+   *
+   * Frees memory allocated for the KLU solver.
+   * Deletes factors L_, U_, and permutation vectors P_ and Q_
+   * if factors have been extracted.
+   * Frees memory allocated for Symbolic_ and Numeric_.
+   * @post All memory allocated for KLU solver is freed.
+   * @post All pointers are set to nullptr.
+   */
   LinSolverDirectKLU::~LinSolverDirectKLU()
   {
     if (factors_extracted_) {
@@ -51,20 +67,61 @@ namespace ReSolve
     klu_free_numeric(&Numeric_, &Common_);
   }
 
+  /**
+   * @brief Setup the KLU solver with the matrix A.
+   *
+   * @param[in] A   - matrix to solve
+   * @param[in] L   - optional lower triangular factor
+   * @param[in] U   - optional upper triangular factor
+   * @param[in] P   - optional row permutation vector
+   * @param[in] Q   - optional column permutation vector
+   * @param[in] rhs - optional right-hand side vector
+   */
   int LinSolverDirectKLU::setup(matrix::Sparse* A,
                                 matrix::Sparse* /* L */,
                                 matrix::Sparse* /* U */,
                                 index_type*     /* P */,
-                                index_type*     /* Q */,    
+                                index_type*     /* Q */,
                                 vector_type*  /* rhs */)
   {
+    if (A == nullptr) {
+      out::error() << "Matrix A is null!\n";
+      return 1;
+    }
+    if (A->getNumRows() != A->getNumColumns()) {
+      out::error() << "Matrix A is not square!\n";
+      return 1;
+    }
+    if (A->getNumRows() == 0) {
+      out::error() << "Matrix A is empty!\n";
+      return 1;
+    }
+    if (A->getNnz() == 0) {
+      out::error() << "Matrix A has no non-zero entries!\n";
+      return 1;
+    }
+    // print A's sparse format
+    if (A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_COLUMN) {
+      out::summary() << "Matrix A is in CSC format.\n";
+    } else if (A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW) {
+      out::summary() << "Matrix A is in CSR format.\n";
+    } else {
+      out::error() << "Matrix A is not in CSC or CSR format!\n";
+      std::cout << "Matrix A sparse format is wrong!" << std::endl;
+      return 1;
+    }
     this->A_ = A;
     return 0;
   }
 
-  int LinSolverDirectKLU::analyze() 
+  /**
+   * @brief Analyze the matrix A and compute symbolic factorization.
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int LinSolverDirectKLU::analyze()
   {
-    // in case we called this function AGAIN 
+    // in case we called this function AGAIN
     if (Symbolic_ != nullptr) {
       klu_free_symbolic(&Symbolic_, &Common_);
     }
@@ -73,14 +130,14 @@ namespace ReSolve
                             A_->getColData(memory::HOST),
                             &Common_);
     factors_extracted_ = false;
-    
+
     if (L_ != nullptr) {
-      delete L_; 
+      delete L_;
       L_ = nullptr;
     }
-   
+
     if (U_ != nullptr) {
-      delete U_; 
+      delete U_;
       U_ = nullptr;
     }
 
@@ -91,8 +148,12 @@ namespace ReSolve
     }
     return 0;
   }
-
-  int LinSolverDirectKLU::factorize() 
+  /**
+   * @brief Factorize the matrix A.
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int LinSolverDirectKLU::factorize()
   {
     if (Numeric_ != nullptr) {
       klu_free_numeric(&Numeric_, &Common_);
@@ -107,12 +168,12 @@ namespace ReSolve
     factors_extracted_ = false;
 
     if (L_ != nullptr) {
-      delete L_; 
+      delete L_;
       L_ = nullptr;
     }
-    
+
     if (U_ != nullptr) {
-      delete U_; 
+      delete U_;
       U_ = nullptr;
     }
 
@@ -122,7 +183,12 @@ namespace ReSolve
     return 0;
   }
 
-  int  LinSolverDirectKLU::refactorize() 
+  /**
+   * @brief Update the factorization of the matrix A.
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int  LinSolverDirectKLU::refactorize()
   {
     int kluStatus = klu_refactor(A_->getRowData(memory::HOST),
                                  A_->getColData(memory::HOST),
@@ -134,12 +200,12 @@ namespace ReSolve
     factors_extracted_ = false;
 
     if (L_ != nullptr) {
-      delete L_; 
+      delete L_;
       L_ = nullptr;
     }
-   
+
     if (U_ != nullptr) {
-      delete U_; 
+      delete U_;
       U_ = nullptr;
     }
 
@@ -150,13 +216,27 @@ namespace ReSolve
     return 0;
   }
 
-  int LinSolverDirectKLU::solve(vector_type* rhs, vector_type* x) 
+  /**
+   * @brief Solves a system of equations A*x = rhs.
+   *
+   * @param[in] rhs - right-hand side vector
+   * @param[out] x   - solution vector
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+
+  int LinSolverDirectKLU::solve(vector_type* rhs, vector_type* x)
   {
     //copy the vector
     x->copyDataFrom(rhs->getData(memory::HOST), memory::HOST, memory::HOST);
     x->setDataUpdated(memory::HOST);
-
-    int kluStatus = klu_solve(Symbolic_, Numeric_, A_->getNumRows(), 1, x->getData(memory::HOST), &Common_);
+    //If A is CSC, solve with A. If A is CSR, solve with A^T
+    int kluStatus = 0;
+    if (A_->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_COLUMN) {
+      kluStatus = klu_solve(Symbolic_, Numeric_, A_->getNumRows(), 1, x->getData(memory::HOST), &Common_);
+    } else {
+      kluStatus = klu_tsolve(Symbolic_, Numeric_, A_->getNumRows(), 1, x->getData(memory::HOST), &Common_);
+    }
 
     if (!kluStatus){
       return 1;
@@ -164,6 +244,9 @@ namespace ReSolve
     return 0;
   }
 
+  /**
+   * @brief Generic solver with matrix A with unspecified rhs (not implemented).
+   */
   int LinSolverDirectKLU::solve(vector_type* )
   {
     out::error() << "Function solve(Vector* x) not implemented in LinSolverDirectKLU!\n"
@@ -171,6 +254,11 @@ namespace ReSolve
     return 1;
   }
 
+  /**
+   * @brief Get the lower triangular factor L.
+   *
+   * @return L factor
+   */
   matrix::Sparse* LinSolverDirectKLU::getLFactor()
   {
     if (!factors_extracted_) {
@@ -181,19 +269,19 @@ namespace ReSolve
       U_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzU);
       L_->allocateMatrixData(memory::HOST);
       U_->allocateMatrixData(memory::HOST);
-    
-      int ok = klu_extract(Numeric_, 
-                           Symbolic_, 
-                           L_->getColData(memory::HOST), 
-                           L_->getRowData(memory::HOST), 
-                           L_->getValues( memory::HOST), 
-                           U_->getColData(memory::HOST), 
-                           U_->getRowData(memory::HOST), 
-                           U_->getValues( memory::HOST), 
-                           nullptr, 
-                           nullptr, 
-                           nullptr, 
-                           nullptr, 
+
+      int ok = klu_extract(Numeric_,
+                           Symbolic_,
+                           L_->getColData(memory::HOST),
+                           L_->getRowData(memory::HOST),
+                           L_->getValues( memory::HOST),
+                           U_->getColData(memory::HOST),
+                           U_->getRowData(memory::HOST),
+                           U_->getValues( memory::HOST),
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           nullptr,
                            nullptr,
                            nullptr,
                            nullptr,
@@ -206,7 +294,11 @@ namespace ReSolve
     }
     return L_;
   }
-
+  /**
+   * @brief Get the upper triangular factor U.
+   *
+   * @return U factor
+   */
   matrix::Sparse* LinSolverDirectKLU::getUFactor()
   {
     if (!factors_extracted_) {
@@ -217,18 +309,18 @@ namespace ReSolve
       U_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzU);
       L_->allocateMatrixData(memory::HOST);
       U_->allocateMatrixData(memory::HOST);
-      int ok = klu_extract(Numeric_, 
-                           Symbolic_, 
-                           L_->getColData(memory::HOST), 
-                           L_->getRowData(memory::HOST), 
-                           L_->getValues( memory::HOST), 
-                           U_->getColData(memory::HOST), 
-                           U_->getRowData(memory::HOST), 
-                           U_->getValues( memory::HOST), 
-                           nullptr, 
-                           nullptr, 
-                           nullptr, 
-                           nullptr, 
+      int ok = klu_extract(Numeric_,
+                           Symbolic_,
+                           L_->getColData(memory::HOST),
+                           L_->getRowData(memory::HOST),
+                           L_->getValues( memory::HOST),
+                           U_->getColData(memory::HOST),
+                           U_->getRowData(memory::HOST),
+                           U_->getValues( memory::HOST),
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           nullptr,
                            nullptr,
                            nullptr,
                            nullptr,
@@ -242,7 +334,11 @@ namespace ReSolve
     }
     return U_;
   }
-
+  /**
+   * @brief Get the permutation vector P.
+   *
+   * @return P permutation vector
+   */
   index_type* LinSolverDirectKLU::getPOrdering()
   {
     if (Numeric_ != nullptr) {
@@ -255,7 +351,11 @@ namespace ReSolve
     }
   }
 
-
+  /**
+   * @brief Get the permutation vector Q.
+   *
+   * @return Q permutation vector
+   */
   index_type* LinSolverDirectKLU::getQOrdering()
   {
     if (Numeric_ != nullptr) {
@@ -268,17 +368,39 @@ namespace ReSolve
     }
   }
 
+  /**
+   * @brief Set the pivot threshold for the KLU solver.
+   *
+   * @param[in] tol - pivot threshold
+   *
+   * @post Common_.tol is set to tol
+   */
   void LinSolverDirectKLU::setPivotThreshold(real_type tol)
   {
     pivot_threshold_tol_ = tol;
-    Common_.tol = tol;    
+    Common_.tol = tol;
   }
 
+  /**
+   * @brief Set the ordering for the KLU solver.
+   *
+   * @param[in] ordering - ordering method
+   *
+   * @post Common_.ordering is set to ordering
+   */
   void LinSolverDirectKLU::setOrdering(int ordering)
   {
     ordering_ = ordering;
     Common_.ordering = ordering;
   }
+
+  /**
+   * @brief Set the halt if singular flag for the KLU solver.
+   *
+   * Tells the solver to halt if a singular matrix is detected.
+   *
+   * @param[in] isHalt - halt if singular flag
+   */
 
   void LinSolverDirectKLU::setHaltIfSingular(bool isHalt)
   {
@@ -286,12 +408,27 @@ namespace ReSolve
     Common_.halt_if_singular = isHalt;
   }
 
+  /**
+   * @brief Get the condition number of the matrix A.
+   *
+   * @return condition number of the matrix A
+   */
   real_type LinSolverDirectKLU::getMatrixConditionNumber()
   {
     klu_rcond(Symbolic_, Numeric_, &Common_);
     return Common_.rcond;
   }
 
+  /**
+   * @brief set Cli parameters for KLU solver.
+   *
+   * @param[in] id    - string ID for parameter to set
+   * @param[in] value - string value for parameter to set
+   *
+   * @post KLU solver parameters id is set to value
+   *
+   * @return 0 if successful, 1 otherwise
+   */
   int LinSolverDirectKLU::setCliParam(const std::string id, const std::string value)
   {
     switch (getParamId(id))
@@ -313,11 +450,11 @@ namespace ReSolve
 
   /**
    * @brief Placeholder function for now.
-   * 
+   *
    * The following switch (getParamId(Id)) cases always run the default and
    * are currently redundant code (like an if (true)).
    * In the future, they will be expanded to include more options.
-   * 
+   *
    * @param id - string ID for parameter to get.
    * @return std::string Value of the string parameter to return.
    */
@@ -331,6 +468,15 @@ namespace ReSolve
     return "";
   }
 
+  /**
+   * @brief Get the integer parameter for the KLU solver.
+   *
+   * Currently, the only integer parameter is the ordering method.
+   *
+   * @param[in] id - string ID for parameter to get
+   *
+   * @return index_type - represents the ordering method
+   */
   index_type LinSolverDirectKLU::getCliParamInt(const std::string id) const
   {
     switch (getParamId(id))
@@ -345,11 +491,11 @@ namespace ReSolve
 
   /**
    * @brief Placeholder function for now.
-   * 
+   *
    * The following switch (getParamId(Id)) cases always run the default and
    * are currently redundant code (like an if (true)).
    * In the future, they will be expanded to include more options.
-   * 
+   *
    * @param id - string ID for parameter to get.
    * @return real_type Value of the real_type parameter to return.
    */
@@ -365,6 +511,15 @@ namespace ReSolve
     return std::numeric_limits<real_type>::quiet_NaN();
   }
 
+  /**
+   * @brief Get the boolean parameter for the KLU solver.
+   *
+   * Currently, the only boolean parameter is the halt if singular flag.
+   *
+   * @param[in] id - string ID for parameter to get
+   *
+   * @return bool - true if halt if singular flag is set to true, false otherwise
+   */
   bool LinSolverDirectKLU::getCliParamBool(const std::string id) const
   {
     switch (getParamId(id))
@@ -377,6 +532,13 @@ namespace ReSolve
     return false;
   }
 
+  /**
+   * @brief Print the KLU solver Cli parameters.
+   *
+   * @param[in] id - string ID for parameter to print
+   *
+   * @return 0 if successful, 1 otherwise
+   */
   int LinSolverDirectKLU::printCliParam(const std::string id) const
   {
     switch (getParamId(id))
@@ -400,7 +562,14 @@ namespace ReSolve
   //
   // Private methods
   //
-
+  /**
+   * @brief Initialize the parameter list for KLU solver.
+   *
+   * @post params_list_ is populated with the KLU solver parameters:
+   * - pivot_tol
+   * - ordering
+   * - halt_if_singular
+   */
   void LinSolverDirectKLU::initParamList()
   {
     params_list_["pivot_tol"]        = PIVOT_TOL;

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -107,7 +107,7 @@ namespace ReSolve
       out::summary() << "Matrix A is in CSR format.\n";
     } else {
       out::error() << "Matrix A is not in CSC or CSR format!\n";
-      std::cout << "Matrix A sparse format is wrong!" << std::endl;
+      out::error() << "Matrix A sparse format is wrong!" << std::endl;
       return 1;
     }
     this->A_ = A;

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -1,5 +1,5 @@
 // Matrix utilities
-// Mirroring memory approach 
+// Mirroring memory approach
 #pragma once
 #include <string>
 #include <functional>
@@ -10,8 +10,8 @@
 namespace ReSolve { namespace matrix {
 
   /**
-   * @brief This class implements basic sparse matrix interface. 
-   * 
+   * @brief This class implements basic sparse matrix interface.
+   *
    * Most of sparse matrix formats store information about matrix rows and
    * columns as integers and nonzero element values as real numbers.
    * This class is virtual and implements only what is common for all basic
@@ -21,7 +21,7 @@ namespace ReSolve { namespace matrix {
    *
    * @author Kasia Swirydowicz <kasia.swirydowicz@pnnl.gov>
    */
-  class Sparse 
+  class Sparse
   {
     public:
       /// Supported sparse matrix formats
@@ -31,8 +31,8 @@ namespace ReSolve { namespace matrix {
       //basic constructor
       Sparse();
       Sparse(index_type n, index_type m, index_type nnz);
-      Sparse(index_type n, 
-             index_type m, 
+      Sparse(index_type n,
+             index_type m,
              index_type nnz,
              bool symmetric,
              bool expanded);
@@ -44,7 +44,7 @@ namespace ReSolve { namespace matrix {
       index_type getNnz();
       SparseFormat getSparseFormat() const;
 
-      bool symmetric(); 
+      bool symmetric();
       bool expanded();
       void setSymmetric(bool symmetric);
       void setExpanded(bool expanded);
@@ -81,15 +81,15 @@ namespace ReSolve { namespace matrix {
 
 
       //update Values just updates values; it allocates if necessary.
-      //values have the same dimensions between different formats 
+      //values have the same dimensions between different formats
       virtual int copyValues(const real_type* new_vals,
                              memory::MemorySpace memspaceIn,
                              memory::MemorySpace memspaceOut);
-      
-      //set new values just sets the pointer, use caution.   
+
+      //set new values just sets the pointer, use caution.
       virtual int setValuesPointer(real_type* new_vals,
                                    memory::MemorySpace memspace);
-    
+
     protected:
       SparseFormat sparse_format_{NONE}; ///< Matrix format
       index_type n_{0}; ///< number of rows
@@ -112,7 +112,7 @@ namespace ReSolve { namespace matrix {
       bool d_data_updated_{false}; ///< DEVICE update flag
 
       void setNotUpdated();
-      
+
       // Data ownership flags
       bool owns_cpu_sparsity_pattern_{false}; ///< for row/col data
       bool owns_cpu_values_{false};           ///< for nonzero values

--- a/tests/functionality/testKlu.cpp
+++ b/tests/functionality/testKlu.cpp
@@ -3,7 +3,7 @@
  * @author Kasia Swirydowicz (kasia.swirydowicz@amd.com)
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Functionality test for rocsolver_rf.
- * 
+ *
  */
 #include <string>
 #include <iostream>
@@ -20,7 +20,7 @@
 #include <resolve/LinSolverIterativeFGMRES.hpp>
 #include <resolve/workspace/LinAlgWorkspace.hpp>
 #include <resolve/utilities/params/CliOptions.hpp>
-
+#include <resolve/Common.hpp>
 #include "TestHelper.hpp"
 
 template <class workspace_type, class refactorization_type>
@@ -125,7 +125,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   status = KLU.factorize();
   error_sum += status;
 
-  std::cout << "KLU factorize status: " << status <<std::endl;      
+  std::cout << "KLU factorize status: " << status <<std::endl;
 
   status = KLU.solve(&vec_rhs, &vec_x);
   error_sum += status;
@@ -133,7 +133,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     test_name += " + IR";
 
-    status =  FGMRES.setup(A); 
+    status =  FGMRES.setup(A);
     error_sum += status;
 
     status = FGMRES.setupPreconditioner("LU", &KLU);
@@ -152,7 +152,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
+  error_sum += helper.checkResult(ReSolve::EPSMAC);
 
   // Load the second matrix
   std::ifstream mat2(matrix_file_name_2);
@@ -178,8 +178,8 @@ int runTest(int argc, char *argv[], std::string& solver_name)
 
   status = KLU.refactorize();
   error_sum += status;
-  std::cout << "KLU refactorization status: " << status << std::endl;      
-  
+  std::cout << "KLU refactorization status: " << status << std::endl;
+
   if (is_ir) {
     FGMRES.resetMatrix(A);
     status = FGMRES.setupPreconditioner("LU", &KLU);
@@ -199,7 +199,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
+  error_sum += helper.checkResult(ReSolve::EPSMAC);
 
   isTestPass(error_sum, test_name);
 


### PR DESCRIPTION
Solves [issue 251](https://github.com/ORNL/ReSolve/issues/251).

I added a check on the sparse format of the matrix $`A`$.
If CSC, the solver resumes normally, calling `klu_solve`
If CSR, the solver calls `klu_tsolve` and solves a system with $`A^T`$. The identity $`\mathrm{csc}(A) = \mathrm{csr}(A^T)`$ guarantees the results are equal, up to numerical precision. 

Note that the tolerance for the test was smaller than numerical precision. It had to be changed to numerical precision for the test to pass.