### PR TITLE
Removed magic numbers and codified them as constants

### DIFF
--- a/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
@@ -168,8 +168,8 @@ int main(int argc, char *argv[] )
     std::cout << "\t2-Norm of the residual: "
               << std::scientific << std::setprecision(16)
               << res_nrm/b_nrm << "\n";
-    if (((res_nrm/b_nrm > REDO_FACTOR_TOL) && (!std::isnan(res_nrm))) || (status_refactor != 0 )) {
-      if ((res_nrm/b_nrm > REDO_FACTOR_TOL )) {
+    if (((res_nrm/b_nrm > 1e-7) && (!std::isnan(res_nrm))) || (status_refactor != 0 )) {
+      if ((res_nrm/b_nrm > 1e-7 )) {
         std::cout << "\n \t !!! ALERT !!! Residual norm is too large; redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n \n";
       } else {
         std::cout << "\n \t !!! ALERT !!! cuSolverRf crashed; redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n \n";

--- a/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -152,7 +152,7 @@ int main(int argc, char *argv[] )
               << std::scientific << std::setprecision(16)
               << res_nrm/b_nrm << "\n";
     if (!isnan(res_nrm)) {
-       if (res_nrm/b_nrm > REDO_FACTOR_TOL) {
+       if (res_nrm/b_nrm > 1e-7) {
          std::cout << "\n \t !!! ALERT !!! Residual norm is too large; "
                    << "redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n\n";
 

--- a/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[] )
 
   ReSolve::LinSolverDirectKLU* KLU = new ReSolve::LinSolverDirectKLU;
   ReSolve::LinSolverDirectRocSolverRf* Rf = new ReSolve::LinSolverDirectRocSolverRf(workspace_HIP);
-  
+
   real_type res_nrm;
   real_type b_nrm;
 
@@ -100,17 +100,17 @@ int main(int argc, char *argv[] )
     // Copy matrix data to device
     A->syncData(ReSolve::memory::DEVICE);
 
-    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
-              << ", nnz: "       << A->getNnz() 
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns()
+              << ", nnz: "       << A->getNnz()
               << ", symmetric? " << A->symmetric()
               << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
-    if (i < 2) { 
+    if (i < 2) {
       vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-    } else { 
+    } else {
       vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
@@ -124,66 +124,66 @@ int main(int argc, char *argv[] )
       status = KLU->factorize();
       std::cout << "KLU factorization status: " << status << std::endl;
       status = KLU->solve(vec_rhs, vec_x);
-      std::cout << "KLU solve status: " << status << std::endl;      
+      std::cout << "KLU solve status: " << status << std::endl;
       if (i == 1) {
         ReSolve::matrix::Csc* L = (ReSolve::matrix::Csc*) KLU->getLFactor();
         ReSolve::matrix::Csc* U = (ReSolve::matrix::Csc*) KLU->getUFactor();
         index_type* P = KLU->getPOrdering();
         index_type* Q = KLU->getQOrdering();
         vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-        Rf->setup(A, L, U, P, Q, vec_rhs); 
+        Rf->setup(A, L, U, P, Q, vec_rhs);
         Rf->refactorize();
       }
     } else {
       std::cout << "Using rocsolver rf" << std::endl;
       status = Rf->refactorize();
-      std::cout << "rocsolver rf refactorization status: " << status << std::endl;      
+      std::cout << "rocsolver rf refactorization status: " << status << std::endl;
       status = Rf->solve(vec_rhs, vec_x);
-      std::cout << "rocsolver rf solve status: " << status << std::endl;      
+      std::cout << "rocsolver rf solve status: " << status << std::endl;
     }
 
     // Check accuracy of the solution
     vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE);
     res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     b_nrm = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
-    std::cout << "\t 2-Norm of the residual: " 
-              << std::scientific << std::setprecision(16) 
+    std::cout << "\t 2-Norm of the residual: "
+              << std::scientific << std::setprecision(16)
               << res_nrm/b_nrm << "\n";
     if (!isnan(res_nrm)) {
-       if (res_nrm/b_nrm > 1e-7 ) {
+       if (res_nrm/b_nrm > REDO_FACTOR_TOL) {
          std::cout << "\n \t !!! ALERT !!! Residual norm is too large; "
                    << "redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n\n";
-       
+
          KLU->setup(A);
          status = KLU->analyze();
          std::cout << "KLU analysis status: " << status << std::endl;
          status = KLU->factorize();
          std::cout << "KLU factorization status: " << status << std::endl;
          status = KLU->solve(vec_rhs, vec_x);
-         std::cout << "KLU solve status: " << status << std::endl;      
-         
+         std::cout << "KLU solve status: " << status << std::endl;
+
          vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
          vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
          matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-         matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+         matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE);
          res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
-         
+
          std::cout << "\t New residual norm: "
            << std::scientific << std::setprecision(16)
            << res_nrm/b_nrm << "\n";
 
 
-         ReSolve::matrix::Csc* L = (ReSolve::matrix::Csc*) KLU->getLFactor();         
+         ReSolve::matrix::Csc* L = (ReSolve::matrix::Csc*) KLU->getLFactor();
          ReSolve::matrix::Csc* U = (ReSolve::matrix::Csc*) KLU->getUFactor();
 
          index_type* P = KLU->getPOrdering();
          index_type* Q = KLU->getQOrdering();
 
-         Rf->setup(A, L, U, P, Q, vec_rhs); 
+         Rf->setup(A, L, U, P, Q, vec_rhs);
        }
     }
 

--- a/examples/randGmres.cpp
+++ b/examples/randGmres.cpp
@@ -163,7 +163,7 @@ int runGmresExample(int argc, char *argv[])
   Precond.setup(A);
   FGMRES.setRestart(150);
   FGMRES.setMaxit(2500);
-  FGMRES.setTol(constants::LOOSE_TOL);
+  FGMRES.setTol(1e-12);
   FGMRES.setup(A);
 
   FGMRES.resetMatrix(A);

--- a/examples/randGmres.cpp
+++ b/examples/randGmres.cpp
@@ -33,7 +33,7 @@ static void printUsage()
   std::cout << "\t -h\tPrints this message.\n\n";
 }
 
-/// Prototype of the example main function 
+/// Prototype of the example main function
 template <class workspace_type, class precon_type>
 static int runGmresExample(int argc, char *argv[]);
 
@@ -163,12 +163,12 @@ int runGmresExample(int argc, char *argv[])
   Precond.setup(A);
   FGMRES.setRestart(150);
   FGMRES.setMaxit(2500);
-  FGMRES.setTol(1e-12);
+  FGMRES.setTol(constants::LOOSE_TOL);
   FGMRES.setup(A);
 
   FGMRES.resetMatrix(A);
   FGMRES.setupPreconditioner("LU", &Precond);
-  FGMRES.setFlexible(1); 
+  FGMRES.setFlexible(1);
 
   FGMRES.solve(vec_rhs, vec_x);
 

--- a/examples/sysRefactor.cpp
+++ b/examples/sysRefactor.cpp
@@ -200,9 +200,6 @@ int sysRefactor(int argc, char *argv[])
   if (is_iterative_refinement) {
     solver.setRefinementMethod("fgmres", "cgs2");
     solver.getIterativeSolver().setCliParam("restart", "100");
-    if (hw_backend == "CUDA") {
-      solver.getIterativeSolver().setTol(constants::MACHINE_EPSILON);
-    }
   }
 
   RESOLVE_RANGE_PUSH(__FUNCTION__);

--- a/examples/sysRefactor.cpp
+++ b/examples/sysRefactor.cpp
@@ -201,7 +201,7 @@ int sysRefactor(int argc, char *argv[])
     solver.setRefinementMethod("fgmres", "cgs2");
     solver.getIterativeSolver().setCliParam("restart", "100");
     if (hw_backend == "CUDA") {
-      solver.getIterativeSolver().setTol(1e-17);
+      solver.getIterativeSolver().setTol(constants::MACHINE_EPSILON);
     }
   }
 

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -7,12 +7,6 @@
 
 namespace ReSolve {
 
-
-  // TODO: these should be dropped
-  constexpr double EPSILON = 1.0e-18;
-  constexpr double EPSMAC  = 1.0e-16;
-
-
   /// @todo Provide CMake option to se these types at config time
   using real_type = double;
   using index_type = std::int32_t;
@@ -22,7 +16,9 @@ namespace ReSolve {
     constexpr real_type ZERO = 0.0;
     constexpr real_type ONE = 1.0;
     constexpr real_type MINUSONE = -1.0;
-    constexpr real_type DEFAULT_TOL = 100*std::numeric_limits<real_type>::epsilon();
+    constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
+    constexpr real_type DEFAULT_TOL = 100*MACHINE_EPSILON;
+    constexpr real_type LOOP_TOL = 10000*MACHINE_EPSILON;
   }
 
   namespace colors

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -17,8 +17,9 @@ namespace ReSolve {
     constexpr real_type ONE = 1.0;
     constexpr real_type MINUSONE = -1.0;
     constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
-    constexpr real_type DEFAULT_TOL = 100*MACHINE_EPSILON;
-    constexpr real_type LOOSE_TOL = 10000*MACHINE_EPSILON;
+    constexpr real_type DEFAULT_TOL = 100 * MACHINE_EPSILON;
+    constexpr real_type SPECIAL_TOL = 1e-12;
+    constexpr real_type LOOSE_TOL = 100 * DEFAULT_TOL;
   }
 
   namespace colors

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -18,7 +18,7 @@ namespace ReSolve {
     constexpr real_type MINUSONE = -1.0;
     constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
     constexpr real_type DEFAULT_TOL = 100 * MACHINE_EPSILON;
-    constexpr real_type LOOSE_TOL = 100 * DEFAULT_TOL;
+    constexpr real_type LOOSE_TOL = 1000 * DEFAULT_TOL;
     constexpr real_type REDO_FACTOR_TOL = 1e-7;
     constexpr real_type DEFAULT_ZERO_DIAGONAL = 1e-6;
   }

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -17,7 +17,7 @@ namespace ReSolve {
     constexpr real_type ONE = 1.0;
     constexpr real_type MINUSONE = -1.0;
     constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
-    constexpr real_type DEFAULT_TOL = 100 * MACHINE_EPSILON;
+    // constexpr real_type DEFAULT_TOL = 100 * MACHINE_EPSILON;
     // constexpr real_type LOOSE_TOL = 1000 * DEFAULT_TOL;
     // constexpr real_type DEFAULT_ZERO_DIAGONAL = 1e-6;
   }

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -19,7 +19,6 @@ namespace ReSolve {
     constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
     constexpr real_type DEFAULT_TOL = 100 * MACHINE_EPSILON;
     // constexpr real_type LOOSE_TOL = 1000 * DEFAULT_TOL;
-    // constexpr real_type REDO_FACTOR_TOL = 1e-7;
     // constexpr real_type DEFAULT_ZERO_DIAGONAL = 1e-6;
   }
 

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -18,7 +18,7 @@ namespace ReSolve {
     constexpr real_type MINUSONE = -1.0;
     constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
     constexpr real_type DEFAULT_TOL = 100*MACHINE_EPSILON;
-    constexpr real_type LOOP_TOL = 10000*MACHINE_EPSILON;
+    constexpr real_type LOOSE_TOL = 10000*MACHINE_EPSILON;
   }
 
   namespace colors

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -18,8 +18,9 @@ namespace ReSolve {
     constexpr real_type MINUSONE = -1.0;
     constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
     constexpr real_type DEFAULT_TOL = 100 * MACHINE_EPSILON;
-    constexpr real_type SPECIAL_TOL = 1e-12;
     constexpr real_type LOOSE_TOL = 100 * DEFAULT_TOL;
+    constexpr real_type REDO_FACTOR_TOL = 1e-7;
+    constexpr real_type DEFAULT_ZERO_DIAGONAL = 1e-6;
   }
 
   namespace colors

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -18,9 +18,9 @@ namespace ReSolve {
     constexpr real_type MINUSONE = -1.0;
     constexpr real_type MACHINE_EPSILON  = std::numeric_limits<real_type>::epsilon();
     constexpr real_type DEFAULT_TOL = 100 * MACHINE_EPSILON;
-    constexpr real_type LOOSE_TOL = 1000 * DEFAULT_TOL;
-    constexpr real_type REDO_FACTOR_TOL = 1e-7;
-    constexpr real_type DEFAULT_ZERO_DIAGONAL = 1e-6;
+    // constexpr real_type LOOSE_TOL = 1000 * DEFAULT_TOL;
+    // constexpr real_type REDO_FACTOR_TOL = 1e-7;
+    // constexpr real_type DEFAULT_ZERO_DIAGONAL = 1e-6;
   }
 
   namespace colors

--- a/resolve/LinSolverDirectCpuILU0.cpp
+++ b/resolve/LinSolverDirectCpuILU0.cpp
@@ -2,8 +2,8 @@
  * @file LinSolverDirectCpuILU0.cpp
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Contains definition of a class for incomplete LU factorization on CPU
- * 
- * 
+ *
+ *
  */
 #include <cassert>
 
@@ -14,7 +14,7 @@
 
 #include "LinSolverDirectCpuILU0.hpp"
 
-namespace ReSolve 
+namespace ReSolve
 {
   using out = io::Logger;
 
@@ -25,7 +25,7 @@ namespace ReSolve
 
   /**
    * @brief Destructor
-   * 
+   *
    * @todo Address how L and U factors are deleted (currently base class does that).
    */
   LinSolverDirectCpuILU0::~LinSolverDirectCpuILU0()
@@ -75,7 +75,7 @@ namespace ReSolve
 
     // Update values in L and U factors
     const index_type N = A_->getNumRows();
-    index_type acount = 0; 
+    index_type acount = 0;
     for (index_type i = 0; i < N; ++i) {
       for (index_type j = rowsL[i]; j < rowsL[i+1]; ++j) {
           valsL[j] = valsA[acount];
@@ -151,7 +151,7 @@ namespace ReSolve
 
     // Set data for L and U
     index_type lcount = 0;
-    index_type ucount = 0; 
+    index_type ucount = 0;
     for (index_type i = 0; i < N; ++i) {
       colsU[ucount] = i;
       valsU[ucount] = diagU_[i];
@@ -161,7 +161,7 @@ namespace ReSolve
           colsL[lcount] = colsA[j];
           valsL[lcount] = valsA[j];
           ++lcount;
-        } 
+        }
         if (colsA[j] > i) {
           colsU[ucount] = colsA[j];
           valsU[ucount] = valsA[j];
@@ -235,7 +235,7 @@ namespace ReSolve
 
   /**
    * @brief Triangular solve
-   * 
+   *
    * @param[in,out] rhs_vec - right-hand-side vector
    * @return int - error code
    */
@@ -277,8 +277,8 @@ namespace ReSolve
 
   /**
    * @brief Triangular solve
-   * 
-   * @param[in]  rhs_vec - right-hand-side vector 
+   *
+   * @param[in]  rhs_vec - right-hand-side vector
    * @param[out] x_vec   - solution vector
    * @return int - status code
    */
@@ -333,11 +333,11 @@ namespace ReSolve
 
   /**
    * @brief Sets approximation to zero on matrix diagonal.
-   * 
+   *
    * If the original matrix has structural zeros on the diagonal, the ILU0
    * analysis will add diagonal elements and set them to `zero_diagonal_`
-   * value. The default is 1e-6, this function allows user to change that.
-   * 
+   * value. The default is set in `Common.hpp`. This function allows user to change that.
+   *
    * @param z - small value approximating zero
    * @return int - returns status code
    */
@@ -349,11 +349,11 @@ namespace ReSolve
 
   /**
    * @brief Placeholder function for now.
-   * 
+   *
    * The following switch (getParamId(Id)) cases always run the default and
    * are currently redundant code (like an if (true)).
    * In the future, they will be expanded to include more options.
-   * 
+   *
    * @param id - string ID for parameter to set.
    * @return int Error code.
    */
@@ -369,11 +369,11 @@ namespace ReSolve
 
   /**
    * @brief Placeholder function for now.
-   * 
+   *
    * The following switch (getParamId(Id)) cases always run the default and
    * are currently redundant code (like an if (true)).
    * In the future, they will be expanded to include more options.
-   * 
+   *
    * @param id - string ID for parameter to get.
    * @return std::string Value of the string parameter to return.
    */
@@ -389,11 +389,11 @@ namespace ReSolve
 
   /**
    * @brief Placeholder function for now.
-   * 
+   *
    * The following switch (getParamId(Id)) cases always run the default and
    * are currently redundant code (like an if (true)).
    * In the future, they will be expanded to include more options.
-   * 
+   *
    * @param id - string ID for parameter to get.
    * @return int Value of the int parameter to return.
    */
@@ -409,11 +409,11 @@ namespace ReSolve
 
   /**
    * @brief Placeholder function for now.
-   * 
+   *
    * The following switch (getParamId(Id)) cases always run the default and
    * are currently redundant code (like an if (true)).
    * In the future, they will be expanded to include more options.
-   * 
+   *
    * @param id - string ID for parameter to get.
    * @return real_type Value of the real_type parameter to return.
    */
@@ -429,11 +429,11 @@ namespace ReSolve
 
   /**
    * @brief Placeholder function for now.
-   * 
+   *
    * The following switch (getParamId(Id)) cases always run the default and
    * are currently redundant code (like an if (true)).
    * In the future, they will be expanded to include more options.
-   * 
+   *
    * @param id - string ID for parameter to get.
    * @return bool Value of the bool parameter to return.
    */

--- a/resolve/LinSolverDirectCpuILU0.cpp
+++ b/resolve/LinSolverDirectCpuILU0.cpp
@@ -336,7 +336,7 @@ namespace ReSolve
    *
    * If the original matrix has structural zeros on the diagonal, the ILU0
    * analysis will add diagonal elements and set them to `zero_diagonal_`
-   * value. The default is set in `Common.hpp`. This function allows user to change that.
+   * value. The default is 1e-6, this function allows user to change that.
    *
    * @param z - small value approximating zero
    * @return int - returns status code

--- a/resolve/LinSolverDirectCpuILU0.hpp
+++ b/resolve/LinSolverDirectCpuILU0.hpp
@@ -3,7 +3,7 @@
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Contains declaration of a class for incomplete LU factorization on CPU
  *
- * 
+ *
  */
 #pragma once
 
@@ -11,7 +11,7 @@
 #include <resolve/LinSolverDirect.hpp>
 #include <resolve/MemoryUtils.hpp>
 
-namespace ReSolve 
+namespace ReSolve
 {
   // Forward declaration of vector::Vector class
   namespace vector
@@ -30,24 +30,24 @@ namespace ReSolve
 
   /**
    * @brief Incomplete LU factorization solver.
-   * 
+   *
    * Implements ILU0 factorization from Algorithm 1 in 2023 paper by Suzuki,
    * Fukaya, and Iwashita with modification where zero diagonal elements in
    * the matrix are replaced by small values specified in `zero_diagonal_`.
    * Factors L and U are stored in separate CSR matrices. Factor L does not
    * store ones at the diagonal.
-   * 
+   *
    * Methods in this class perform all operations on raw matrix data.
-   * 
+   *
    */
-  class LinSolverDirectCpuILU0 : public LinSolverDirect 
+  class LinSolverDirectCpuILU0 : public LinSolverDirect
   {
     using vector_type = vector::Vector;
-    
-    public: 
+
+    public:
       LinSolverDirectCpuILU0(LinAlgWorkspaceCpu* workspace = nullptr);
       ~LinSolverDirectCpuILU0();
-      
+
       int setup(matrix::Sparse* A,
                 matrix::Sparse* L = nullptr,
                 matrix::Sparse* U = nullptr,
@@ -58,7 +58,7 @@ namespace ReSolve
       int reset(matrix::Sparse* A);
       int analyze() override;
       int factorize() override;
-       
+
       int solve(vector_type* rhs, vector_type* x) override;
       int solve(vector_type* rhs) override; // the solution is returned IN RHS (rhs is overwritten)
 
@@ -83,6 +83,6 @@ namespace ReSolve
       index_type* idxmap_{nullptr}; ///< Mapping for matrix column indices
       bool owns_factors_{false};    ///< If the class owns L and U factors
 
-      real_type zero_diagonal_{1e-6}; ///< Approximation for zero diagonal
+      real_type zero_diagonal_{constants::DEFAULT_ZERO_DIAGONAL}; ///< Value to replace zero diagonal elements
   };
 } // namespace ReSolve

--- a/resolve/LinSolverDirectCpuILU0.hpp
+++ b/resolve/LinSolverDirectCpuILU0.hpp
@@ -83,6 +83,6 @@ namespace ReSolve
       index_type* idxmap_{nullptr}; ///< Mapping for matrix column indices
       bool owns_factors_{false};    ///< If the class owns L and U factors
 
-      real_type zero_diagonal_{constants::DEFAULT_ZERO_DIAGONAL}; ///< Value to replace zero diagonal elements
+      real_type zero_diagonal_{1e-6}; ///< Value to replace zero diagonal elements
   };
 } // namespace ReSolve

--- a/resolve/LinSolverIterative.hpp
+++ b/resolve/LinSolverIterative.hpp
@@ -3,18 +3,18 @@
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Declaration of iterative solver base class.
- * 
+ *
  */
 #pragma once
 
 #include <string>
 #include <resolve/LinSolver.hpp>
 
-namespace ReSolve 
+namespace ReSolve
 {
   class GramSchmidt;
 
-  class LinSolverIterative : public LinSolver 
+  class LinSolverIterative : public LinSolver
   {
     public:
       LinSolverIterative();
@@ -43,7 +43,7 @@ namespace ReSolve
       index_type total_iters_;
 
       // Parameters common for all iterative solvers
-      real_type tol_{1e-14};  ///< Solver tolerance
+      real_type tol_{constants::DEFAULT_TOL};  ///< Solver tolerance
       index_type maxit_{100}; ///< Maximum solver iterations
   };
 }

--- a/resolve/LinSolverIterative.hpp
+++ b/resolve/LinSolverIterative.hpp
@@ -43,7 +43,7 @@ namespace ReSolve
       index_type total_iters_;
 
       // Parameters common for all iterative solvers
-      real_type tol_{constants::DEFAULT_TOL};  ///< Solver tolerance
+      real_type tol_{100 * constants::MACHINE_EPSILON}; ///< Convergence tolerance
       index_type maxit_{100}; ///< Maximum solver iterations
   };
 }

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -134,8 +134,8 @@ namespace ReSolve
       // check if maybe residual is already small enough?
       if (it == 0) {
         tolrel = tol_ * rnorm;
-        if (std::abs(tolrel) < 1e-16) {
-          tolrel = 1e-16;
+        if (std::abs(tolrel) < MACHINE_EPSILON) {
+          tolrel = MACHINE_EPSILON;
         }
       }
 

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -2,7 +2,7 @@
  * @file LinSolverIterativeFGMRES.cpp
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @brief Implementation of LinSolverIterativeFGMRES class
- * 
+ *
  */
 #include <iostream>
 #include <cassert>
@@ -37,8 +37,8 @@ namespace ReSolve
                                                      GramSchmidt*   gs)
   {
     // Base class settings here (to be removed when solver parameter settings are implemented)
-    tol_ = tol; 
-    maxit_= maxit; 
+    tol_ = tol;
+    maxit_= maxit;
     restart_ = restart;
     conv_cond_ = conv_cond;
     flexible_ = true;
@@ -59,13 +59,13 @@ namespace ReSolve
 
   /**
    * @brief Set pointer to system matrix and allocate solver data.
-   * 
+   *
    * @param[in] A - Sparse system matrix
-   * 
+   *
    * @pre A is a valid sparse matrix
-   * 
+   *
    * @post A_ == A
-   * @post Solver data allocated. 
+   * @post Solver data allocated.
    */
   int LinSolverIterativeFGMRES::setup(matrix::Sparse* A)
   {
@@ -98,9 +98,9 @@ namespace ReSolve
     using namespace constants;
 
     //io::Logger::setVerbosity(io::Logger::EVERYTHING);
-    
+
     int outer_flag = 1;
-    int notconv = 1; 
+    int notconv = 1;
     int i  = 0;
     int it = 0;
     int j  = 0;
@@ -118,8 +118,8 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_);
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
     rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
@@ -127,7 +127,7 @@ namespace ReSolve
     rnorm = std::sqrt(rnorm);
     bnorm = std::sqrt(bnorm);
     io::Logger::misc() << "it 0: norm of residual "
-                       << std::scientific << std::setprecision(16) 
+                       << std::scientific << std::setprecision(16)
                        << rnorm << " Norm of rhs: " << bnorm << "\n";
     initial_residual_norm_ = rnorm;
     while(outer_flag) {
@@ -143,13 +143,13 @@ namespace ReSolve
       switch (conv_cond_)
       {
         case 0:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON));
           break;
         case 1:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < tol_));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < tol_));
           break;
         case 2:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < (tol_*bnorm)));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < (tol_*bnorm)));
           break;
       }
 
@@ -187,7 +187,7 @@ namespace ReSolve
 
         vec_v->setData( vec_V_->getVectorData(i + 1, memspace_), memspace_);
 
-        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_); 
+        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_);
 
         // orthogonalize V[i+1], form a column of h_H_
 
@@ -204,8 +204,8 @@ namespace ReSolve
         real_type Hii1 = h_H_[(i) * (restart_ + 1) + i + 1];
         real_type gam = std::sqrt(Hii * Hii + Hii1 * Hii1);
 
-        if(std::abs(gam - ZERO) <= EPSILON) {
-          gam = EPSMAC;
+        if(std::abs(gam - ZERO) <= MACHINE_EPSILON) {
+          gam = MACHINE_EPSILON;
         }
 
         /* next Given's rotation */
@@ -260,7 +260,7 @@ namespace ReSolve
 
         vec_v->setData( vec_V_->getData(memspace_), memspace_);
         this->precV(vec_z, vec_v);
-        // and add to x 
+        // and add to x
         vector_handler_->axpy(&ONE, vec_v, x, memspace_);
       }
 
@@ -271,8 +271,8 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_);
       rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
       // rnorm = ||V_1||
       rnorm = std::sqrt(rnorm);
@@ -294,7 +294,7 @@ namespace ReSolve
       out::warning() << "Only LU-type solve can be used as a preconditioner at this time." << std::endl;
       return 1;
     } else {
-      LU_solver_ = LU_solver;  
+      LU_solver_ = LU_solver;
       return 0;
     }
 
@@ -309,7 +309,7 @@ namespace ReSolve
 
   /**
    * @brief Sets pointer to Gram-Schmidt (re)orthogonalization.
-   * 
+   *
    * @param[in] gs - pointer to Gram-Schmidt class instance.
    * @return 0 if successful, error code otherwise.
    */
@@ -321,13 +321,13 @@ namespace ReSolve
 
   /**
    * @brief Set/change GMRES restart value
-   * 
+   *
    * This function should leave solver instance in the same state but with
    * the new restart value.
-   * 
-   * @param[in] restart - the restart value 
+   *
+   * @param[in] restart - the restart value
    * @return 0 if successful, error code otherwise.
-   * 
+   *
    * @todo Consider not setting up GS, if it was not previously set up.
    */
   int LinSolverIterativeFGMRES::setRestart(index_type restart)
@@ -359,7 +359,7 @@ namespace ReSolve
 
   /**
    * @brief Switches between flexible and standard GMRES
-   * 
+   *
    * @param is_flexible - true means set flexible GMRES
    * @return 0 if successful, error code otherwise.
    */
@@ -374,7 +374,7 @@ namespace ReSolve
         // otherwise Z is just a one vector, not multivector and we dont keep it
         vec_Z_ = new vector_type(n_);
       }
-      vec_Z_->allocate(memspace_); 
+      vec_Z_->allocate(memspace_);
     }
     flexible_ = is_flexible;
     matrix_handler_->setValuesChanged(true, memspace_);
@@ -383,8 +383,8 @@ namespace ReSolve
 
   /**
    * @brief Set the convergence condition for GMRES solver
-   * 
-   * @param[in] conv_cond - Possible values: 0, 1, 2 
+   *
+   * @param[in] conv_cond - Possible values: 0, 1, 2
    * @return int - error code, 0 if successful
    */
   int LinSolverIterativeFGMRES::setConvergenceCondition(index_type conv_cond)
@@ -522,7 +522,7 @@ namespace ReSolve
   int LinSolverIterativeFGMRES::allocateSolverData()
   {
     vec_V_ = new vector_type(n_, restart_ + 1);
-    vec_V_->allocate(memspace_);      
+    vec_V_->allocate(memspace_);
     if (flexible_) {
       vec_Z_ = new vector_type(n_, restart_ + 1);
     } else {
@@ -544,7 +544,7 @@ namespace ReSolve
     delete [] h_c_ ;
     delete [] h_s_ ;
     delete [] h_rs_;
-    delete vec_V_;   
+    delete vec_V_;
     delete vec_Z_;
 
     h_H_  = nullptr;
@@ -558,7 +558,7 @@ namespace ReSolve
   }
 
   void LinSolverIterativeFGMRES::precV(vector_type* rhs, vector_type* x)
-  { 
+  {
     LU_solver_->solve(rhs, x);
   }
 
@@ -569,9 +569,9 @@ namespace ReSolve
     bool is_vector_handler_cuda = matrix_handler_->getIsCudaEnabled();
     bool is_vector_handler_hip  = matrix_handler_->getIsHipEnabled();
 
-    if ((is_matrix_handler_cuda != is_vector_handler_cuda) || 
+    if ((is_matrix_handler_cuda != is_vector_handler_cuda) ||
         (is_matrix_handler_hip  != is_vector_handler_hip )) {
-      out::error() << "Matrix and vector handler backends are incompatible!\n";  
+      out::error() << "Matrix and vector handler backends are incompatible!\n";
     }
 
     if (is_matrix_handler_cuda || is_matrix_handler_hip) {

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -2,7 +2,7 @@
  * @file LinSolverIterativeRandFGMRES.cpp
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @brief Implementation of LinSolverIterativeRandFGMRES class.
- * 
+ *
  */
 #include <iostream>
 #include <cassert>
@@ -23,8 +23,8 @@ namespace ReSolve
   using out = io::Logger;
 
   LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(MatrixHandler*  matrix_handler,
-                                                             VectorHandler*  vector_handler, 
-                                                             SketchingMethod rand_method, 
+                                                             VectorHandler*  vector_handler,
+                                                             SketchingMethod rand_method,
                                                              GramSchmidt*    gs)
   {
     tol_ = 1e-14; //default
@@ -42,17 +42,17 @@ namespace ReSolve
     initParamList();
   }
 
-  LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(index_type      restart, 
+  LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(index_type      restart,
                                                              real_type       tol,
                                                              index_type      maxit,
                                                              index_type      conv_cond,
                                                              MatrixHandler*  matrix_handler,
                                                              VectorHandler*  vector_handler,
-                                                             SketchingMethod rand_method, 
+                                                             SketchingMethod rand_method,
                                                              GramSchmidt*    gs)
   {
-    tol_ = tol; 
-    maxit_= maxit; 
+    tol_ = tol;
+    maxit_= maxit;
     restart_ = restart;
     conv_cond_ = conv_cond;
     flexible_ = true;
@@ -81,9 +81,9 @@ namespace ReSolve
 
   /**
    * @brief Set system matrix and allocate solver and sketching data
-   * 
+   *
    * @param[in] A - sparse system matrix
-   * @return 0 if setup successful 
+   * @return 0 if setup successful
    */
   int LinSolverIterativeRandFGMRES::setup(matrix::Sparse* A)
   {
@@ -127,7 +127,7 @@ namespace ReSolve
     // io::Logger::setVerbosity(io::Logger::EVERYTHING);
 
     int outer_flag = 1;
-    int notconv = 1; 
+    int notconv = 1;
     index_type i = 0;
     int it = 0;
     int j;
@@ -147,8 +147,8 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_);
 
     vec_v->setData(vec_V_->getVectorData(0, memspace_), memspace_);
     vec_s->setData(vec_S_->getVectorData(0, memspace_), memspace_);
@@ -166,7 +166,7 @@ namespace ReSolve
     rnorm = std::sqrt(rnorm); // rnorm = ||V_1||
     bnorm = std::sqrt(bnorm);
     io::Logger::misc() << "it 0: norm of residual "
-                       << std::scientific << std::setprecision(16) 
+                       << std::scientific << std::setprecision(16)
                        << rnorm << " Norm of rhs: " << bnorm << "\n";
     initial_residual_norm_ = rnorm;
     while(outer_flag) {
@@ -182,13 +182,13 @@ namespace ReSolve
       switch (conv_cond_)
       {
         case 0:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON));
           break;
         case 1:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < tol_));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < tol_));
           break;
         case 2:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < (tol_*bnorm)));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < (tol_*bnorm)));
           break;
       }
 
@@ -229,12 +229,12 @@ namespace ReSolve
         // V_{i+1}=A*Z_i
         vec_v->setData(vec_V_->getVectorData(i + 1, memspace_), memspace_);
 
-        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_); 
+        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_);
 
         // orthogonalize V[i+1], form a column of h_H_
         // this is where it differs from normal solver GS
         vec_s->setData(vec_S_->getVectorData(i + 1, memspace_), memspace_);
-        sketching_handler_->Theta(vec_v, vec_s); 
+        sketching_handler_->Theta(vec_v, vec_s);
         if (sketching_method_ == fwht) {
           vector_handler_->scal(&one_over_k_, vec_s, memspace_);
         }
@@ -248,13 +248,13 @@ namespace ReSolve
         }
         vec_z->setData(d_aux_, memspace_);
         vec_z->setCurrentSize(i + 1);
-        // V(:, i+1) = w - V(:, 1:i)*d_H_col = V(:, i+1) - d_H_col*V(:,1:i); 
+        // V(:, i+1) = w - V(:, 1:i)*d_H_col = V(:, i+1) - d_H_col*V(:,1:i);
 
-        vector_handler_->gemv('N', n_, i + 1, &MINUSONE, &ONE, vec_V_, vec_z, vec_v, memspace_ );  
+        vector_handler_->gemv('N', n_, i + 1, &MINUSONE, &ONE, vec_V_, vec_z, vec_v, memspace_ );
 
         vec_z->setCurrentSize(n_);
         t = 1.0 / h_H_[i * (restart_ + 1) + i + 1];
-        vector_handler_->scal(&t, vec_v, memspace_);  
+        vector_handler_->scal(&t, vec_v, memspace_);
         mem_.deviceSynchronize();
         vec_s->setData(vec_S_->getVectorData(i + 1, memspace_), memspace_);
 
@@ -270,8 +270,8 @@ namespace ReSolve
         real_type Hii1 = h_H_[(i) * (restart_ + 1) + i + 1];
         real_type gam = std::sqrt(Hii * Hii + Hii1 * Hii1);
 
-        if(std::abs(gam - ZERO) <= EPSILON) {
-          gam = EPSMAC;
+        if(std::abs(gam - ZERO) <= MACHINE_EPSILON) {
+          gam = MACHINE_EPSILON;
         }
 
         /* next Given's rotation */
@@ -327,7 +327,7 @@ namespace ReSolve
 
         vec_v->setData(vec_V_->getData(memspace_), memspace_);
         this->precV(vec_z, vec_v);
-        // and add to x 
+        // and add to x
         vector_handler_->axpy(&ONE, vec_v, x, memspace_);
       }
 
@@ -337,8 +337,8 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_);
       if (outer_flag) {
 
         sketching_handler_->reset();
@@ -380,7 +380,7 @@ namespace ReSolve
       out::warning() << "Only cusolverRf tri solve can be used as a preconditioner at this time." << std::endl;
       return 1;
     } else {
-      LU_solver_ = LU_solver;  
+      LU_solver_ = LU_solver;
       return 0;
     }
 
@@ -400,8 +400,8 @@ namespace ReSolve
 
   /**
    * @brief Set sketching method based on input string.
-   * 
-   * @param[in] method - string describing sketching method 
+   *
+   * @param[in] method - string describing sketching method
    * @return 0 if successful, 1 otherwise.
    */
   int LinSolverIterativeRandFGMRES::setSketchingMethod(SketchingMethod method)
@@ -440,13 +440,13 @@ namespace ReSolve
 
   /**
    * @brief Set/change GMRES restart value
-   * 
+   *
    * This function should leave solver instance in the same state but with
    * the new restart value.
-   * 
-   * @param[in] restart - the restart value 
+   *
+   * @param[in] restart - the restart value
    * @return 0 if successful, error code otherwise.
-   * 
+   *
    * @todo Consider not setting up GS, if it was not previously set up.
    */
   int LinSolverIterativeRandFGMRES::setRestart(index_type restart)
@@ -481,7 +481,7 @@ namespace ReSolve
 
   /**
    * @brief Switches between flexible and standard GMRES
-   * 
+   *
    * @param is_flexible - true means set flexible GMRES
    * @return 0 if successful, error code otherwise.
    */
@@ -496,7 +496,7 @@ namespace ReSolve
         // otherwise Z is just a one vector, not multivector and we dont keep it
         vec_Z_ = new vector_type(n_);
       }
-      vec_Z_->allocate(memspace_); 
+      vec_Z_->allocate(memspace_);
     }
     flexible_ = is_flexible;
     matrix_handler_->setValuesChanged(true, memspace_);
@@ -505,8 +505,8 @@ namespace ReSolve
 
   /**
    * @brief Set the convergence condition for GMRES solver
-   * 
-   * @param[in] conv_cond - Possible values: 0, 1, 2 
+   *
+   * @param[in] conv_cond - Possible values: 0, 1, 2
    * @return int - error code, 0 if successful
    */
   int LinSolverIterativeRandFGMRES::setConvergenceCondition(index_type conv_cond)
@@ -637,20 +637,20 @@ namespace ReSolve
   int LinSolverIterativeRandFGMRES::allocateSolverData()
   {
     vec_V_ = new vector_type(n_, restart_ + 1);
-    vec_V_->allocate(memspace_);      
+    vec_V_->allocate(memspace_);
     if (flexible_) {
       vec_Z_ = new vector_type(n_, restart_ + 1);
     } else {
       // otherwise Z is just one vector, not multivector and we dont keep it
       vec_Z_ = new vector_type(n_);
     }
-    vec_Z_->allocate(memspace_);   
+    vec_Z_->allocate(memspace_);
     h_H_  = new real_type[restart_ * (restart_ + 1)];
     h_c_  = new real_type[restart_];      // needed for givens
     h_s_  = new real_type[restart_];      // same
     h_rs_ = new real_type[restart_ + 1];  // for residual norm history
     if (memspace_ == memory::DEVICE) {
-      mem_.allocateArrayOnDevice(&d_aux_, restart_ + 1); 
+      mem_.allocateArrayOnDevice(&d_aux_, restart_ + 1);
     } else {
       d_aux_  = new real_type[restart_ + 1];
     }
@@ -663,12 +663,12 @@ namespace ReSolve
     delete [] h_c_ ;
     delete [] h_s_ ;
     delete [] h_rs_;
-    if (memspace_ == memory::DEVICE) { 
+    if (memspace_ == memory::DEVICE) {
       mem_.deleteOnDevice(d_aux_);
     } else {
       delete [] d_aux_;
     }
-    delete vec_V_;   
+    delete vec_V_;
     delete vec_Z_;
 
     h_H_   = nullptr;
@@ -684,7 +684,7 @@ namespace ReSolve
 
   /**
    * @brief Allocate data and instantiate sketching handler.
-   * 
+   *
    * @pre Randomized solver data is allocated.
    */
   int LinSolverIterativeRandFGMRES::allocateSketchingData()
@@ -697,7 +697,7 @@ namespace ReSolve
           k_rand_ = static_cast<index_type>(std::ceil(restart_ * std::log(static_cast<real_type>(n_))));
         }
         sketching_handler_ = new SketchingHandler(sketching_method_, device_type_);
-        // set k and n 
+        // set k and n
         break;
       case fwht:
         if (std::ceil(2.0 * restart_ * std::log(n_) / std::log(restart_)) < k_rand_) {
@@ -706,7 +706,7 @@ namespace ReSolve
         sketching_handler_ = new SketchingHandler(sketching_method_, device_type_);
         break;
       default:
-        io::Logger::warning() << "Wrong sketching method, setting to default (CountSketch)\n"; 
+        io::Logger::warning() << "Wrong sketching method, setting to default (CountSketch)\n";
         sketching_method_ = cs;
         if (std::ceil(restart_ * std::log(n_)) < k_rand_) {
           k_rand_ = static_cast<index_type>(std::ceil(restart_ * std::log(n_)));
@@ -717,7 +717,7 @@ namespace ReSolve
 
     one_over_k_ = 1.0 / std::sqrt((real_type) k_rand_);
     vec_S_ = new vector_type(k_rand_, restart_ + 1);
-    vec_S_->allocate(memspace_);      
+    vec_S_->allocate(memspace_);
     if (sketching_method_ == cs) {
       vec_S_->setToZero(memspace_);
     }
@@ -738,7 +738,7 @@ namespace ReSolve
   }
 
   void LinSolverIterativeRandFGMRES::precV(vector_type* rhs, vector_type* x)
-  { 
+  {
     LU_solver_->solve(rhs, x);
   }
 
@@ -746,7 +746,7 @@ namespace ReSolve
   /**
    * @brief Set memory space and device tape based on how MatrixHandler
    * and VectorHandler are configured.
-   * 
+   *
    */
   void LinSolverIterativeRandFGMRES::setMemorySpace()
   {
@@ -755,9 +755,9 @@ namespace ReSolve
     bool is_vector_handler_cuda = matrix_handler_->getIsCudaEnabled();
     bool is_vector_handler_hip  = matrix_handler_->getIsHipEnabled();
 
-    if ((is_matrix_handler_cuda != is_vector_handler_cuda) || 
+    if ((is_matrix_handler_cuda != is_vector_handler_cuda) ||
         (is_matrix_handler_hip  != is_vector_handler_hip )) {
-      out::error() << "Matrix and vector handler backends are incompatible!\n";  
+      out::error() << "Matrix and vector handler backends are incompatible!\n";
     }
 
     if (is_matrix_handler_cuda) {

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -27,7 +27,7 @@ namespace ReSolve
                                                              SketchingMethod rand_method,
                                                              GramSchmidt*    gs)
   {
-    tol_ = 1e-14; //default
+    tol_ = constants::DEFAULT_TOL;
     maxit_= 100; //default
     restart_ = 10;
     conv_cond_ = 0;//default

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -173,8 +173,8 @@ namespace ReSolve
       // check if maybe residual is already small enough?
       if (it == 0) {
         tolrel = tol_ * rnorm;
-        if (std::abs(tolrel) < 1e-16) {
-          tolrel = 1e-16;
+        if (std::abs(tolrel) < MACHINE_EPSILON) {
+          tolrel = MACHINE_EPSILON;
         }
       }
 

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -27,8 +27,7 @@ namespace ReSolve
                                                              SketchingMethod rand_method,
                                                              GramSchmidt*    gs)
   {
-    tol_ = constants::DEFAULT_TOL;
-    maxit_= 100; //default
+
     restart_ = 10;
     conv_cond_ = 0;//default
     flexible_ = true;

--- a/resolve/LinSolverIterativeRandFGMRES.hpp
+++ b/resolve/LinSolverIterativeRandFGMRES.hpp
@@ -2,7 +2,7 @@
  * @file LinSolverIterativeRandFGMRES.hpp
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @brief Declaration of LinSolverIterativeRandFGMRES class
- * 
+ *
  */
 #pragma once
 
@@ -26,12 +26,12 @@ namespace ReSolve
 
   /**
    * @brief Randomized (F)GMRES
-   * 
+   *
    * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
-   * 
+   *
    * @note Pointers to MatrixHandler and VectorHandler objects are inherited from
    * LinSolver base class.
-   * 
+   *
    */
   class LinSolverIterativeRandFGMRES : public LinSolverIterative
   {
@@ -39,12 +39,12 @@ namespace ReSolve
       using vector_type = vector::Vector;
 
     public:
-      enum SketchingMethod {cs = 0, // count sketch 
+      enum SketchingMethod {cs = 0, // count sketch
                             fwht};  // fast Walsh-Hadamard transform
-    
+
       LinSolverIterativeRandFGMRES(MatrixHandler* matrix_handler,
                                    VectorHandler* vector_handler,
-                                   SketchingMethod rand_method, 
+                                   SketchingMethod rand_method,
                                    GramSchmidt*   gs);
 
       LinSolverIterativeRandFGMRES(index_type restart,
@@ -52,15 +52,15 @@ namespace ReSolve
                                    index_type maxit,
                                    index_type conv_cond,
                                    MatrixHandler* matrix_handler,
-                                   VectorHandler* vector_handler, 
-                                   SketchingMethod rand_method, 
+                                   VectorHandler* vector_handler,
+                                   SketchingMethod rand_method,
                                    GramSchmidt*   gs);
 
       ~LinSolverIterativeRandFGMRES();
 
       int solve(vector_type* rhs, vector_type* x) override;
       int setup(matrix::Sparse* A) override;
-      int resetMatrix(matrix::Sparse* new_A) override; 
+      int resetMatrix(matrix::Sparse* new_A) override;
       int setupPreconditioner(std::string name, LinSolverDirect* LU_solver) override;
       int setOrthogonalization(GramSchmidt* gs) override;
 
@@ -87,6 +87,8 @@ namespace ReSolve
       index_type restart_{10};  ///< GMRES restart
       index_type conv_cond_{0}; ///< GMRES convergence condition
       bool flexible_{true};     ///< If using flexible GMRES (FGMRES) algorithm
+      real_type tol_{100 * constants::MACHINE_EPSILON}; ///< Convergence tolerance
+      index_type maxit_{100}; ///< Maximum number of iterations
 
     private:
       int allocateSolverData();

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -394,7 +394,6 @@ namespace ReSolve
       status += refactorizationSolver_->setup(A_, L_, U_, P_, Q_);
 
       LinSolverDirectCuSolverRf* Rf = dynamic_cast<LinSolverDirectCuSolverRf*>(refactorizationSolver_);
-      Rf->setNumericalProperties(constants::DEFAULT_TOL, 1e-1);
 
       is_solve_on_device_ = false;
     }

--- a/tests/functionality/testKlu.cpp
+++ b/tests/functionality/testKlu.cpp
@@ -3,7 +3,7 @@
  * @author Kasia Swirydowicz (kasia.swirydowicz@amd.com)
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Functionality test for rocsolver_rf.
- * 
+ *
  */
 #include <string>
 #include <iostream>
@@ -125,7 +125,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   status = KLU.factorize();
   error_sum += status;
 
-  std::cout << "KLU factorize status: " << status <<std::endl;      
+  std::cout << "KLU factorize status: " << status <<std::endl;
 
   status = KLU.solve(&vec_rhs, &vec_x);
   error_sum += status;
@@ -133,7 +133,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     test_name += " + IR";
 
-    status =  FGMRES.setup(A); 
+    status =  FGMRES.setup(A);
     error_sum += status;
 
     status = FGMRES.setupPreconditioner("LU", &KLU);
@@ -152,7 +152,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
+  error_sum += helper.checkResult(ReSolve::constants::MACHINE_EPSILON);
 
   // Load the second matrix
   std::ifstream mat2(matrix_file_name_2);
@@ -178,8 +178,8 @@ int runTest(int argc, char *argv[], std::string& solver_name)
 
   status = KLU.refactorize();
   error_sum += status;
-  std::cout << "KLU refactorization status: " << status << std::endl;      
-  
+  std::cout << "KLU refactorization status: " << status << std::endl;
+
   if (is_ir) {
     FGMRES.resetMatrix(A);
     status = FGMRES.setupPreconditioner("LU", &KLU);
@@ -199,7 +199,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
+  error_sum += helper.checkResult(ReSolve::constants::MACHINE_EPSILON);
 
   isTestPass(error_sum, test_name);
 

--- a/tests/functionality/testRandGmres.cpp
+++ b/tests/functionality/testRandGmres.cpp
@@ -2,8 +2,8 @@
  * @file testRandGMRES.cpp
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @author Slaven Peles (peless@ornl.gov)
- * @brief Functionality test for randomized GMRES class with CUDA backend. 
- * 
+ * @brief Functionality test for randomized GMRES class with CUDA backend.
+ *
  */
 #include <string>
 #include <iostream>
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
 
   error_sum += runTest<ReSolve::LinAlgWorkspaceCpu,
                        ReSolve::LinSolverDirectCpuILU0>(argc, argv);
- 
+
 #ifdef RESOLVE_USE_CUDA
   error_sum += runTest<ReSolve::LinAlgWorkspaceCUDA,
                        ReSolve::LinSolverDirectCuSparseILU0>(argc, argv);
@@ -113,10 +113,10 @@ int runTest(int argc, char *argv[])
 
   matrix_handler.setValuesChanged(true, memspace);
 
-  real_type tol = 1e-12; // iterative solver tolerance
+  real_type tol = constants::LOOSE_TOL;
   real_type test_pass_tol = 10.0*tol; // test results tolerance
 
-  // Configure preconditioner 
+  // Configure preconditioner
   status = ILU.setup(A);
   error_sum += status;
 
@@ -133,7 +133,7 @@ int runTest(int argc, char *argv[])
   status = FGMRES.setupPreconditioner("LU", &ILU);
   error_sum += status;
 
-  FGMRES.setFlexible(true); 
+  FGMRES.setFlexible(true);
 
   status = FGMRES.solve(vec_rhs, &vec_x);
   error_sum += status;
@@ -144,7 +144,7 @@ int runTest(int argc, char *argv[])
   // Print result summary and check solution
   std::cout << "\nRandomized FGMRES results: \n"
             << "\t Hardware backend:                              : "
-            << hwbackend << "\n" 
+            << hwbackend << "\n"
             << "\t Sketching method:                              : "
             << "CountSketch\n";
   helper.printIterativeSolverSummary(&FGMRES);
@@ -164,7 +164,7 @@ int runTest(int argc, char *argv[])
   // Print result summary and check solution
   std::cout << "\nRandomized FGMRES results: \n"
             << "\t Hardware backend:                              : "
-            << hwbackend << "\n" 
+            << hwbackend << "\n"
             << "\t Sketching method:                              : "
             << "FWHT\n";
   helper.printIterativeSolverSummary(&FGMRES);
@@ -179,7 +179,7 @@ int runTest(int argc, char *argv[])
 }
 
 
-ReSolve::vector::Vector* generateRhs(const index_type n, 
+ReSolve::vector::Vector* generateRhs(const index_type n,
                                      ReSolve::memory::MemorySpace memspace)
 {
   vector_type* vec_rhs = new vector_type(n);
@@ -199,9 +199,9 @@ ReSolve::vector::Vector* generateRhs(const index_type n,
     vec_rhs->syncData(memspace);
   }
   return vec_rhs;
-} 
+}
 
-ReSolve::matrix::Csr* generateMatrix(const index_type n, 
+ReSolve::matrix::Csr* generateMatrix(const index_type n,
                                      ReSolve::memory::MemorySpace memspace)
 {
   std::vector<real_type> r1 = {1., 5., 7., 8., 3., 2., 4.}; // sum 30
@@ -227,7 +227,7 @@ ReSolve::matrix::Csr* generateMatrix(const index_type n,
 
   index_type* rowptr = A->getRowData(ReSolve::memory::HOST);
   index_type* colidx = A->getColData(ReSolve::memory::HOST);
-  real_type* val     = A->getValues(ReSolve::memory::HOST); 
+  real_type* val     = A->getValues(ReSolve::memory::HOST);
 
   // Populate CSR matrix using same row pattern as for nnz calculation
   rowptr[0] = 0;
@@ -251,7 +251,7 @@ ReSolve::matrix::Csr* generateMatrix(const index_type n,
         where =  (j - rowptr[i]) * n/nnz_per_row + (n%(n/nnz_per_row));
         // evenly distribute nonzeros ^^^^             ^^^^^^^^ perturb offset
         what = row_sample[static_cast<size_t>(j - rowptr[i])];
-      } 
+      }
       colidx[j] = where;
       val[j] = what;
     }

--- a/tests/functionality/testRandGmres.cpp
+++ b/tests/functionality/testRandGmres.cpp
@@ -113,7 +113,7 @@ int runTest(int argc, char *argv[])
 
   matrix_handler.setValuesChanged(true, memspace);
 
-  real_type tol = constants::LOOSE_TOL;
+  real_type tol = 1000*constants::MACHINE_EPSILON;
   real_type test_pass_tol = 10.0*tol; // test results tolerance
 
   // Configure preconditioner

--- a/tests/functionality/testRefactor.cpp
+++ b/tests/functionality/testRefactor.cpp
@@ -3,7 +3,7 @@
  * @author Kasia Swirydowicz (kasia.swirydowicz@amd.com)
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Functionality test for rocsolver_rf.
- * 
+ *
  */
 #include <string>
 #include <iostream>
@@ -185,7 +185,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   index_type* P = KLU.getPOrdering();
   index_type* Q = KLU.getQOrdering();
 
-  status = Rf.setup(A, L, U, P, Q, &vec_rhs); 
+  status = Rf.setup(A, L, U, P, Q, &vec_rhs);
   error_sum += status;
 
   // Refactorize (on device where available)
@@ -200,7 +200,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     test_name += " + IR";
 
-    status =  FGMRES.setup(A); 
+    status =  FGMRES.setup(A);
     error_sum += status;
 
     status = FGMRES.setupPreconditioner("LU", &Rf);
@@ -219,7 +219,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
+  error_sum += helper.checkResult(ReSolve::constants::MACHINE_EPSILON);
 
   // Load the second matrix
   std::ifstream mat2(matrix_file_name_2);
@@ -246,7 +246,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   // Refactorize second matrix
   status = Rf.refactorize();
   error_sum += status;
-  
+
   // Solve system (now one can go directly to IR when enabled)
   if (is_ir) {
     FGMRES.resetMatrix(A);
@@ -268,8 +268,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   if (is_ir) {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
-
+  error_sum += helper.checkResult(ReSolve::constants::MACHINE_EPSILON);
   isTestPass(error_sum, test_name);
 
   // delete data on the heap

--- a/tests/functionality/testSysGLU.cpp
+++ b/tests/functionality/testSysGLU.cpp
@@ -4,8 +4,8 @@
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Functionality test for SystemSolver class
  * @date 2023-12-14
- * 
- * 
+ *
+ *
  */
 #include <string>
 #include <iostream>
@@ -103,20 +103,20 @@ int main(int argc, char *argv[])
   // but DO NOT SOLVE with KLU!
   status = solver.refactorizationSetup();
   error_sum += status;
-  std::cout << "GLU setup status: " << status << std::endl;      
+  std::cout << "GLU setup status: " << status << std::endl;
 
   // Move rhs vector data to GPU
   vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = solver.solve(vec_rhs, vec_x);
   error_sum += status;
-  std::cout << "GLU solve status: " << status << std::endl;      
+  std::cout << "GLU solve status: " << status << std::endl;
 
   // Compute residual on device
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE);
   error_sum += status;
-  
+
   // Compute residual norm
   real_type normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
@@ -127,8 +127,8 @@ int main(int argc, char *argv[])
   real_type normB1 = sqrt(vector_handler.dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
 
   // Compute norm of scaled residuals
-  real_type inf_norm_A = 0.0;  
-  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE); 
+  real_type inf_norm_A = 0.0;
+  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE);
   real_type inf_norm_x = vector_handler.infNorm(vec_x, ReSolve::memory::DEVICE);
   real_type inf_norm_r = vector_handler.infNorm(vec_r, ReSolve::memory::DEVICE);
   real_type nsr_norm   = inf_norm_r / (inf_norm_A * inf_norm_x);
@@ -139,8 +139,8 @@ int main(int argc, char *argv[])
     std::cout << "Norm of scaled residuals computation failed:\n";
     std::cout << std::scientific << std::setprecision(16)
               << "\tMatrix inf  norm                 : " << inf_norm_A << "\n"
-              << "\tResidual inf norm                : " << inf_norm_r << "\n"  
-              << "\tSolution inf norm                : " << inf_norm_x << "\n"  
+              << "\tResidual inf norm                : " << inf_norm_r << "\n"
+              << "\tSolution inf norm                : " << inf_norm_x << "\n"
               << "\tNorm of scaled residuals         : " << nsr_norm   << "\n"
               << "\tNorm of scaled residuals (system): " << nsr_system << "\n\n";
     error_sum++;
@@ -162,10 +162,10 @@ int main(int argc, char *argv[])
   vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix1 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
- 
+
   // Compute residual norm ON THE GPU using REFERENCE solution
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
   }
- 
+
   std::cout << "Results (first matrix): \n\n" << std::scientific << std::setprecision(16);
   std::cout << "\t ||b-A*x||_2                 : " << normRmatrix1              << " (residual norm)\n";
   std::cout << "\t ||b-A*x||_2  (CPU)          : " << normRmatrix1CPU           << " (residual norm)\n";
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
   // Refactorize and solve
   status = solver.refactorize();
   error_sum += status;
-  std::cout << "CUSOLVER GLU refactorization status: " << status << std::endl;      
+  std::cout << "CUSOLVER GLU refactorization status: " << status << std::endl;
 
   status = solver.solve(vec_rhs, vec_x);
   error_sum += status;
@@ -230,16 +230,16 @@ int main(int argc, char *argv[])
   // Compute residual norm for the second system
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
-  
+
   // Compute norm of the rhs vector for the second system
   real_type normB2 = sqrt(vector_handler.dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
 
   // Compute norm of scaled residuals for the second system
-  inf_norm_A = 0.0;  
-  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE); 
+  inf_norm_A = 0.0;
+  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE);
   inf_norm_x = vector_handler.infNorm(vec_x, ReSolve::memory::DEVICE);
   inf_norm_r = vector_handler.infNorm(vec_r, ReSolve::memory::DEVICE);
   nsr_norm   = inf_norm_r / (inf_norm_A * inf_norm_x);
@@ -250,8 +250,8 @@ int main(int argc, char *argv[])
     std::cout << "Norm of scaled residuals computation failed:\n";
     std::cout << std::scientific << std::setprecision(16)
               << "\tMatrix inf  norm                 : " << inf_norm_A << "\n"
-              << "\tResidual inf norm                : " << inf_norm_r << "\n"  
-              << "\tSolution inf norm                : " << inf_norm_x << "\n"  
+              << "\tResidual inf norm                : " << inf_norm_r << "\n"
+              << "\tSolution inf norm                : " << inf_norm_x << "\n"
               << "\tNorm of scaled residuals         : " << nsr_norm   << "\n"
               << "\tNorm of scaled residuals (system): " << nsr_system << "\n\n";
     error_sum++;
@@ -261,13 +261,13 @@ int main(int argc, char *argv[])
   vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix2 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
- 
+
   //compute the residual using exact solution
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
-  
+
   // Verify relative residual norm computation in SystemSolver
   rel_residual_norm = solver.getResidualNorm(vec_rhs, vec_x);
   error = std::abs(normB2 * rel_residual_norm - normRmatrix2)/normRmatrix2;
@@ -278,7 +278,7 @@ int main(int argc, char *argv[])
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
   }
- 
+
   std::cout << "Results (second matrix): " << std::endl << std::endl;
   std::cout << std::scientific << std::setprecision(16);
   std::cout << "\t ||b-A*x||_2                 : " << normRmatrix2              << " (residual norm)\n";
@@ -292,7 +292,7 @@ int main(int argc, char *argv[])
     std::cout << "Result is not a finite number!\n";
     error_sum++;
   }
-  if ((normRmatrix1/normB1 > 1e-16 ) || (normRmatrix2/normB2 > 1e-16)) {
+  if ((normRmatrix1/normB1 > ReSolve::constants::MACHINE_EPSILON ) || (normRmatrix2/normB2 > ReSolve::constants::MACHINE_EPSILON)) {
     std::cout << "Result inaccurate!\n";
     error_sum++;
   }

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -12,6 +12,8 @@
 #include <iomanip>
 #include <vector>
 #include <cmath>
+#include <sstream>
+
 #include <resolve/matrix/Csr.hpp>
 #include <resolve/matrix/Csc.hpp>
 #include <resolve/vector/Vector.hpp>
@@ -23,6 +25,7 @@
 #include <resolve/GramSchmidt.hpp>
 #include <resolve/SystemSolver.hpp>
 #include <resolve/utilities/params/CliOptions.hpp>
+
 
 #include "TestHelper.hpp"
 
@@ -146,7 +149,14 @@ int test(int argc, char *argv[])
 
   // Set solver options
   solver.getIterativeSolver().setCliParam("maxit", "2500");
-  solver.getIterativeSolver().setCliParam("tol", "1e-12");
+  //solver.getIterativeSolver().setCliParam("tol", "1e-12");
+  //solver.getIterativeSolver().setCliParam("tol", std::to_string(ReSolve::constants::SPECIAL_TOL));
+  std::ostringstream oss;
+  oss << std::scientific << ReSolve::constants::SPECIAL_TOL;
+  solver.getIterativeSolver().setCliParam("tol", oss.str());
+
+
+
 
   // Tolerance value to output
   real_type tol_out = solver.getIterativeSolver().getCliParamReal("tol");

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -149,10 +149,8 @@ int test(int argc, char *argv[])
 
   // Set solver options
   solver.getIterativeSolver().setCliParam("maxit", "2500");
-  //solver.getIterativeSolver().setCliParam("tol", "1e-12");
-  //solver.getIterativeSolver().setCliParam("tol", std::to_string(ReSolve::constants::SPECIAL_TOL));
   std::ostringstream oss;
-  oss << std::scientific << ReSolve::constants::SPECIAL_TOL;
+  oss << std::scientific << ReSolve::constants::LOOSE_TOL;
   solver.getIterativeSolver().setCliParam("tol", oss.str());
 
 

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -2,10 +2,10 @@
  * @file testSysRandGMRES.cpp
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @author Slaven Peles (peless@ornl.gov)
- * @brief Functionality tests for SystemSolver and GMRES classes 
+ * @brief Functionality tests for SystemSolver and GMRES classes
  * @date 2023-12-18
- * 
- * 
+ *
+ *
  */
 #include <string>
 #include <iostream>
@@ -210,10 +210,10 @@ void processInputs(std::string& method, std::string& gs, std::string& sketch)
     std::cout << "Setting iterative solver method to the default (FGMRES).\n\n";
     method = "fgmres";
   }
-  if (gs != "cgs1" && 
-      gs != "cgs2" && 
-      gs != "mgs" && 
-      gs != "mgs_two_sync" 
+  if (gs != "cgs1" &&
+      gs != "cgs2" &&
+      gs != "mgs" &&
+      gs != "mgs_two_sync"
       && gs != "mgs_pm") {
     std::cout << "Unknown orthogonalization " << gs << "\n";
     std::cout << "Setting orthogonalization to the default (CGS2).\n\n";
@@ -221,7 +221,7 @@ void processInputs(std::string& method, std::string& gs, std::string& sketch)
   }
 }
 
-std::string headerInfo(const std::string& method, 
+std::string headerInfo(const std::string& method,
                        const std::string& gs,
                        const std::string& sketch,
                        std::string flexible)
@@ -251,11 +251,11 @@ std::string headerInfo(const std::string& method,
   } else if (gs == "cgs1")  {
     header += (withgs + "classical Gram-Schmidt\n");
   } else if (gs == "mgs") {
-    header += (withgs + "modified Gram-Schmidt\n");    
+    header += (withgs + "modified Gram-Schmidt\n");
   } else if (gs == "mgs_two_sync") {
-    header += (withgs + "modified Gram-Schmidt 2-sync\n");    
+    header += (withgs + "modified Gram-Schmidt 2-sync\n");
   } else if (gs == "mgs_pm") {
-    header += (withgs + "post-modern modified Gram-Schmidt\n");    
+    header += (withgs + "post-modern modified Gram-Schmidt\n");
   } else {
     // do nothing
   }
@@ -283,7 +283,7 @@ ReSolve::vector::Vector* generateRhs(const index_type N, ReSolve::memory::Memory
     vec_rhs->syncData(memspace);
   }
   return vec_rhs;
-} 
+}
 
 ReSolve::matrix::Csr* generateMatrix(const index_type N, ReSolve::memory::MemorySpace memspace)
 {
@@ -310,7 +310,7 @@ ReSolve::matrix::Csr* generateMatrix(const index_type N, ReSolve::memory::Memory
 
   index_type* rowptr = A->getRowData(ReSolve::memory::HOST);
   index_type* colidx = A->getColData(ReSolve::memory::HOST);
-  real_type* val     = A->getValues(ReSolve::memory::HOST); 
+  real_type* val     = A->getValues(ReSolve::memory::HOST);
 
   // Populate CSR matrix using same row pattern as for NNZ calculation
   rowptr[0] = 0;
@@ -334,7 +334,7 @@ ReSolve::matrix::Csr* generateMatrix(const index_type N, ReSolve::memory::Memory
         where =  (j - rowptr[i]) * N/nnz_per_row + (N%(N/nnz_per_row));
         // evenly distribute nonzeros ^^^^             ^^^^^^^^ perturb offset
         what = row_sample[static_cast<size_t>(j - rowptr[i])];
-      } 
+      }
       colidx[j] = where;
       val[j] = what;
     }

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -149,9 +149,7 @@ int test(int argc, char *argv[])
 
   // Set solver options
   solver.getIterativeSolver().setCliParam("maxit", "2500");
-  std::ostringstream oss;
-  oss << std::scientific << ReSolve::constants::LOOSE_TOL;
-  solver.getIterativeSolver().setCliParam("tol", oss.str());
+  solver.getIterativeSolver().setTol(1e-12);
 
 
 

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -100,13 +100,6 @@ static int runTest(int argc, char *argv[], std::string backend)
   // settings than HIP-based one)
   solver.setRefinementMethod("fgmres", "cgs2");
   solver.getIterativeSolver().setCliParam("restart", "100");
-  if (backend == "hip") {
-    solver.getIterativeSolver().setMaxit(200);
-  }
-  if (backend == "cuda") {
-    solver.getIterativeSolver().setMaxit(400);
-    solver.getIterativeSolver().setTol(ReSolve::constants::LOOSE_TOL);
-  }
 
   // Input to this code is location of `data` directory where matrix files are stored
   const std::string data_path = (argc == 2) ? argv[1] : ".";
@@ -171,7 +164,7 @@ static int runTest(int argc, char *argv[], std::string backend)
   // Print result summary and check solution
   std::cout << "\nResults (first matrix): \n\n";
   helper.printSummary();
-  error_sum += helper.checkResult(ReSolve::constants::LOOSE_TOL);
+  error_sum += helper.checkResult(1e-12);
 
   // Verify norm of scaled residuals calculation in SystemSolver class
   real_type nsr_system = solver.getNormOfScaledResiduals(&vec_rhs, &vec_x);
@@ -223,7 +216,7 @@ static int runTest(int argc, char *argv[], std::string backend)
   std::cout << "\nResults (second matrix): \n\n";
   helper.printSummary();
   helper.printIrSummary(&(solver.getIterativeSolver()));
-  error_sum += helper.checkResult(ReSolve::constants::DEFAULT_TOL);
+  error_sum += helper.checkResult(1e-15);
 
   // Verify norm of scaled residuals calculation in SystemSolver class
   nsr_system = solver.getNormOfScaledResiduals(&vec_rhs, &vec_x);

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -4,8 +4,8 @@
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Functionality test for SystemSolver class
  * @date 2023-12-14
- * 
- * 
+ *
+ *
  */
 #include <string>
 #include <iostream>
@@ -105,7 +105,7 @@ static int runTest(int argc, char *argv[], std::string backend)
   }
   if (backend == "cuda") {
     solver.getIterativeSolver().setMaxit(400);
-    solver.getIterativeSolver().setTol(1e-17);
+    solver.getIterativeSolver().setTol(ReSolve::constants::LOOSE_TOL);
   }
 
   // Input to this code is location of `data` directory where matrix files are stored
@@ -171,7 +171,7 @@ static int runTest(int argc, char *argv[], std::string backend)
   // Print result summary and check solution
   std::cout << "\nResults (first matrix): \n\n";
   helper.printSummary();
-  error_sum += helper.checkResult(1e-12);
+  error_sum += helper.checkResult(ReSolve::constants::LOOSE_TOL);
 
   // Verify norm of scaled residuals calculation in SystemSolver class
   real_type nsr_system = solver.getNormOfScaledResiduals(&vec_rhs, &vec_x);
@@ -211,11 +211,11 @@ static int runTest(int argc, char *argv[], std::string backend)
   // Refactorize matrix
   status = solver.refactorize();
   error_sum += status;
-  
+
   // Solve system
   status = solver.solve(&vec_rhs, &vec_x);
   error_sum += status;
-  
+
   // Compute error norms for the system
   helper.resetSystem(A, &vec_rhs, &vec_x);
 
@@ -223,7 +223,7 @@ static int runTest(int argc, char *argv[], std::string backend)
   std::cout << "\nResults (second matrix): \n\n";
   helper.printSummary();
   helper.printIrSummary(&(solver.getIterativeSolver()));
-  error_sum += helper.checkResult(1e-15); // Why does test not pass with 1e-16?
+  error_sum += helper.checkResult(ReSolve::constants::DEFAULT_TOL);
 
   // Verify norm of scaled residuals calculation in SystemSolver class
   nsr_system = solver.getNormOfScaledResiduals(&vec_rhs, &vec_x);
@@ -232,7 +232,7 @@ static int runTest(int argc, char *argv[], std::string backend)
   // Verify relative residual norm computation in SystemSolver
   rel_residual_norm = solver.getResidualNorm(&vec_rhs, &vec_x);
   error_sum += helper.checkRelativeResidualNorm(rel_residual_norm);
- 
+
   // Add one output specific to GMRES
   index_type restart = solver.getIterativeSolver().getCliParamInt("restart");
   std::cout << "\t IR GMRES restart                                : " << restart << "\n";


### PR DESCRIPTION
## Description
 
 _Closes #194. This allows the user to control all tolerances from a single location: `Common.hpp` and relates most of them to the working machine precision._
 

 ## Proposed changes
 
 _I removed numbers from the code and replaced them with constants related to machine epsilon. The user can choose a tolerance of machine precision, a larger default tolerance, or an even looser loose tolerance. The latter is used for solvers that cannot achieve very high precision. There are additional values to decide to recompute the factorization and to replace zeros on the diagonal. These are all configurable from `Common.hpp`. Overall, there are 5 tolerances spanning from 1e-6 to ~2.22e-16 (machine epsilon). Developers are encouraged to use one of these. If necessary, justify adding a constant of a different order of magnitude._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [x] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc._

