### PR TITLE
Enhancement: remove unnecessary second analyze 

### DIFF
--- a/examples/gpuRefactor.cpp
+++ b/examples/gpuRefactor.cpp
@@ -228,8 +228,6 @@ int gpuRefactor(int argc, char *argv[])
         index_type* Q = KLU.getQOrdering();
 
         Rf.setup(A, L, U, P, Q, vec_rhs);
-        // Refactorization
-        // Rf.refactorize();
 
         // Setup iterative refinement solver
         if (is_iterative_refinement) {

--- a/examples/gpuRefactor.cpp
+++ b/examples/gpuRefactor.cpp
@@ -193,9 +193,8 @@ int gpuRefactor(int argc, char *argv[])
 
     int status = 0;
 
-    if (i < 2) {
+    if (i == 0) {
       RESOLVE_RANGE_PUSH("KLU");
-
       // Setup factorization solver
       KLU.setup(A);
       matrix_handler.setValuesChanged(true, memory::DEVICE);
@@ -203,7 +202,9 @@ int gpuRefactor(int argc, char *argv[])
       // Analysis (symbolic factorization)
       status = KLU.analyze();
       std::cout << "KLU analysis status: " << status << std::endl;
+    }
 
+    if (i < 2) {
       // Numeric factorization
       status = KLU.factorize();
       std::cout << "KLU factorization status: " << status << std::endl;
@@ -228,7 +229,7 @@ int gpuRefactor(int argc, char *argv[])
 
         Rf.setup(A, L, U, P, Q, vec_rhs);
         // Refactorization
-        Rf.refactorize();
+        // Rf.refactorize();
 
         // Setup iterative refinement solver
         if (is_iterative_refinement) {

--- a/examples/kluRefactor.cpp
+++ b/examples/kluRefactor.cpp
@@ -134,18 +134,16 @@ int main(int argc, char *argv[])
     mat_file.close();
     rhs_file.close();
 
-    // Update data.
-    if (i < 2) {
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
-    }
     std::cout<<"COO to CSR completed. Expanded NNZ: "<< A->getNnz()<<std::endl;
     //Now call direct solver
     int status;
-
-    if (i < 2){
+    if (i==0) {
+      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
       KLU->setup(A);
       status = KLU->analyze();
       std::cout<<"KLU analysis status: "<<status<<std::endl;
+    }
+    if (i < 2){
       status = KLU->factorize();
       std::cout<<"KLU factorization status: "<<status<<std::endl;
     } else {

--- a/examples/sysRefactor.cpp
+++ b/examples/sysRefactor.cpp
@@ -108,6 +108,12 @@ int sysRefactor(int argc, char *argv[])
   CliOptions options(argc, argv);
   CliOptions::Option* opt = nullptr;
 
+  bool is_help = options.hasKey("-h");
+  if (is_help) {
+    printHelpInfo();
+    return 0;
+  }
+
   bool is_iterative_refinement = options.hasKey("-i");
 
   index_type num_systems = 0;
@@ -171,7 +177,7 @@ int sysRefactor(int argc, char *argv[])
   // Create system solver
   std::string refactor("none");
   if (hw_backend == "CUDA") {
-    refactor = "cusolverrf";
+    refactor = "glu";
   } else if (hw_backend == "HIP") {
     refactor = "rocsolverrf";
   } else {

--- a/examples/sysRefactor.cpp
+++ b/examples/sysRefactor.cpp
@@ -282,9 +282,6 @@ int sysRefactor(int argc, char *argv[])
       status = solver.refactorizationSetup();
       std::cout << "Refactorization setup status: " << status << std::endl;
 
-      // Refactorize on the device
-      status = solver.refactorize();
-      std::cout << "Refactorization on the device status: " << status << std::endl;
     } else {
       // Refactorize on the device
       status = solver.refactorize();

--- a/examples/sysRefactor.cpp
+++ b/examples/sysRefactor.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
   else if (opt->second == "cpu")
   {
     sysRefactor<ReSolve::LinAlgWorkspaceCpu>(argc, argv);
-  } 
+  }
   else
   {
     std::cout << "Re::Solve is not built with support for " << opt->second;

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -332,6 +332,7 @@ namespace ReSolve
   int SystemSolver::factorize()
   {
     if (factorizationMethod_ == "klu") {
+      is_solve_on_device_ = false;
       return factorizationSolver_->factorize();
     } 
     return 1;
@@ -346,7 +347,8 @@ namespace ReSolve
     if (refactorizationMethod_ == "glu" || 
         refactorizationMethod_ == "cusolverrf" || 
         refactorizationMethod_ == "rocsolverrf") {
-      return refactorizationSolver_->refactorize();
+          is_solve_on_device_ = true;
+          return refactorizationSolver_->refactorize();
     }
 
     return 1;
@@ -385,7 +387,7 @@ namespace ReSolve
 
 #ifdef RESOLVE_USE_CUDA
     if (refactorizationMethod_ == "glu") {
-      isSolveOnDevice_ = true;
+      is_solve_on_device_ = true;
       status += refactorizationSolver_->setup(A_, L_, U_, P_, Q_);
     }
     if (refactorizationMethod_ == "cusolverrf") {
@@ -394,13 +396,13 @@ namespace ReSolve
       LinSolverDirectCuSolverRf* Rf = dynamic_cast<LinSolverDirectCuSolverRf*>(refactorizationSolver_);
       Rf->setNumericalProperties(1e-14, 1e-1);
 
-      isSolveOnDevice_ = true;
+      is_solve_on_device_ = false;
     }
 #endif
 
 #ifdef RESOLVE_USE_HIP
     if (refactorizationMethod_ == "rocsolverrf") {
-      isSolveOnDevice_ = true;
+      is_solve_on_device_ = false;
       auto* Rf = dynamic_cast<LinSolverDirectRocSolverRf*>(refactorizationSolver_);
       Rf->setSolveMode(1);
       status += refactorizationSolver_->setup(A_, L_, U_, P_, Q_, resVector_);
@@ -444,7 +446,7 @@ namespace ReSolve
     } 
 
     if (solveMethod_ == "glu" || solveMethod_ == "cusolverrf" || solveMethod_ == "rocsolverrf") {
-      if (isSolveOnDevice_) {
+      if (is_solve_on_device_) {
         status += refactorizationSolver_->solve(rhs, x);
       } else {
         status += factorizationSolver_->solve(rhs, x);
@@ -452,7 +454,7 @@ namespace ReSolve
     } 
 
     if (irMethod_ == "fgmres") {
-      if (isSolveOnDevice_) {
+      if (is_solve_on_device_) {
         status += refine(rhs, x);
       }
     }
@@ -465,7 +467,7 @@ namespace ReSolve
     if (precondition_method_ == "ilu0") {
       status += preconditioner_->setup(A_);
       if (memspace_ != "cpu") {
-        isSolveOnDevice_ = true;
+        is_solve_on_device_ = true;
       }
       iterativeSolver_->setupPreconditioner("LU", preconditioner_);
     }
@@ -632,7 +634,7 @@ namespace ReSolve
       norm_b = std::sqrt(vectorHandler_->dot(rhs, rhs, memory::HOST));
 #if defined(RESOLVE_USE_HIP) || defined(RESOLVE_USE_CUDA)
     } else if (memspace_ == "cuda" || memspace_ == "hip") {
-      if (isSolveOnDevice_) {
+      if (is_solve_on_device_) {
         norm_b = std::sqrt(vectorHandler_->dot(rhs, rhs, memory::DEVICE));
       } else {
         norm_b = std::sqrt(vectorHandler_->dot(rhs, rhs, memory::HOST));
@@ -657,7 +659,7 @@ namespace ReSolve
       norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::HOST));
 #if defined(RESOLVE_USE_HIP) || defined(RESOLVE_USE_CUDA)
     } else if (memspace_ == "cuda" || memspace_ == "hip") {
-      if (isSolveOnDevice_) {
+      if (is_solve_on_device_) {
         resVector_->copyDataFrom(rhs, memory::DEVICE, memory::DEVICE);
         norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::DEVICE));
       } else {
@@ -689,7 +691,7 @@ namespace ReSolve
       resVector_->copyDataFrom(rhs, memory::HOST, memory::HOST);
 #if defined(RESOLVE_USE_HIP) || defined(RESOLVE_USE_CUDA)
     } else if (memspace_ == "cuda" || memspace_ == "hip") {
-      if (isSolveOnDevice_) {
+      if (is_solve_on_device_) {
         resVector_->copyDataFrom(rhs, memory::DEVICE, memory::DEVICE);
       } else {
         resVector_->copyDataFrom(rhs, memory::HOST, memory::DEVICE);

--- a/resolve/SystemSolver.hpp
+++ b/resolve/SystemSolver.hpp
@@ -103,7 +103,7 @@ namespace ReSolve
       MatrixHandler* matrixHandler_{nullptr};
       VectorHandler* vectorHandler_{nullptr};
 
-      bool isSolveOnDevice_{false};
+      bool is_solve_on_device_{false};
 
       matrix_type* L_{nullptr};
       matrix_type* U_{nullptr};


### PR DESCRIPTION
## Description
 
`kluRefactor`, `sysRefactor`, and `gpuRefactor` were all performing a redundant second analyze.
 
 ## Proposed changes
 
 _Made sure analyze is only done once. All tests pass._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [X] All tests pass. Code tested on
     - [X] CPU backend
     - [X] CUDA backend
     - [X] HIP backend
- [X] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [X] The new code follows Re::Solve style guidelines.
- [X] There are unit tests for the new code.
- [X] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 

