### PR TITLE
adding minimal changes to remove magic numbers

### DIFF
--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -7,12 +7,6 @@
 
 namespace ReSolve {
 
-
-  // TODO: these should be dropped
-  constexpr double EPSILON = 1.0e-18;
-  constexpr double EPSMAC  = 1.0e-16;
-
-
   /// @todo Provide CMake option to se these types at config time
   using real_type = double;
   using index_type = std::int32_t;
@@ -22,7 +16,7 @@ namespace ReSolve {
     constexpr real_type ZERO = 0.0;
     constexpr real_type ONE = 1.0;
     constexpr real_type MINUS_ONE = -1.0;
-    constexpr real_type DEFAULT_TOL = 100*std::numeric_limits<real_type>::epsilon();
+    constexpr real_type MACHINE_EPSILON = std::numeric_limits<real_type>::epsilon();
   }
 
   namespace colors

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -159,7 +159,7 @@ namespace ReSolve
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
         H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
-        if(std::abs(t) > EPSILON) {
+        if(std::abs(t) > MACHINE_EPSILON) {
           t = 1.0/t;
           vector_handler_->scal(&t, vec_w_, memspace_);
         } else {
@@ -205,7 +205,7 @@ namespace ReSolve
         t = std::sqrt(t);
         H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
 
-        if(std::abs(t) > EPSILON) {
+        if(std::abs(t) > MACHINE_EPSILON) {
           t = 1.0/t;
           vector_handler_->scal(&t, vec_v_, memspace_);
         } else {
@@ -249,7 +249,7 @@ namespace ReSolve
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
         H[ idxmap(i, i + 1, num_vecs_ + 1)] = t;
-        if(std::abs(t) > EPSILON) {
+        if(std::abs(t) > MACHINE_EPSILON) {
           t = 1.0 / t;
           vector_handler_->scal(&t, vec_w_, memspace_);
           for (int ii=0; ii<=i; ++ii)
@@ -325,7 +325,7 @@ namespace ReSolve
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
         H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
-        if(std::abs(t) > EPSILON) {
+        if(std::abs(t) > MACHINE_EPSILON) {
           t = 1.0 / t;
           vector_handler_->scal(&t, vec_w_, memspace_);
         } else {
@@ -353,7 +353,7 @@ namespace ReSolve
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
         H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
-        if(std::abs(t) > EPSILON) {
+        if(std::abs(t) > MACHINE_EPSILON) {
           t = 1.0/t;
           vector_handler_->scal(&t, vec_v_, memspace_);
         } else {

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -134,8 +134,8 @@ namespace ReSolve
       // check if maybe residual is already small enough?
       if (it == 0) {
         tolrel = tol_ * rnorm;
-        if (std::abs(tolrel) < 1e-16) {
-          tolrel = 1e-16;
+        if (std::abs(tolrel) < MACHINE_EPSILON) {
+          tolrel = MACHINE_EPSILON;
         }
       }
 
@@ -143,13 +143,13 @@ namespace ReSolve
       switch (conv_cond_)
       {
         case 0:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON));
           break;
         case 1:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < tol_));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < tol_));
           break;
         case 2:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < (tol_*bnorm)));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < (tol_*bnorm)));
           break;
       }
 
@@ -204,8 +204,8 @@ namespace ReSolve
         real_type Hii1 = h_H_[(i) * (restart_ + 1) + i + 1];
         real_type gam = std::sqrt(Hii * Hii + Hii1 * Hii1);
 
-        if(std::abs(gam - ZERO) <= EPSILON) {
-          gam = EPSMAC;
+        if(std::abs(gam - ZERO) <= MACHINE_EPSILON) {
+          gam = MACHINE_EPSILON;
         }
 
         /* next Given's rotation */

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -173,8 +173,8 @@ namespace ReSolve
       // check if maybe residual is already small enough?
       if (it == 0) {
         tolrel = tol_ * rnorm;
-        if (std::abs(tolrel) < 1e-16) {
-          tolrel = 1e-16;
+        if (std::abs(tolrel) < MACHINE_EPSILON) {
+          tolrel = MACHINE_EPSILON;
         }
       }
 
@@ -182,13 +182,13 @@ namespace ReSolve
       switch (conv_cond_)
       {
         case 0:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON));
           break;
         case 1:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < tol_));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < tol_));
           break;
         case 2:
-          exit_cond = ((std::abs(rnorm - ZERO) <= EPSILON) || (rnorm < (tol_*bnorm)));
+          exit_cond = ((std::abs(rnorm - ZERO) <= MACHINE_EPSILON) || (rnorm < (tol_*bnorm)));
           break;
       }
 
@@ -270,8 +270,8 @@ namespace ReSolve
         real_type Hii1 = h_H_[(i) * (restart_ + 1) + i + 1];
         real_type gam = std::sqrt(Hii * Hii + Hii1 * Hii1);
 
-        if(std::abs(gam - ZERO) <= EPSILON) {
-          gam = EPSMAC;
+        if(std::abs(gam - ZERO) <= MACHINE_EPSILON) {
+          gam = MACHINE_EPSILON;
         }
 
         /* next Given's rotation */

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -260,7 +260,8 @@ int main(int argc, char* argv[])
     std::cout << "Result is not a finite number!\n";
     error_sum++;
   }
-  if ((scaled_residual_norm_one > DEFAULT_TOL) || (scaled_residual_norm_two > DEFAULT_TOL)) {
+  real_type tol = 100 * ReSolve::constants::MACHINE_EPSILON;
+  if ((scaled_residual_norm_one > tol) || (scaled_residual_norm_two > tol)) {
     std::cout << "Result inaccurate!\n";
     error_sum++;
   }


### PR DESCRIPTION
## Description
 
 This allows the user to control all tolerances from a single location: `Common.hpp` and relates most of them to the working machine precision. This PR implements only the changes that were agreed upon from [this one](https://github.com/ORNL/ReSolve/pull/269/files#diff-372a7cb3ae4975b3023f03bdfe4195515d38e04abb5b1f2fb98a56391fdd4469).

Closes #194

 ## Proposed changes
 
 _I removed numbers from the code and replaced them with constants related to machine epsilon._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc._

