### PR TITLE
Fixed flipped assert statement that lead to failing tests.

### DIFF
--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -7,7 +7,7 @@
 #include "Coo.hpp"
 
 
-namespace ReSolve 
+namespace ReSolve
 {
   using out = io::Logger;
 
@@ -20,16 +20,16 @@ namespace ReSolve
   {
     sparse_format_ = TRIPLET;
   }
-  
-  matrix::Coo::Coo(index_type n, 
-                   index_type m, 
+
+  matrix::Coo::Coo(index_type n,
+                   index_type m,
                    index_type nnz,
                    bool symmetric,
                    bool expanded) : Sparse(n, m, nnz, symmetric, expanded)
   {
     sparse_format_ = TRIPLET;
   }
-  
+
   /**
    * @brief Hijacking constructor
    */
@@ -189,7 +189,7 @@ namespace ReSolve
     if (((memspaceIn == memory::DEVICE)) && ((memspaceOut == memory::DEVICE))){ control = 3;}
 
     if (memspaceOut == memory::HOST) {
-      //check if cpu data allocated	
+      //check if cpu data allocated
       assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) &&
              "In Coo::copyDataFrom one of host row or column data is null!\n");
 
@@ -249,7 +249,7 @@ namespace ReSolve
         return -1;
     }
     return 0;
-  } 
+  }
 
   int matrix::Coo::copyDataFrom(const index_type* row_data,
                                 const index_type* col_data,
@@ -261,7 +261,7 @@ namespace ReSolve
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
     return copyDataFrom(row_data, col_data, val_data, memspaceIn, memspaceOut);
-  } 
+  }
 
   int matrix::Coo::allocateMatrixData(memory::MemorySpace memspace)
   {
@@ -270,20 +270,20 @@ namespace ReSolve
 
     if (memspace == memory::HOST) {
       this->h_row_data_ = new index_type[nnz_current];
-      std::fill(h_row_data_, h_row_data_ + nnz_current, 0);  
+      std::fill(h_row_data_, h_row_data_ + nnz_current, 0);
       this->h_col_data_ = new index_type[nnz_current];
-      std::fill(h_col_data_, h_col_data_ + nnz_current, 0);  
+      std::fill(h_col_data_, h_col_data_ + nnz_current, 0);
       this->h_val_data_ = new real_type[nnz_current];
-      std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);  
+      std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);
       owns_cpu_sparsity_pattern_ = true;
       owns_cpu_values_ = true;
       return 0;
     }
 
     if (memspace == memory::DEVICE) {
-      mem_.allocateArrayOnDevice(&d_row_data_, nnz_current); 
-      mem_.allocateArrayOnDevice(&d_col_data_, nnz_current); 
-      mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
+      mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
+      mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);
+      mem_.allocateArrayOnDevice(&d_val_data_, nnz_current);
       owns_gpu_sparsity_pattern_ = true;
       owns_gpu_values_ = true;
       return 0;
@@ -293,13 +293,13 @@ namespace ReSolve
 
   /**
    * @brief Sync data in memspace with the updated memory space.
-   * 
+   *
    * @param memspace - memory space to be synced up (HOST or DEVICE)
    * @return int - 0 if successful, error code otherwise
-   * 
+   *
    * @pre The memory space other than `memspace` must be up-to-date. Otherwise,
    * this function will return an error.
-   * 
+   *
    * @see Sparse::setUpdated
    */
   int matrix::Coo::syncData(memory::MemorySpace memspace)
@@ -308,7 +308,7 @@ namespace ReSolve
 
     switch (memspace) {
       case HOST:
-        assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
+        assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) &&
                "In Coo::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
@@ -322,12 +322,12 @@ namespace ReSolve
           assert(d_data_updated_);
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
-          h_row_data_ = new index_type[nnz_];      
-          h_col_data_ = new index_type[nnz_];      
+          h_row_data_ = new index_type[nnz_];
+          h_col_data_ = new index_type[nnz_];
           owns_cpu_sparsity_pattern_ = true;
         }
         if (h_val_data_ == nullptr) {
-          h_val_data_ = new real_type[nnz_];      
+          h_val_data_ = new real_type[nnz_];
           owns_cpu_values_ = true;
         }
         mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, nnz_);
@@ -336,7 +336,7 @@ namespace ReSolve
         h_data_updated_ = true;
         return 0;
       case DEVICE:
-        assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
+        assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) &&
                "In Coo::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
@@ -370,7 +370,7 @@ namespace ReSolve
 
   /**
    * @brief Prints matrix data.
-   * 
+   *
    * @param out - Output stream where the matrix data is printed
    */
   void matrix::Coo::print(std::ostream& out, index_type indexing_base)

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -5,7 +5,7 @@
 #include <resolve/utilities/logger/Logger.hpp>
 #include "Csc.hpp"
 
-namespace ReSolve 
+namespace ReSolve
 {
   using out = io::Logger;
 
@@ -18,9 +18,9 @@ namespace ReSolve
   {
     sparse_format_ = COMPRESSED_SPARSE_COLUMN;
   }
-  
-  matrix::Csc::Csc(index_type n, 
-                   index_type m, 
+
+  matrix::Csc::Csc(index_type n,
+                   index_type m,
                    index_type nnz,
                    bool symmetric,
                    bool expanded) : Sparse(n, m, nnz, symmetric, expanded)
@@ -99,7 +99,7 @@ namespace ReSolve
         this->h_col_data_ = new index_type[m_ + 1];
         this->h_row_data_ = new index_type[nnz_current];
         owns_cpu_sparsity_pattern_ = true;
-      } 
+      }
       if (h_val_data_ == nullptr) {
         this->h_val_data_ = new real_type[nnz_current];
         owns_cpu_values_ = true;
@@ -112,12 +112,12 @@ namespace ReSolve
              "In Csc::copyDataFrom one of device row or column data is null!\n");
 
       if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
-        mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
+        mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1);
         mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
         owns_gpu_sparsity_pattern_ = true;
       }
       if (d_val_data_ == nullptr) {
-        mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
+        mem_.allocateArrayOnDevice(&d_val_data_, nnz_current);
         owns_gpu_values_ = true;
       }
     }
@@ -152,7 +152,7 @@ namespace ReSolve
     }
     return 0;
 
-  } 
+  }
 
   int matrix::Csc::copyDataFrom(const index_type* row_data,
                                 const index_type* col_data,
@@ -173,36 +173,36 @@ namespace ReSolve
 
     if (memspace == memory::HOST) {
       this->h_col_data_ = new index_type[m_ + 1];
-      std::fill(h_col_data_, h_col_data_ + m_ + 1, 0);  
+      std::fill(h_col_data_, h_col_data_ + m_ + 1, 0);
       this->h_row_data_ = new index_type[nnz_current];
-      std::fill(h_row_data_, h_row_data_ + nnz_current, 0);  
+      std::fill(h_row_data_, h_row_data_ + nnz_current, 0);
       this->h_val_data_ = new real_type[nnz_current];
-      std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);  
+      std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);
       owns_cpu_sparsity_pattern_ = true;
       owns_cpu_values_ = true;
       return 0;
     }
 
     if (memspace == memory::DEVICE) {
-      mem_.allocateArrayOnDevice(&d_col_data_,      m_ + 1); 
-      mem_.allocateArrayOnDevice(&d_row_data_, nnz_current); 
-      mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
+      mem_.allocateArrayOnDevice(&d_col_data_,      m_ + 1);
+      mem_.allocateArrayOnDevice(&d_row_data_, nnz_current);
+      mem_.allocateArrayOnDevice(&d_val_data_, nnz_current);
       owns_gpu_sparsity_pattern_ = true;
       owns_gpu_values_ = true;
-      return 0;   
+      return 0;
     }
     return -1;
   }
 
   /**
    * @brief Sync data in memspace with the updated memory space.
-   * 
+   *
    * @param memspace - memory space to be synced up (HOST or DEVICE)
    * @return int - 0 if successful, error code otherwise
-   * 
+   *
    * @pre The memory space other than `memspace` must be up-to-date. Otherwise,
    * this function will return an error.
-   * 
+   *
    * @see Sparse::setUpdated
    */
   int matrix::Csc::syncData(memory::MemorySpace memspace)
@@ -211,7 +211,7 @@ namespace ReSolve
 
     switch(memspace) {
       case HOST:
-        assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
+        assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) &&
                "In Csc::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
@@ -225,21 +225,21 @@ namespace ReSolve
           assert(d_data_updated_);
         }
         if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr)) {
-          h_col_data_ = new index_type[m_ + 1];      
-          h_row_data_ = new index_type[nnz_];      
+          h_col_data_ = new index_type[m_ + 1];
+          h_row_data_ = new index_type[nnz_];
           owns_cpu_sparsity_pattern_ = true;
         }
         if (h_val_data_ == nullptr) {
-          h_val_data_ = new real_type[nnz_];      
+          h_val_data_ = new real_type[nnz_];
           owns_cpu_values_ = true;
         }
         mem_.copyArrayDeviceToHost(h_col_data_, d_col_data_, m_ + 1);
         mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_,   nnz_);
         mem_.copyArrayDeviceToHost(h_val_data_, d_val_data_,   nnz_);
         h_data_updated_ = true;
-        return 0;   
+        return 0;
       case DEVICE:
-        assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
+        assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) &&
                "In Csc::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
@@ -253,7 +253,7 @@ namespace ReSolve
           assert(h_data_updated_);
         }
         if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr)) {
-          mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1); 
+          mem_.allocateArrayOnDevice(&d_col_data_, m_ + 1);
           mem_.allocateArrayOnDevice(&d_row_data_,   nnz_);
           owns_gpu_sparsity_pattern_ = true;
         }
@@ -273,7 +273,7 @@ namespace ReSolve
 
   /**
    * @brief Prints matrix data.
-   * 
+   *
    * @param out - Output stream where the matrix data is printed
    */
   void matrix::Csc::print(std::ostream& out, index_type indexing_base)

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -7,7 +7,7 @@
 #include "Coo.hpp"
 #include <resolve/utilities/logger/Logger.hpp>
 
-namespace ReSolve 
+namespace ReSolve
 {
   using out = io::Logger;
 
@@ -20,9 +20,9 @@ namespace ReSolve
   {
     sparse_format_ = COMPRESSED_SPARSE_ROW;
   }
-  
-  matrix::Csr::Csr(index_type n, 
-                   index_type m, 
+
+  matrix::Csr::Csr(index_type n,
+                   index_type m,
                    index_type nnz,
                    bool symmetric,
                    bool expanded) : Sparse(n, m, nnz, symmetric, expanded)
@@ -32,20 +32,20 @@ namespace ReSolve
 
   /**
    * @brief Hijacking constructor
-   * 
-   * @param[in] n 
-   * @param[in] m 
-   * @param[in] nnz 
-   * @param[in] symmetric 
-   * @param[in] expanded 
-   * @param[in,out] rows 
-   * @param[in,out] cols 
-   * @param[in,out] vals 
-   * @param[in] memspaceSrc 
-   * @param[in] memspaceDst 
+   *
+   * @param[in] n
+   * @param[in] m
+   * @param[in] nnz
+   * @param[in] symmetric
+   * @param[in] expanded
+   * @param[in,out] rows
+   * @param[in,out] cols
+   * @param[in,out] vals
+   * @param[in] memspaceSrc
+   * @param[in] memspaceDst
    */
-  matrix::Csr::Csr(index_type n, 
-                   index_type m, 
+  matrix::Csr::Csr(index_type n,
+                   index_type m,
                    index_type nnz,
                    bool symmetric,
                    bool expanded,
@@ -214,7 +214,7 @@ namespace ReSolve
         this->h_row_data_ = new index_type[n_ + 1];
         this->h_col_data_ = new index_type[nnz_current];
         owns_cpu_sparsity_pattern_ = true;
-      } 
+      }
       if (h_val_data_ == nullptr) {
         this->h_val_data_ = new real_type[nnz_current];
         owns_cpu_values_ = true;
@@ -227,18 +227,18 @@ namespace ReSolve
              "In Csr::copyDataFrom one of device row or column data is null!\n");
 
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
-        mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
+        mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1);
         mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);
         owns_gpu_values_ = true;
       }
       if (d_val_data_ == nullptr) {
-        mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
+        mem_.allocateArrayOnDevice(&d_val_data_, nnz_current);
         owns_gpu_sparsity_pattern_ = true;
       }
     }
 
 
-    //copy	
+    //copy
     switch(control)  {
       case 0: //cpu->cpu
         mem_.copyArrayHostToHost(h_row_data_, row_data,      n_ + 1);
@@ -268,7 +268,7 @@ namespace ReSolve
         return -1;
     }
     return 0;
-  } 
+  }
 
   int matrix::Csr::copyDataFrom(const index_type* row_data,
                                 const index_type* col_data,
@@ -280,7 +280,7 @@ namespace ReSolve
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
     return copyDataFrom(row_data, col_data, val_data, memspaceIn, memspaceOut);
-  } 
+  }
 
   int matrix::Csr::allocateMatrixData(memory::MemorySpace memspace)
   {
@@ -289,36 +289,36 @@ namespace ReSolve
 
     if (memspace == memory::HOST) {
       this->h_row_data_ = new index_type[n_ + 1];
-      std::fill(h_row_data_, h_row_data_ + n_ + 1, 0);  
+      std::fill(h_row_data_, h_row_data_ + n_ + 1, 0);
       this->h_col_data_ = new index_type[nnz_current];
-      std::fill(h_col_data_, h_col_data_ + nnz_current, 0);  
+      std::fill(h_col_data_, h_col_data_ + nnz_current, 0);
       this->h_val_data_ = new real_type[nnz_current];
-      std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);  
+      std::fill(h_val_data_, h_val_data_ + nnz_current, 0.0);
       owns_cpu_sparsity_pattern_ = true;
       owns_cpu_values_ = true;
-      return 0;   
+      return 0;
     }
 
     if (memspace == memory::DEVICE) {
-      mem_.allocateArrayOnDevice(&d_row_data_,      n_ + 1); 
-      mem_.allocateArrayOnDevice(&d_col_data_, nnz_current); 
-      mem_.allocateArrayOnDevice(&d_val_data_, nnz_current); 
+      mem_.allocateArrayOnDevice(&d_row_data_,      n_ + 1);
+      mem_.allocateArrayOnDevice(&d_col_data_, nnz_current);
+      mem_.allocateArrayOnDevice(&d_val_data_, nnz_current);
       owns_gpu_sparsity_pattern_ = true;
       owns_gpu_values_ = true;
-      return 0;  
+      return 0;
     }
     return -1;
   }
 
   /**
    * @brief Sync data in memspace with the updated memory space.
-   * 
+   *
    * @param memspace - memory space to be synced up (HOST or DEVICE)
    * @return int - 0 if successful, error code otherwise
-   * 
+   *
    * @pre The memory space other than `memspace` must be up-to-date. Otherwise,
    * this function will return an error.
-   * 
+   *
    * @see Sparse::setUpdated
    */
   int matrix::Csr::syncData(memory::MemorySpace memspace)
@@ -328,7 +328,7 @@ namespace ReSolve
     switch (memspace) {
       case HOST:
         //check if we need to copy or not
-        assert(((h_row_data_ == nullptr) != (h_col_data_ == nullptr)) &&
+        assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) &&
                "In Csr::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
@@ -343,11 +343,11 @@ namespace ReSolve
         }
         if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr)) {
           h_row_data_ = new index_type[n_ + 1];
-          h_col_data_ = new index_type[nnz_];      
+          h_col_data_ = new index_type[nnz_];
           owns_cpu_sparsity_pattern_ = true;
         }
         if (h_val_data_ == nullptr) {
-          h_val_data_ = new real_type[nnz_];      
+          h_val_data_ = new real_type[nnz_];
           owns_cpu_values_ = true;
         }
         mem_.copyArrayDeviceToHost(h_row_data_, d_row_data_, n_ + 1);
@@ -356,7 +356,7 @@ namespace ReSolve
         h_data_updated_ = true;
         return 0;
       case DEVICE:
-        assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr)) &&
+        assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) &&
                "In Csr::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
@@ -370,12 +370,12 @@ namespace ReSolve
           assert(h_data_updated_);
         }
         if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr)) {
-          mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1); 
-          mem_.allocateArrayOnDevice(&d_col_data_, nnz_); 
+          mem_.allocateArrayOnDevice(&d_row_data_, n_ + 1);
+          mem_.allocateArrayOnDevice(&d_col_data_, nnz_);
           owns_gpu_sparsity_pattern_ = true;
         }
         if (d_val_data_ == nullptr) {
-          mem_.allocateArrayOnDevice(&d_val_data_, nnz_); 
+          mem_.allocateArrayOnDevice(&d_val_data_, nnz_);
           owns_gpu_values_ = true;
         }
         mem_.copyArrayHostToDevice(d_row_data_, h_row_data_, n_ + 1);
@@ -391,7 +391,7 @@ namespace ReSolve
 
   /**
    * @brief Prints matrix data.
-   * 
+   *
    * @param out - Output stream where the matrix data is printed
    */
   void matrix::Csr::print(std::ostream& out, index_type indexing_base)
@@ -399,11 +399,11 @@ namespace ReSolve
     out << std::scientific << std::setprecision(std::numeric_limits<real_type>::digits10);
     for(index_type i = 0; i < n_; ++i) {
       for (index_type j = h_row_data_[i]; j < h_row_data_[i+1]; ++j) {
-        out << i              + indexing_base << " " 
+        out << i              + indexing_base << " "
             << h_col_data_[j] + indexing_base << " "
             << h_val_data_[j] << "\n";
       }
     }
   }
-} // namespace ReSolve 
+} // namespace ReSolve
 


### PR DESCRIPTION
## Description
 
 ```
The assert statement `assert(((d_row_data_ == nullptr) != (d_col_data_ == nullptr))` should be `==` instead (for host as well).
```
 
 _Closes # [Issue 262](https://github.com/ORNL/ReSolve/issues/262)


 ## Proposed changes
 
 _Corrected the conditional_
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [X] All tests pass. Code tested on
     - [X] CPU backend
     - [X] CUDA backend
     - [x] HIP backend
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows Re::Solve style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [X] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc._

