### PR TITLE
Improve error messages in sparse matrix classes

### DIFF
--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -239,7 +239,7 @@ namespace ReSolve
         mem_.copyArrayHostToDevice(d_val_data_, val_data, nnz_current);
         d_data_updated_ = true;
         break;
-      case 3://gpu->gpua
+      case 3://gpu->gpu
         mem_.copyArrayDeviceToDevice(d_row_data_, row_data, nnz_current);
         mem_.copyArrayDeviceToDevice(d_col_data_, col_data, nnz_current);
         mem_.copyArrayDeviceToDevice(d_val_data_, val_data, nnz_current);
@@ -307,16 +307,18 @@ namespace ReSolve
 
     switch (memspace) {
       case HOST:
+        assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
+        "In Coo::syncData one of host row or column data is null!\n");
+
         if (h_data_updated_) {
-          out::misc() << "In Coo::syncData trying to sync host, but host already up to date!\n";
+          out::warning() << "Coo::syncData is trying to sync host, but host already up to date!\n"
+                         << "Function call ignored!\n";
           return 0;
         }
         if (!d_data_updated_) {
-          out::error() << "In Coo::syncData trying to sync host with device, but device is out of date!\n";
+          out::error() << "Coo::syncData is trying to sync host with device, but device is out of date!\n"
+                       << "See Coo::syncData documentation\n."
           assert(d_data_updated_);
-        }
-        if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-          out::error() << "In Coo::syncData one of host row or column data is null!\n";
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
           h_row_data_ = new index_type[nnz_];      
@@ -333,16 +335,18 @@ namespace ReSolve
         h_data_updated_ = true;
         return 0;
       case DEVICE:
+        assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
+               "In Coo::syncData one of device row or column data is null!\n");
+
         if (d_data_updated_) {
-          out::misc() << "In Coo::syncData trying to sync device, but device already up to date!\n";
+          out::warning() << "Coo::syncData is trying to sync device, but device already up to date!\n"
+                         << "Function call ignored!\n";
           return 0;
         }
         if (!h_data_updated_) {
-          out::error() << "In Coo::syncData trying to sync device with host, but host is out of date!\n";
+          out::error() << "Coo::syncData is trying to sync device with host, but host is out of date!\n"
+                       << "See Coo::syncData documentation\n."
           assert(h_data_updated_);
-        }
-        if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-          out::error() << "In Coo::syncData one of device row or column data is null!\n";
         }
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_row_data_, nnz_);

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -312,13 +312,13 @@ namespace ReSolve
                "In Coo::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::warning() << "Coo::syncData is trying to sync host, but host already up to date!\n"
-                         << "Function call ignored!\n";
+          out::misc() << "Coo::syncData is trying to sync host, but host already up to date!\n"
+                      << "Function call ignored!\n";
           return 0;
         }
         if (!d_data_updated_) {
           out::error() << "Coo::syncData is trying to sync host with device, but device is out of date!\n"
-                       << "See Coo::syncData documentation\n."
+                       << "See Coo::syncData documentation\n.";
           assert(d_data_updated_);
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
@@ -340,13 +340,13 @@ namespace ReSolve
                "In Coo::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::warning() << "Coo::syncData is trying to sync device, but device already up to date!\n"
-                         << "Function call ignored!\n";
+          out::misc() << "Coo::syncData is trying to sync device, but device already up to date!\n"
+                      << "Function call ignored!\n";
           return 0;
         }
         if (!h_data_updated_) {
           out::error() << "Coo::syncData is trying to sync device with host, but host is out of date!\n"
-                       << "See Coo::syncData documentation\n."
+                       << "See Coo::syncData documentation\n.";
           assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -297,9 +297,10 @@ namespace ReSolve
    * @param memspace - memory space to be synced up (HOST or DEVICE)
    * @return int - 0 if successful, error code otherwise
    * 
-   * @todo Handle case when neither memory space is updated. Currently,
-   * this function does nothing in that situation, quitely ignoring
-   * the sync call.
+   * @pre The memory space other than `memspace` must be up-to-date. Otherwise,
+   * this function will return an error.
+   * 
+   * @see Sparse::setUpdated
    */
   int matrix::Coo::syncData(memory::MemorySpace memspace)
   {
@@ -308,7 +309,7 @@ namespace ReSolve
     switch (memspace) {
       case HOST:
         assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
-        "In Coo::syncData one of host row or column data is null!\n");
+               "In Coo::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
           out::warning() << "Coo::syncData is trying to sync host, but host already up to date!\n"

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -190,9 +190,9 @@ namespace ReSolve
 
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated	
-      if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Coo::copyDataFrom one of host row or column data is null!\n";
-      }
+      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) &&
+             "In Coo::copyDataFrom one of host row or column data is null!\n");
+
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[nnz_current];
         this->h_col_data_ = new index_type[nnz_current];
@@ -206,9 +206,9 @@ namespace ReSolve
 
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
-      if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Coo::copyDataFrom one of device row or column data is null!\n";
-      }
+      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) &&
+             "In Coo::copyDataFrom one of device row or column data is null!\n");
+
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
         mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -200,9 +200,10 @@ namespace ReSolve
    * @param memspace - memory space to be synced up (HOST or DEVICE)
    * @return int - 0 if successful, error code otherwise
    * 
-   * @todo Handle case when neither memory space is updated. Currently,
-   * this function does nothing in that situation, quitely ignoring
-   * the sync call.
+   * @pre The memory space other than `memspace` must be up-to-date. Otherwise,
+   * this function will return an error.
+   * 
+   * @see Sparse::setUpdated
    */
   int matrix::Csc::syncData(memory::MemorySpace memspace)
   {
@@ -211,7 +212,7 @@ namespace ReSolve
     switch(memspace) {
       case HOST:
         assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
-        "In Csc::syncData one of host row or column data is null!\n");
+               "In Csc::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
           out::warning() << "Csc::syncData is trying to sync host, but host already up to date!\n"
@@ -239,7 +240,7 @@ namespace ReSolve
         return 0;   
       case DEVICE:
         assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
-        "In Csc::syncData one of device row or column data is null!\n");
+               "In Csc::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
           out::warning() << "Csc::syncData is trying to sync device, but device already up to date!\n"

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -215,13 +215,13 @@ namespace ReSolve
                "In Csc::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::warning() << "Csc::syncData is trying to sync host, but host already up to date!\n"
-                        << "Function call ignored!\n";
+          out::misc() << "Csc::syncData is trying to sync host, but host already up to date!\n"
+                      << "Function call ignored!\n";
           return 0;
         }
         if (!d_data_updated_) {
           out::error() << "Csc::syncData is trying to sync host with device, but device is out of date!\n"
-                      << "See Csc::syncData documentation\n."
+                       << "See Csc::syncData documentation\n.";
           assert(d_data_updated_);
         }
         if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
@@ -243,13 +243,13 @@ namespace ReSolve
                "In Csc::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::warning() << "Csc::syncData is trying to sync device, but device already up to date!\n"
-                         << "Function call ignored!\n";
+          out::misc() << "Csc::syncData is trying to sync device, but device already up to date!\n"
+                      << "Function call ignored!\n";
           return 0;
         }
         if (!h_data_updated_) {
           out::error() << "Csc::syncData is trying to sync device with host, but host is out of date!\n"
-                       << "See Csc::syncData documentation\n."
+                       << "See Csc::syncData documentation\n.";
           assert(h_data_updated_);
         }
         if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -210,16 +210,18 @@ namespace ReSolve
 
     switch(memspace) {
       case HOST:
+        assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
+        "In Csc::syncData one of host row or column data is null!\n");
+
         if (h_data_updated_) {
-          out::misc() << "In Csc::syncData trying to sync host, but host already up to date!\n";
+          out::warning() << "Csc::syncData is trying to sync host, but host already up to date!\n"
+                        << "Function call ignored!\n";
           return 0;
         }
         if (!d_data_updated_) {
-          out::error() << "In Csc::syncData trying to sync host with device, but device is out of date!\n";
+          out::error() << "Csc::syncData is trying to sync host with device, but device is out of date!\n"
+                      << "See Csc::syncData documentation\n."
           assert(d_data_updated_);
-        }
-        if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-          out::error() << "In Csc::syncData one of host row or column data is null!\n";
         }
         if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
           h_col_data_ = new index_type[m_ + 1];      
@@ -236,16 +238,18 @@ namespace ReSolve
         h_data_updated_ = true;
         return 0;   
       case DEVICE:
+        assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
+        "In Csc::syncData one of device row or column data is null!\n");
+
         if (d_data_updated_) {
-          out::misc() << "In Csc::syncData trying to sync device, but device already up to date!\n";
+          out::warning() << "Csc::syncData is trying to sync device, but device already up to date!\n"
+                         << "Function call ignored!\n";
           return 0;
         }
         if (!h_data_updated_) {
-          out::error() << "In Csc::syncData trying to sync device with host, but host is out of date!\n";
+          out::error() << "Csc::syncData is trying to sync device with host, but host is out of date!\n"
+                       << "See Csc::syncData documentation\n."
           assert(h_data_updated_);
-        }
-        if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-          out::error() << "In Csc::syncData one of device row or column data is null!\n";
         }
         if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -92,9 +92,9 @@ namespace ReSolve
 
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
-      if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csc::copyDataFrom one of host row or column data is null!\n";
-      }
+      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) &&
+             "In Csc::copyDataFrom one of host row or column data is null!\n");
+
       if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
         this->h_col_data_ = new index_type[m_ + 1];
         this->h_row_data_ = new index_type[nnz_current];
@@ -108,9 +108,9 @@ namespace ReSolve
 
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
-      if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csc::copyDataFrom one of device row or column data is null!\n";
-      }
+      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) &&
+             "In Csc::copyDataFrom one of device row or column data is null!\n");
+
       if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -207,9 +207,9 @@ namespace ReSolve
 
     if (memspaceOut == memory::HOST) {
       //check if cpu data allocated
-      if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-        out::error() << "In Csr::copyDataFrom one of host row or column data is null!\n";
-      }
+      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) &&
+             "In Csr::copyDataFrom one of host row or column data is null!\n");
+
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
         this->h_row_data_ = new index_type[n_ + 1];
         this->h_col_data_ = new index_type[nnz_current];
@@ -223,9 +223,9 @@ namespace ReSolve
 
     if (memspaceOut == memory::DEVICE) {
       //check if cuda data allocated
-      if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-        out::error() << "In Csr::copyDataFrom one of device row or column data is null!\n";
-      }
+      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) &&
+             "In Csr::copyDataFrom one of device row or column data is null!\n");
+
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
         mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
         mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -316,9 +316,10 @@ namespace ReSolve
    * @param memspace - memory space to be synced up (HOST or DEVICE)
    * @return int - 0 if successful, error code otherwise
    * 
-   * @todo Handle case when neither memory space is updated. Currently,
-   * this function does nothing in that situation, quitely ignoring
-   * the sync call.
+   * @pre The memory space other than `memspace` must be up-to-date. Otherwise,
+   * this function will return an error.
+   * 
+   * @see Sparse::setUpdated
    */
   int matrix::Csr::syncData(memory::MemorySpace memspace)
   {
@@ -328,7 +329,7 @@ namespace ReSolve
       case HOST:
         //check if we need to copy or not
         assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
-        "In Csr::syncData one of host row or column data is null!\n");
+               "In Csr::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
           out::warning() << "Csr::syncData is trying to sync host, but host already up to date!\n"
@@ -356,7 +357,7 @@ namespace ReSolve
         return 0;
       case DEVICE:
         assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
-        "In Csr::syncData one of device row or column data is null!\n");
+               "In Csr::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
         out::warning() << "Csr::syncData is trying to sync device, but device already up to date!\n"

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -332,13 +332,13 @@ namespace ReSolve
                "In Csr::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::warning() << "Csr::syncData is trying to sync host, but host already up to date!\n"
-                         << "Function call ignored!\n";
+          out::misc() << "Csr::syncData is trying to sync host, but host already up to date!\n"
+                      << "Function call ignored!\n";
           return 0;
         }
         if (!d_data_updated_) {
           out::error() << "Csr::syncData is trying to sync host with device, but device is out of date!\n"
-                       << "See Csr::syncData documentation\n."
+                       << "See Csr::syncData documentation\n.";
           assert(d_data_updated_);
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
@@ -360,14 +360,14 @@ namespace ReSolve
                "In Csr::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-        out::warning() << "Csr::syncData is trying to sync device, but device already up to date!\n"
-                        << "Function call ignored!\n";
-        return 0;
+          out::misc() << "Csr::syncData is trying to sync device, but device already up to date!\n"
+                      << "Function call ignored!\n";
+          return 0;
         }
         if (!h_data_updated_) {
-        out::error() << "Csr::syncData is trying to sync device with host, but host is out of date!\n"
-                      << "See Csr::syncData documentation\n."
-        assert(h_data_updated_);
+          out::error() << "Csr::syncData is trying to sync device with host, but host is out of date!\n"
+                       << "See Csr::syncData documentation\n.";
+          assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -327,16 +327,18 @@ namespace ReSolve
     switch (memspace) {
       case HOST:
         //check if we need to copy or not
+        assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
+        "In Csr::syncData one of host row or column data is null!\n");
+
         if (h_data_updated_) {
-          out::misc() << "In Csr::syncData trying to sync host, but host already up to date!\n";
+          out::warning() << "Csr::syncData is trying to sync host, but host already up to date!\n"
+                         << "Function call ignored!\n";
           return 0;
         }
         if (!d_data_updated_) {
-          out::error() << "In Csr::syncData trying to sync host with device, but device is out of date!\n";
+          out::error() << "Csr::syncData is trying to sync host with device, but device is out of date!\n"
+                       << "See Csr::syncData documentation\n."
           assert(d_data_updated_);
-        }
-        if ((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) {
-          out::error() << "In Csr::syncData one of host row or column data is null!\n";
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
           h_row_data_ = new index_type[n_ + 1];
@@ -353,16 +355,18 @@ namespace ReSolve
         h_data_updated_ = true;
         return 0;
       case DEVICE:
+        assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
+        "In Csr::syncData one of device row or column data is null!\n");
+
         if (d_data_updated_) {
-          out::misc() << "In Csr::syncData trying to sync device, but device already up to date!\n";
-          return 0;
+        out::warning() << "Csr::syncData is trying to sync device, but device already up to date!\n"
+                        << "Function call ignored!\n";
+        return 0;
         }
         if (!h_data_updated_) {
-          out::error() << "In Csr::syncData trying to sync device with host, but host is out of date!\n";
-          assert(h_data_updated_);
-        }
-        if ((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) {
-          out::error() << "In Csr::syncData one of device row or column data is null!\n";
+        out::error() << "Csr::syncData is trying to sync device with host, but host is out of date!\n"
+                      << "See Csr::syncData documentation\n."
+        assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
           mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -203,7 +203,7 @@ namespace ReSolve {
    * In such case, the matrix has no way of knowing which data is most recent, so
    * you have to tell it.
    * 
-   * @warning This is expert-level function. Use only if you know what you are
+   * @warning This is an expert-level function. Use only if you know what you are
    * doing.
    * 
    * @note If you want to set both DEVICE and HOST memory to the same value

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -191,7 +191,7 @@ namespace ReSolve {
   }
 
   /**
-   * @brief Tags `memsapce` as updated.
+   * @brief Tags `memspace` as updated.
    *
    * @param[in] memspace - memory space (HOST or DEVICE) to set to "updated"
    *

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -197,10 +197,10 @@ namespace ReSolve {
    *
    * @return 0 if successful, -1 if not.
    * 
-   * The method sets boolean flag indicating that the `memspace` is updated.
+   * The method sets the boolean flag indicating that the `memspace` is updated.
    * It automatically sets the other data mirror to non-updated. You would
    * use this function if you update matrix data by accessing its raw pointers.
-   * In such case, matrix has no way of knowing which data is most recent, so
+   * In such case, the matrix has no way of knowing which data is most recent, so
    * you have to tell it.
    * 
    * @warning This is expert-level function. Use only if you know what you are

--- a/resolve/matrix/Sparse.cpp
+++ b/resolve/matrix/Sparse.cpp
@@ -191,13 +191,23 @@ namespace ReSolve {
   }
 
   /**
-   * @brief Set the data to be updated on HOST or DEVICE. 
+   * @brief Tags `memsapce` as updated.
    *
-   * @param[in] memspace - memory space (HOST or DEVICE) of data that is set to "updated"
+   * @param[in] memspace - memory space (HOST or DEVICE) to set to "updated"
    *
    * @return 0 if successful, -1 if not.
    * 
-   * @note The method automatically sets the other mirror data to non-updated (but it does not copy).
+   * The method sets boolean flag indicating that the `memspace` is updated.
+   * It automatically sets the other data mirror to non-updated. You would
+   * use this function if you update matrix data by accessing its raw pointers.
+   * In such case, matrix has no way of knowing which data is most recent, so
+   * you have to tell it.
+   * 
+   * @warning This is expert-level function. Use only if you know what you are
+   * doing.
+   * 
+   * @note If you want to set both DEVICE and HOST memory to the same value
+   * use syncData function.
    */  
   int matrix::Sparse::setUpdated(memory::MemorySpace memspace)
   {

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -279,7 +279,9 @@ ReSolve::vector::Vector* generateRhs(const index_type N, ReSolve::memory::Memory
     }
   }
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
-  vec_rhs->syncData(memspace);
+  if (memspace != ReSolve::memory::HOST) {
+    vec_rhs->syncData(memspace);
+  }
   return vec_rhs;
 } 
 
@@ -339,6 +341,8 @@ ReSolve::matrix::Csr* generateMatrix(const index_type N, ReSolve::memory::Memory
   }
 
   A->setUpdated(ReSolve::memory::HOST);
-  A->syncData(memspace);
+  if (memspace != ReSolve::memory::HOST) {
+    A->syncData(memspace);
+  }
   return A;
 }

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -126,7 +126,9 @@ static int runTest(int argc, char *argv[], std::string backend)
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1, true);
-  A->syncData(memspace);
+  if (memspace != memory::HOST) {
+    A->syncData(memspace);
+  }
   mat1.close();
 
   // Read first rhs vector


### PR DESCRIPTION
Several changes are made to improve error messages returned to user:
- If one of arrays with row or column indices is allocated but the other is not, this is probably a bug in Re::Solve. Instead of sending error message to the user, use `assert` statement to catch such errors in CI pipeline.
- Send warning to the user if trying to sync memory space that is already up-to-date. In that case, the user is probably doing something wrong but the issue might be harmless. The code ignores command and continues to run.
- Send an error message to the user if they are trying to sync a memory space with the other that is out of date. This is most likely a bug in user's code; user is directed to `syncData` documentation.

Closes #229