### PR TITLE
Revert multivector changes in #260

### DIFF
--- a/examples/ExampleHelper.hpp
+++ b/examples/ExampleHelper.hpp
@@ -348,7 +348,7 @@ namespace ReSolve
                                                ReSolve::memory::MemorySpace memspace)
         {
           using namespace ReSolve::constants;
-          mh_.matvec(&A, &x, &r, &ONE, &MINUSONE, memspace); // r := A * x - r
+          mh_.matvec(&A, &x, &r, &ONE, &MINUS_ONE, memspace); // r := A * x - r
           return norm2(r, memspace);
         }
 

--- a/examples/experimental/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/experimental/r_KLU_GLU_matrix_values_update.cpp
@@ -12,7 +12,7 @@
 #include <resolve/LinSolverDirectCuSolverGLU.hpp>
 #include <resolve/workspace/LinAlgWorkspace.hpp>
 
-// this updates the matrix values to simulate what CFD/optimization software does. 
+// this updates the matrix values to simulate what CFD/optimization software does.
 
 using namespace ReSolve::constants;
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
       } else {
         ReSolve::io::updateMatrixFromFile(mat_file, A_exp);
       }
-      std::cout<<"Updating values of A_coo!"<<std::endl; 
+      std::cout<<"Updating values of A_coo!"<<std::endl;
       A->copyValues(A_exp->getValues(ReSolve::memory::HOST), ReSolve::memory::HOST, ReSolve::memory::HOST);
       //ReSolve::io::updateMatrixFromFile(mat_file, A);
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
@@ -108,17 +108,17 @@ int main(int argc, char *argv[])
     // Copy matrix data to device
     A->syncData(ReSolve::memory::DEVICE);
 
-    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
-              << ", nnz: "       << A->getNnz() 
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns()
+              << ", nnz: "       << A->getNnz()
               << ", symmetric? " << A->symmetric()
               << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
-    if (i < 1) { 
+    if (i < 1) {
       vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-    } else { 
+    } else {
       vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
@@ -136,27 +136,27 @@ int main(int argc, char *argv[])
       if (L == nullptr) {printf("ERROR");}
       index_type* P = KLU->getPOrdering();
       index_type* Q = KLU->getQOrdering();
-      GLU->setup(A, L, U, P, Q); 
+      GLU->setup(A, L, U, P, Q);
       status = GLU->solve(vec_rhs, vec_x);
-      std::cout<<"GLU solve status: "<<status<<std::endl;      
+      std::cout<<"GLU solve status: "<<status<<std::endl;
       //      status = KLU->solve(vec_rhs, vec_x);
-      //    std::cout<<"KLU solve status: "<<status<<std::endl;      
+      //    std::cout<<"KLU solve status: "<<status<<std::endl;
     } else {
       //status =  KLU->refactorize();
       std::cout<<"Using CUSOLVER GLU"<<std::endl;
       status = GLU->refactorize();
-      std::cout<<"CUSOLVER GLU refactorization status: "<<status<<std::endl;      
+      std::cout<<"CUSOLVER GLU refactorization status: "<<status<<std::endl;
       status = GLU->solve(vec_rhs, vec_x);
-      std::cout<<"CUSOLVER GLU solve status: "<<status<<std::endl;      
+      std::cout<<"CUSOLVER GLU solve status: "<<status<<std::endl;
     }
     vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
 
-    std::cout << "\t 2-Norm of the residual: " 
-              << std::scientific << std::setprecision(16) 
+    std::cout << "\t 2-Norm of the residual: "
+              << std::scientific << std::setprecision(16)
               << sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE)) << "\n";
   }
 

--- a/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
@@ -108,17 +108,17 @@ int main(int argc, char *argv[] )
     // Copy matrix data to device
     A->syncData(ReSolve::memory::DEVICE);
 
-    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns() 
-              << ", nnz: "       << A->getNnz() 
+    std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x "<< A->getNumColumns()
+              << ", nnz: "       << A->getNnz()
               << ", symmetric? " << A->symmetric()
               << ", Expanded? "  << A->expanded() << std::endl;
     mat_file.close();
     rhs_file.close();
 
     // Update host and device data.
-    if (i < 2) { 
+    if (i < 2) {
       vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-    } else { 
+    } else {
       vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
@@ -131,7 +131,7 @@ int main(int argc, char *argv[] )
       status = KLU->factorize();
       std::cout<<"KLU factorization status: "<<status<<std::endl;
       status = KLU->solve(vec_rhs, vec_x);
-      std::cout<<"KLU solve status: "<<status<<std::endl;      
+      std::cout<<"KLU solve status: "<<status<<std::endl;
       if (i == 1) {
         L_csc = (ReSolve::matrix::Csc*) KLU->getLFactor();
         U_csc = (ReSolve::matrix::Csc*) KLU->getUFactor();
@@ -146,7 +146,7 @@ int main(int argc, char *argv[] )
         }
         P = KLU->getPOrdering();
         Q = KLU->getQOrdering();
-        Rf->setup(A, L, U, P, Q); 
+        Rf->setup(A, L, U, P, Q);
         Rf->refactorize();
         delete L;
         delete U;
@@ -154,24 +154,24 @@ int main(int argc, char *argv[] )
     } else {
       std::cout<<"Using cusolver rf"<<std::endl;
       status_refactor = Rf->refactorize();
-      std::cout<<"cusolver rf refactorization status: "<<status<<std::endl;      
+      std::cout<<"cusolver rf refactorization status: "<<status<<std::endl;
       status = Rf->solve(vec_rhs, vec_x);
-      std::cout<<"cusolver rf solve status: "<<status<<std::endl;      
+      std::cout<<"cusolver rf solve status: "<<status<<std::endl;
     }
     vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+    matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
     res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
     b_nrm   = sqrt(vector_handler->dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
-    std::cout << "\t2-Norm of the residual: " 
-              << std::scientific << std::setprecision(16) 
+    std::cout << "\t2-Norm of the residual: "
+              << std::scientific << std::setprecision(16)
               << res_nrm/b_nrm << "\n";
     if (((res_nrm/b_nrm > 1e-7 ) && (!std::isnan(res_nrm))) || (status_refactor != 0 )) {
       if ((res_nrm/b_nrm > 1e-7 )) {
         std::cout << "\n \t !!! ALERT !!! Residual norm is too large; redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n \n";
-      } else { 
+      } else {
         std::cout << "\n \t !!! ALERT !!! cuSolverRf crashed; redoing KLU symbolic and numeric factorization. !!! ALERT !!! \n \n";
       }
       KLU->setup(A);
@@ -180,14 +180,14 @@ int main(int argc, char *argv[] )
       status = KLU->factorize();
       std::cout<<"KLU factorization status: "<<status<<std::endl;
       status = KLU->solve(vec_rhs, vec_x);
-      std::cout<<"KLU solve status: "<<status<<std::endl;      
+      std::cout<<"KLU solve status: "<<status<<std::endl;
 
       vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
-      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+      matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
       res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
       std::cout <<"\t New residual norm: "
@@ -206,7 +206,7 @@ int main(int argc, char *argv[] )
       P = KLU->getPOrdering();
       Q = KLU->getQOrdering();
 
-      Rf->setup(A, L, U, P, Q); 
+      Rf->setup(A, L, U, P, Q);
       Rf->refactorize();
 
       delete L;

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -21,7 +21,7 @@ namespace ReSolve {
   {
     constexpr real_type ZERO = 0.0;
     constexpr real_type ONE = 1.0;
-    constexpr real_type MINUSONE = -1.0;
+    constexpr real_type MINUS_ONE = -1.0;
     constexpr real_type DEFAULT_TOL = 100*std::numeric_limits<real_type>::epsilon();
   }
 

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -36,10 +36,10 @@ namespace ReSolve
 
   /**
    * @brief Sets/changes Gram-Schmidt variant
-   * 
+   *
    * This function should leave Gram-Schmidt class instance in the same state
    * as it found it only with different implementation of the orthogonalization.
-   * 
+   *
    * @param[in] variant - Gram-Schmidt orthogonalization variant
    */
   int GramSchmidt::setVariant(GSVariant variant)
@@ -67,17 +67,17 @@ namespace ReSolve
     setup(n, num_vecs_);
     setup_complete_ = true;
 
-    return 0;  
+    return 0;
   }
 
   GramSchmidt::GSVariant GramSchmidt::getVariant()
   {
-    return variant_;  
+    return variant_;
   }
 
   real_type* GramSchmidt::getL()
   {
-    return h_L_;  
+    return h_L_;
   }
 
   bool GramSchmidt::isSetupComplete()
@@ -106,30 +106,30 @@ namespace ReSolve
       vec_rv_->setToZero(memspace_);
 
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
-      vec_Hcolumn_->allocate(memspace_);      
+      vec_Hcolumn_->allocate(memspace_);
       vec_Hcolumn_->setToZero(memspace_);
 
-      setup_complete_ = true; 
+      setup_complete_ = true;
     }
     if(variant_ == CGS2) {
       h_aux_ = new real_type[num_vecs_ + 1]();
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
       vec_Hcolumn_->allocate(memspace_);
-      vec_Hcolumn_->setToZero(memspace_);      
+      vec_Hcolumn_->setToZero(memspace_);
 
-      setup_complete_ = true; 
+      setup_complete_ = true;
     }
     if(variant_ == CGS1) {
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
-      vec_Hcolumn_->allocate(memspace_);      
-      vec_Hcolumn_->setToZero(memspace_);      
+      vec_Hcolumn_->allocate(memspace_);
+      vec_Hcolumn_->setToZero(memspace_);
 
-      setup_complete_ = true; 
+      setup_complete_ = true;
     }
     if(variant_ == MGS_PM) {
       h_aux_ = new real_type[num_vecs_ + 1]();
 
-      setup_complete_ = true; 
+      setup_complete_ = true;
     }
 
     return setup_complete_ ? 0 : 1;
@@ -144,15 +144,15 @@ namespace ReSolve
     real_type* h_rv = nullptr;
 
     switch (variant_) {
-      case MGS: 
+      case MGS:
         vec_w_->setData(V->getVectorData(i + 1, memspace_), memspace_);
         for(int j = 0; j <= i; ++j) {
           t = 0.0;
           vec_v_->setData( V->getVectorData(j, memspace_), memspace_);
-          t = vector_handler_->dot(vec_v_, vec_w_, memspace_);  
-          H[ idxmap(i, j, num_vecs_ + 1) ] = t; 
+          t = vector_handler_->dot(vec_v_, vec_w_, memspace_);
+          H[ idxmap(i, j, num_vecs_ + 1) ] = t;
           t *= -1.0;
-          vector_handler_->axpy(&t, vec_v_, vec_w_, memspace_);  
+          vector_handler_->axpy(&t, vec_v_, vec_w_, memspace_);
         }
         t = 0.0;
         t = vector_handler_->dot(vec_w_, vec_w_, memspace_);
@@ -161,7 +161,7 @@ namespace ReSolve
         H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
         if(std::abs(t) > EPSILON) {
           t = 1.0/t;
-          vector_handler_->scal(&t, vec_w_, memspace_);  
+          vector_handler_->scal(&t, vec_w_, memspace_);
         } else {
           assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
           return 1;
@@ -172,9 +172,9 @@ namespace ReSolve
         vec_v_->setData(V->getVectorData(i + 1, memspace_), memspace_);
         vector_handler_->gemv('T', n, i + 1, &ONE, &ZERO, V,  vec_v_, vec_Hcolumn_, memspace_);
         // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
-        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace_ );  
+        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_ );
         mem_.deviceSynchronize();
-        
+
         // copy H_col to aux, we will need it later
         vec_Hcolumn_->setDataUpdated(memspace_);
         vec_Hcolumn_->setCurrentSize(i + 1);
@@ -186,7 +186,7 @@ namespace ReSolve
         mem_.deviceSynchronize();
 
         // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
-        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace_ );  
+        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_ );
         mem_.deviceSynchronize();
 
         // copy H_col to H
@@ -200,14 +200,14 @@ namespace ReSolve
           H[ idxmap(i, j, num_vecs_ + 1)] += h_aux_[j];
         }
 
-        t = vector_handler_->dot(vec_v_, vec_v_, memspace_);  
+        t = vector_handler_->dot(vec_v_, vec_v_, memspace_);
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
-        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t; 
+        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
 
         if(std::abs(t) > EPSILON) {
           t = 1.0/t;
-          vector_handler_->scal(&t, vec_v_, memspace_);  
+          vector_handler_->scal(&t, vec_v_, memspace_);
         } else {
           assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
           return 1;
@@ -227,7 +227,7 @@ namespace ReSolve
 
         vec_rv_->copyDataTo(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);
-        
+
         for(int j=0; j<=i; ++j) {
           H[ idxmap(i, j, num_vecs_ + 1) ] = 0.0;
         }
@@ -238,25 +238,25 @@ namespace ReSolve
           for(int k = 0; k < j; ++k) {
             s += h_L_[ idxmap(j, k, num_vecs_ + 1) ] * H[ idxmap(i, k, num_vecs_ + 1) ];
           } // for k
-          H[ idxmap(i, j, num_vecs_ + 1) ] -= s; 
+          H[ idxmap(i, j, num_vecs_ + 1) ] -= s;
         }   // for j
         vec_Hcolumn_->setCurrentSize(i + 1);
-        vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_); 
+        vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
         vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V, vec_w_, memspace_);
 
         // normalize (second synch)
-        t = vector_handler_->dot(vec_w_, vec_w_, memspace_);  
+        t = vector_handler_->dot(vec_w_, vec_w_, memspace_);
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
-        H[ idxmap(i, i + 1, num_vecs_ + 1)] = t;    
+        H[ idxmap(i, i + 1, num_vecs_ + 1)] = t;
         if(std::abs(t) > EPSILON) {
           t = 1.0 / t;
-          vector_handler_->scal(&t, vec_w_, memspace_);  
+          vector_handler_->scal(&t, vec_w_, memspace_);
           for (int ii=0; ii<=i; ++ii)
           {
             vec_v_->setData(V->getVectorData(ii, memspace_), memspace_);
             vec_w_->setData(V->getVectorData(i + 1, memspace_), memspace_);
-          }        
+          }
         } else {
           assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
           return 1;
@@ -317,17 +317,17 @@ namespace ReSolve
         }
 
         vec_Hcolumn_->setCurrentSize(i + 1);
-        vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_); 
+        vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
 
         vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V,  vec_w_, memspace_);
         // normalize (second synch)
-        t = vector_handler_->dot(vec_w_, vec_w_, memspace_);  
+        t = vector_handler_->dot(vec_w_, vec_w_, memspace_);
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
-        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;    
+        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
         if(std::abs(t) > EPSILON) {
           t = 1.0 / t;
-          vector_handler_->scal(&t, vec_w_, memspace_);  
+          vector_handler_->scal(&t, vec_w_, memspace_);
         } else {
           assert(0 && "Iterative refinement failed, Krylov vector with ZERO norm\n");
           return 1;
@@ -340,28 +340,28 @@ namespace ReSolve
         //Hcol = V(:,1:i)^T*V(:,i+1);
         vector_handler_->gemv('T', n, i + 1, &ONE, &ZERO, V,  vec_v_, vec_Hcolumn_, memspace_);
         // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
-        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUSONE, V, vec_Hcolumn_, vec_v_, memspace_ );  
+        vector_handler_->gemv('N', n, i + 1, &ONE, &MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_ );
         mem_.deviceSynchronize();
-        
+
         // copy H_col to H
         vec_Hcolumn_->setDataUpdated(memspace_);
         vec_Hcolumn_->setCurrentSize(i + 1);
         vec_Hcolumn_->copyDataTo(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         mem_.deviceSynchronize();
 
-        t = vector_handler_->dot(vec_v_, vec_v_, memspace_);  
+        t = vector_handler_->dot(vec_v_, vec_v_, memspace_);
         //set the last entry in Hessenberg matrix
         t = std::sqrt(t);
-        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t; 
+        H[ idxmap(i, i + 1, num_vecs_ + 1) ] = t;
         if(std::abs(t) > EPSILON) {
           t = 1.0/t;
-          vector_handler_->scal(&t, vec_v_, memspace_);  
+          vector_handler_->scal(&t, vec_v_, memspace_);
         } else {
           assert(0 && "Gram-Schmidt failed, vector with ZERO norm\n");
           return 1;
         }
         return 0;
-        
+
       default:
         assert(0 && "Iterative refinement failed, wrong orthogonalization.\n");
         return 1;
@@ -376,7 +376,7 @@ namespace ReSolve
 
   int GramSchmidt::freeGramSchmidtData()
   {
-    if(variant_ == MGS_TWO_SYNC || variant_ == MGS_PM) {    
+    if(variant_ == MGS_TWO_SYNC || variant_ == MGS_PM) {
       delete h_L_;
       h_L_ = nullptr;
 
@@ -389,14 +389,14 @@ namespace ReSolve
     if (variant_ == CGS2) {
       delete h_aux_;
       h_aux_ = nullptr;
-      delete vec_Hcolumn_;    
+      delete vec_Hcolumn_;
       vec_Hcolumn_ = nullptr;
-    }    
+    }
 
     if (variant_ == CGS1) {
-      delete vec_Hcolumn_;    
+      delete vec_Hcolumn_;
       vec_Hcolumn_ = nullptr;
-    }    
+    }
 
     if (variant_ == MGS_PM) {
       delete h_aux_;

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -2,7 +2,7 @@
  * @file LinSolverIterativeFGMRES.cpp
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @brief Implementation of LinSolverIterativeFGMRES class
- * 
+ *
  */
 #include <iostream>
 #include <cassert>
@@ -37,8 +37,8 @@ namespace ReSolve
                                                      GramSchmidt*   gs)
   {
     // Base class settings here (to be removed when solver parameter settings are implemented)
-    tol_ = tol; 
-    maxit_= maxit; 
+    tol_ = tol;
+    maxit_= maxit;
     restart_ = restart;
     conv_cond_ = conv_cond;
     flexible_ = true;
@@ -59,13 +59,13 @@ namespace ReSolve
 
   /**
    * @brief Set pointer to system matrix and allocate solver data.
-   * 
+   *
    * @param[in] A - Sparse system matrix
-   * 
+   *
    * @pre A is a valid sparse matrix
-   * 
+   *
    * @post A_ == A
-   * @post Solver data allocated. 
+   * @post Solver data allocated.
    */
   int LinSolverIterativeFGMRES::setup(matrix::Sparse* A)
   {
@@ -98,9 +98,9 @@ namespace ReSolve
     using namespace constants;
 
     //io::Logger::setVerbosity(io::Logger::EVERYTHING);
-    
+
     int outer_flag = 1;
-    int notconv = 1; 
+    int notconv = 1;
     int i  = 0;
     int it = 0;
     int j  = 0;
@@ -118,8 +118,8 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+    matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
     rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
@@ -127,7 +127,7 @@ namespace ReSolve
     rnorm = std::sqrt(rnorm);
     bnorm = std::sqrt(bnorm);
     io::Logger::misc() << "it 0: norm of residual "
-                       << std::scientific << std::setprecision(16) 
+                       << std::scientific << std::setprecision(16)
                        << rnorm << " Norm of rhs: " << bnorm << "\n";
     initial_residual_norm_ = rnorm;
     while(outer_flag) {
@@ -187,7 +187,7 @@ namespace ReSolve
 
         vec_v->setData( vec_V_->getVectorData(i + 1, memspace_), memspace_);
 
-        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_); 
+        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_);
 
         // orthogonalize V[i+1], form a column of h_H_
 
@@ -260,7 +260,7 @@ namespace ReSolve
 
         vec_v->setData( vec_V_->getData(memspace_), memspace_);
         this->precV(vec_z, vec_v);
-        // and add to x 
+        // and add to x
         vector_handler_->axpy(&ONE, vec_v, x, memspace_);
       }
 
@@ -271,8 +271,8 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
       rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
       // rnorm = ||V_1||
       rnorm = std::sqrt(rnorm);
@@ -294,7 +294,7 @@ namespace ReSolve
       out::warning() << "Only LU-type solve can be used as a preconditioner at this time." << std::endl;
       return 1;
     } else {
-      LU_solver_ = LU_solver;  
+      LU_solver_ = LU_solver;
       return 0;
     }
 
@@ -309,7 +309,7 @@ namespace ReSolve
 
   /**
    * @brief Sets pointer to Gram-Schmidt (re)orthogonalization.
-   * 
+   *
    * @param[in] gs - pointer to Gram-Schmidt class instance.
    * @return 0 if successful, error code otherwise.
    */
@@ -321,13 +321,13 @@ namespace ReSolve
 
   /**
    * @brief Set/change GMRES restart value
-   * 
+   *
    * This function should leave solver instance in the same state but with
    * the new restart value.
-   * 
-   * @param[in] restart - the restart value 
+   *
+   * @param[in] restart - the restart value
    * @return 0 if successful, error code otherwise.
-   * 
+   *
    * @todo Consider not setting up GS, if it was not previously set up.
    */
   int LinSolverIterativeFGMRES::setRestart(index_type restart)
@@ -359,7 +359,7 @@ namespace ReSolve
 
   /**
    * @brief Switches between flexible and standard GMRES
-   * 
+   *
    * @param is_flexible - true means set flexible GMRES
    * @return 0 if successful, error code otherwise.
    */
@@ -374,7 +374,7 @@ namespace ReSolve
         // otherwise Z is just a one vector, not multivector and we dont keep it
         vec_Z_ = new vector_type(n_);
       }
-      vec_Z_->allocate(memspace_); 
+      vec_Z_->allocate(memspace_);
     }
     flexible_ = is_flexible;
     matrix_handler_->setValuesChanged(true, memspace_);
@@ -383,8 +383,8 @@ namespace ReSolve
 
   /**
    * @brief Set the convergence condition for GMRES solver
-   * 
-   * @param[in] conv_cond - Possible values: 0, 1, 2 
+   *
+   * @param[in] conv_cond - Possible values: 0, 1, 2
    * @return int - error code, 0 if successful
    */
   int LinSolverIterativeFGMRES::setConvergenceCondition(index_type conv_cond)
@@ -522,7 +522,7 @@ namespace ReSolve
   int LinSolverIterativeFGMRES::allocateSolverData()
   {
     vec_V_ = new vector_type(n_, restart_ + 1);
-    vec_V_->allocate(memspace_);      
+    vec_V_->allocate(memspace_);
     if (flexible_) {
       vec_Z_ = new vector_type(n_, restart_ + 1);
     } else {
@@ -544,7 +544,7 @@ namespace ReSolve
     delete [] h_c_ ;
     delete [] h_s_ ;
     delete [] h_rs_;
-    delete vec_V_;   
+    delete vec_V_;
     delete vec_Z_;
 
     h_H_  = nullptr;
@@ -558,7 +558,7 @@ namespace ReSolve
   }
 
   void LinSolverIterativeFGMRES::precV(vector_type* rhs, vector_type* x)
-  { 
+  {
     LU_solver_->solve(rhs, x);
   }
 
@@ -569,9 +569,9 @@ namespace ReSolve
     bool is_vector_handler_cuda = matrix_handler_->getIsCudaEnabled();
     bool is_vector_handler_hip  = matrix_handler_->getIsHipEnabled();
 
-    if ((is_matrix_handler_cuda != is_vector_handler_cuda) || 
+    if ((is_matrix_handler_cuda != is_vector_handler_cuda) ||
         (is_matrix_handler_hip  != is_vector_handler_hip )) {
-      out::error() << "Matrix and vector handler backends are incompatible!\n";  
+      out::error() << "Matrix and vector handler backends are incompatible!\n";
     }
 
     if (is_matrix_handler_cuda || is_matrix_handler_hip) {

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -2,7 +2,7 @@
  * @file LinSolverIterativeRandFGMRES.cpp
  * @author Kasia Swirydowicz (kasia.swirydowicz@pnnl.gov)
  * @brief Implementation of LinSolverIterativeRandFGMRES class.
- * 
+ *
  */
 #include <iostream>
 #include <cassert>
@@ -23,8 +23,8 @@ namespace ReSolve
   using out = io::Logger;
 
   LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(MatrixHandler*  matrix_handler,
-                                                             VectorHandler*  vector_handler, 
-                                                             SketchingMethod rand_method, 
+                                                             VectorHandler*  vector_handler,
+                                                             SketchingMethod rand_method,
                                                              GramSchmidt*    gs)
   {
     tol_ = 1e-14; //default
@@ -42,17 +42,17 @@ namespace ReSolve
     initParamList();
   }
 
-  LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(index_type      restart, 
+  LinSolverIterativeRandFGMRES::LinSolverIterativeRandFGMRES(index_type      restart,
                                                              real_type       tol,
                                                              index_type      maxit,
                                                              index_type      conv_cond,
                                                              MatrixHandler*  matrix_handler,
                                                              VectorHandler*  vector_handler,
-                                                             SketchingMethod rand_method, 
+                                                             SketchingMethod rand_method,
                                                              GramSchmidt*    gs)
   {
-    tol_ = tol; 
-    maxit_= maxit; 
+    tol_ = tol;
+    maxit_= maxit;
     restart_ = restart;
     conv_cond_ = conv_cond;
     flexible_ = true;
@@ -81,9 +81,9 @@ namespace ReSolve
 
   /**
    * @brief Set system matrix and allocate solver and sketching data
-   * 
+   *
    * @param[in] A - sparse system matrix
-   * @return 0 if setup successful 
+   * @return 0 if setup successful
    */
   int LinSolverIterativeRandFGMRES::setup(matrix::Sparse* A)
   {
@@ -127,7 +127,7 @@ namespace ReSolve
     // io::Logger::setVerbosity(io::Logger::EVERYTHING);
 
     int outer_flag = 1;
-    int notconv = 1; 
+    int notconv = 1;
     index_type i = 0;
     int it = 0;
     int j;
@@ -147,8 +147,8 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-    matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+    matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
 
     vec_v->setData(vec_V_->getVectorData(0, memspace_), memspace_);
     vec_s->setData(vec_S_->getVectorData(0, memspace_), memspace_);
@@ -166,7 +166,7 @@ namespace ReSolve
     rnorm = std::sqrt(rnorm); // rnorm = ||V_1||
     bnorm = std::sqrt(bnorm);
     io::Logger::misc() << "it 0: norm of residual "
-                       << std::scientific << std::setprecision(16) 
+                       << std::scientific << std::setprecision(16)
                        << rnorm << " Norm of rhs: " << bnorm << "\n";
     initial_residual_norm_ = rnorm;
     while(outer_flag) {
@@ -229,12 +229,12 @@ namespace ReSolve
         // V_{i+1}=A*Z_i
         vec_v->setData(vec_V_->getVectorData(i + 1, memspace_), memspace_);
 
-        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_); 
+        matrix_handler_->matvec(A_, vec_z, vec_v, &ONE, &ZERO, memspace_);
 
         // orthogonalize V[i+1], form a column of h_H_
         // this is where it differs from normal solver GS
         vec_s->setData(vec_S_->getVectorData(i + 1, memspace_), memspace_);
-        sketching_handler_->Theta(vec_v, vec_s); 
+        sketching_handler_->Theta(vec_v, vec_s);
         if (sketching_method_ == fwht) {
           vector_handler_->scal(&one_over_k_, vec_s, memspace_);
         }
@@ -248,13 +248,13 @@ namespace ReSolve
         }
         vec_z->setData(d_aux_, memspace_);
         vec_z->setCurrentSize(i + 1);
-        // V(:, i+1) = w - V(:, 1:i)*d_H_col = V(:, i+1) - d_H_col*V(:,1:i); 
+        // V(:, i+1) = w - V(:, 1:i)*d_H_col = V(:, i+1) - d_H_col*V(:,1:i);
 
-        vector_handler_->gemv('N', n_, i + 1, &MINUSONE, &ONE, vec_V_, vec_z, vec_v, memspace_ );  
+        vector_handler_->gemv('N', n_, i + 1, &MINUS_ONE, &ONE, vec_V_, vec_z, vec_v, memspace_ );
 
         vec_z->setCurrentSize(n_);
         t = 1.0 / h_H_[i * (restart_ + 1) + i + 1];
-        vector_handler_->scal(&t, vec_v, memspace_);  
+        vector_handler_->scal(&t, vec_v, memspace_);
         mem_.deviceSynchronize();
         vec_s->setData(vec_S_->getVectorData(i + 1, memspace_), memspace_);
 
@@ -327,7 +327,7 @@ namespace ReSolve
 
         vec_v->setData(vec_V_->getData(memspace_), memspace_);
         this->precV(vec_z, vec_v);
-        // and add to x 
+        // and add to x
         vector_handler_->axpy(&ONE, vec_v, x, memspace_);
       }
 
@@ -337,8 +337,8 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);  
-      matrix_handler_->matvec(A_, x, vec_V_, &MINUSONE, &ONE, memspace_); 
+      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
       if (outer_flag) {
 
         sketching_handler_->reset();
@@ -380,7 +380,7 @@ namespace ReSolve
       out::warning() << "Only cusolverRf tri solve can be used as a preconditioner at this time." << std::endl;
       return 1;
     } else {
-      LU_solver_ = LU_solver;  
+      LU_solver_ = LU_solver;
       return 0;
     }
 
@@ -400,8 +400,8 @@ namespace ReSolve
 
   /**
    * @brief Set sketching method based on input string.
-   * 
-   * @param[in] method - string describing sketching method 
+   *
+   * @param[in] method - string describing sketching method
    * @return 0 if successful, 1 otherwise.
    */
   int LinSolverIterativeRandFGMRES::setSketchingMethod(SketchingMethod method)
@@ -440,13 +440,13 @@ namespace ReSolve
 
   /**
    * @brief Set/change GMRES restart value
-   * 
+   *
    * This function should leave solver instance in the same state but with
    * the new restart value.
-   * 
-   * @param[in] restart - the restart value 
+   *
+   * @param[in] restart - the restart value
    * @return 0 if successful, error code otherwise.
-   * 
+   *
    * @todo Consider not setting up GS, if it was not previously set up.
    */
   int LinSolverIterativeRandFGMRES::setRestart(index_type restart)
@@ -481,7 +481,7 @@ namespace ReSolve
 
   /**
    * @brief Switches between flexible and standard GMRES
-   * 
+   *
    * @param is_flexible - true means set flexible GMRES
    * @return 0 if successful, error code otherwise.
    */
@@ -496,7 +496,7 @@ namespace ReSolve
         // otherwise Z is just a one vector, not multivector and we dont keep it
         vec_Z_ = new vector_type(n_);
       }
-      vec_Z_->allocate(memspace_); 
+      vec_Z_->allocate(memspace_);
     }
     flexible_ = is_flexible;
     matrix_handler_->setValuesChanged(true, memspace_);
@@ -505,8 +505,8 @@ namespace ReSolve
 
   /**
    * @brief Set the convergence condition for GMRES solver
-   * 
-   * @param[in] conv_cond - Possible values: 0, 1, 2 
+   *
+   * @param[in] conv_cond - Possible values: 0, 1, 2
    * @return int - error code, 0 if successful
    */
   int LinSolverIterativeRandFGMRES::setConvergenceCondition(index_type conv_cond)
@@ -637,20 +637,20 @@ namespace ReSolve
   int LinSolverIterativeRandFGMRES::allocateSolverData()
   {
     vec_V_ = new vector_type(n_, restart_ + 1);
-    vec_V_->allocate(memspace_);      
+    vec_V_->allocate(memspace_);
     if (flexible_) {
       vec_Z_ = new vector_type(n_, restart_ + 1);
     } else {
       // otherwise Z is just one vector, not multivector and we dont keep it
       vec_Z_ = new vector_type(n_);
     }
-    vec_Z_->allocate(memspace_);   
+    vec_Z_->allocate(memspace_);
     h_H_  = new real_type[restart_ * (restart_ + 1)];
     h_c_  = new real_type[restart_];      // needed for givens
     h_s_  = new real_type[restart_];      // same
     h_rs_ = new real_type[restart_ + 1];  // for residual norm history
     if (memspace_ == memory::DEVICE) {
-      mem_.allocateArrayOnDevice(&d_aux_, restart_ + 1); 
+      mem_.allocateArrayOnDevice(&d_aux_, restart_ + 1);
     } else {
       d_aux_  = new real_type[restart_ + 1];
     }
@@ -663,12 +663,12 @@ namespace ReSolve
     delete [] h_c_ ;
     delete [] h_s_ ;
     delete [] h_rs_;
-    if (memspace_ == memory::DEVICE) { 
+    if (memspace_ == memory::DEVICE) {
       mem_.deleteOnDevice(d_aux_);
     } else {
       delete [] d_aux_;
     }
-    delete vec_V_;   
+    delete vec_V_;
     delete vec_Z_;
 
     h_H_   = nullptr;
@@ -684,7 +684,7 @@ namespace ReSolve
 
   /**
    * @brief Allocate data and instantiate sketching handler.
-   * 
+   *
    * @pre Randomized solver data is allocated.
    */
   int LinSolverIterativeRandFGMRES::allocateSketchingData()
@@ -697,7 +697,7 @@ namespace ReSolve
           k_rand_ = static_cast<index_type>(std::ceil(restart_ * std::log(static_cast<real_type>(n_))));
         }
         sketching_handler_ = new SketchingHandler(sketching_method_, device_type_);
-        // set k and n 
+        // set k and n
         break;
       case fwht:
         if (std::ceil(2.0 * restart_ * std::log(n_) / std::log(restart_)) < k_rand_) {
@@ -706,7 +706,7 @@ namespace ReSolve
         sketching_handler_ = new SketchingHandler(sketching_method_, device_type_);
         break;
       default:
-        io::Logger::warning() << "Wrong sketching method, setting to default (CountSketch)\n"; 
+        io::Logger::warning() << "Wrong sketching method, setting to default (CountSketch)\n";
         sketching_method_ = cs;
         if (std::ceil(restart_ * std::log(n_)) < k_rand_) {
           k_rand_ = static_cast<index_type>(std::ceil(restart_ * std::log(n_)));
@@ -717,7 +717,7 @@ namespace ReSolve
 
     one_over_k_ = 1.0 / std::sqrt((real_type) k_rand_);
     vec_S_ = new vector_type(k_rand_, restart_ + 1);
-    vec_S_->allocate(memspace_);      
+    vec_S_->allocate(memspace_);
     if (sketching_method_ == cs) {
       vec_S_->setToZero(memspace_);
     }
@@ -738,7 +738,7 @@ namespace ReSolve
   }
 
   void LinSolverIterativeRandFGMRES::precV(vector_type* rhs, vector_type* x)
-  { 
+  {
     LU_solver_->solve(rhs, x);
   }
 
@@ -746,7 +746,7 @@ namespace ReSolve
   /**
    * @brief Set memory space and device tape based on how MatrixHandler
    * and VectorHandler are configured.
-   * 
+   *
    */
   void LinSolverIterativeRandFGMRES::setMemorySpace()
   {
@@ -755,9 +755,9 @@ namespace ReSolve
     bool is_vector_handler_cuda = matrix_handler_->getIsCudaEnabled();
     bool is_vector_handler_hip  = matrix_handler_->getIsHipEnabled();
 
-    if ((is_matrix_handler_cuda != is_vector_handler_cuda) || 
+    if ((is_matrix_handler_cuda != is_vector_handler_cuda) ||
         (is_matrix_handler_hip  != is_vector_handler_hip )) {
-      out::error() << "Matrix and vector handler backends are incompatible!\n";  
+      out::error() << "Matrix and vector handler backends are incompatible!\n";
     }
 
     if (is_matrix_handler_cuda) {

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -49,7 +49,7 @@ namespace ReSolve
                              std::string refactor,
                              std::string solve,
                              std::string precond,
-                             std::string ir) 
+                             std::string ir)
     : workspaceCpu_(workspaceCpu),
       factorizationMethod_(factor),
       refactorizationMethod_(refactor),
@@ -70,17 +70,17 @@ namespace ReSolve
     vectorHandler_ = new VectorHandler(workspaceCpu_);
 
     memspace_ = "cpu";
-    
+
     initialize();
   }
 
 #ifdef RESOLVE_USE_CUDA
-  SystemSolver::SystemSolver(LinAlgWorkspaceCUDA*  workspaceCuda, 
+  SystemSolver::SystemSolver(LinAlgWorkspaceCUDA*  workspaceCuda,
                              std::string factor,
                              std::string refactor,
                              std::string solve,
                              std::string precond,
-                             std::string ir) 
+                             std::string ir)
     : workspaceCuda_(workspaceCuda),
       factorizationMethod_(factor),
       refactorizationMethod_(refactor),
@@ -101,18 +101,18 @@ namespace ReSolve
     vectorHandler_ = new VectorHandler(workspaceCuda_);
 
     memspace_ = "cuda";
-    
+
     initialize();
   }
 #endif
 
 #ifdef RESOLVE_USE_HIP
-  SystemSolver::SystemSolver(LinAlgWorkspaceHIP*  workspaceHip, 
+  SystemSolver::SystemSolver(LinAlgWorkspaceHIP*  workspaceHip,
                              std::string factor,
                              std::string refactor,
                              std::string solve,
                              std::string precond,
-                             std::string ir) 
+                             std::string ir)
     : workspaceHip_(workspaceHip),
       factorizationMethod_(factor),
       refactorizationMethod_(refactor),
@@ -133,7 +133,7 @@ namespace ReSolve
     vectorHandler_ = new VectorHandler(workspaceHip_);
 
     memspace_ = "hip";
-    
+
     initialize();
   }
 #endif
@@ -191,9 +191,9 @@ namespace ReSolve
 
   /**
    * @brief Sets up the system solver
-   * 
+   *
    * This method instantiates components of the system solver based on
-   * user inputs. 
+   * user inputs.
    */
   int SystemSolver::initialize()
   {
@@ -218,7 +218,7 @@ namespace ReSolve
       delete gs_;
       gs_ = nullptr;
     }
-    
+
     // Create factorization solver
     if (factorizationMethod_ == "none") {
       // do nothing
@@ -247,7 +247,7 @@ namespace ReSolve
       refactorizationSolver_ = new ReSolve::LinSolverDirectRocSolverRf(workspaceHip_);
 #endif
     } else {
-      out::error() << "Refactorization method " << refactorizationMethod_ 
+      out::error() << "Refactorization method " << refactorizationMethod_
                    << " not recognized ...\n";
       return 1;
     }
@@ -281,7 +281,7 @@ namespace ReSolve
         return 1;
       }
     } else {
-      out::error() << "Preconditioner method " << precondition_method_ 
+      out::error() << "Preconditioner method " << precondition_method_
                    << " not recognized ...\n";
       return 1;
     }
@@ -325,8 +325,8 @@ namespace ReSolve
     if (factorizationMethod_ == "klu") {
       factorizationSolver_->setup(A_);
       return factorizationSolver_->analyze();
-    } 
-    return 1;  
+    }
+    return 1;
   }
 
   int SystemSolver::factorize()
@@ -334,7 +334,7 @@ namespace ReSolve
     if (factorizationMethod_ == "klu") {
       is_solve_on_device_ = false;
       return factorizationSolver_->factorize();
-    } 
+    }
     return 1;
   }
 
@@ -344,8 +344,8 @@ namespace ReSolve
       return factorizationSolver_->refactorize();
     }
 
-    if (refactorizationMethod_ == "glu" || 
-        refactorizationMethod_ == "cusolverrf" || 
+    if (refactorizationMethod_ == "glu" ||
+        refactorizationMethod_ == "cusolverrf" ||
         refactorizationMethod_ == "rocsolverrf") {
           is_solve_on_device_ = true;
           return refactorizationSolver_->refactorize();
@@ -356,19 +356,19 @@ namespace ReSolve
 
   /**
    * @brief Sets up refactorization.
-   * 
+   *
    * Extracts factors and permutation vectors from the factorization solver
    * and configures selected refactorization solver. Also configures iterative
    * refinement, if it is enabled by the user.
-   * 
+   *
    * Also sets flag `is_solve_on_device_` to true signaling to a triangular
    * solver to run on GPU.
-   * 
+   *
    * @pre Factorization solver exists and provides access to L and U factors,
    * as well as left and right permutation vectors P and Q. Since KLU is
    * the only factorization solver available through ReSolve, the factors are
    * expected in CSC format.
-   * 
+   *
    * @return int 0 if successful, 1 if it fails
    */
   int SystemSolver::refactorizationSetup()
@@ -419,14 +419,14 @@ namespace ReSolve
 
   /**
    * @brief Calls triangular solver
-   * 
+   *
    * @param[in]  rhs - Right-hand-side vector of the system
    * @param[out] x   - Solution vector (will be overwritten)
    * @return int status of factorization
-   * 
+   *
    * @pre Factorization or refactorization has been performed and triangular
    * factors are available. Alternatively, a Krylov solver has been set up.
-   * 
+   *
    * @todo Make `rhs` a constant vector
    * @todo Need to use `enum`s and `switch` statements here or implement as PIMPL
    */
@@ -443,7 +443,7 @@ namespace ReSolve
 
     if (solveMethod_ == "klu") {
       status += factorizationSolver_->solve(rhs, x);
-    } 
+    }
 
     if (solveMethod_ == "glu" || solveMethod_ == "cusolverrf" || solveMethod_ == "rocsolverrf") {
       if (is_solve_on_device_) {
@@ -451,7 +451,7 @@ namespace ReSolve
       } else {
         status += factorizationSolver_->solve(rhs, x);
       }
-    } 
+    }
 
     if (irMethod_ == "fgmres") {
       if (is_solve_on_device_) {
@@ -507,9 +507,9 @@ namespace ReSolve
 
   /**
    * @brief Sets refactorization method to use
-   * 
+   *
    * @param[in] method - ID for the refactorization method
-   * 
+   *
    * @post Destroys whatever refactorization solver existed before
    * and sets `refactorization_solver_` pointer to the new
    * refactorization object. Sets refactorization method ID
@@ -537,16 +537,16 @@ namespace ReSolve
       refactorizationSolver_ = new ReSolve::LinSolverDirectRocSolverRf(workspaceHip_);
 #endif
     } else {
-      out::error() << "Refactorization method " << refactorizationMethod_ 
+      out::error() << "Refactorization method " << refactorizationMethod_
                    << " not recognized ...\n";
     }
   }
 
   /**
    * @brief Sets solve method
-   * 
+   *
    * @param[in] method - ID of the solve method
-   * 
+   *
    */
   int SystemSolver::setSolveMethod(std::string method)
   {
@@ -580,7 +580,7 @@ namespace ReSolve
                                                       vectorHandler_,
                                                       gs_);
     } else {
-      out::error() << "Solve method " << solveMethod_ 
+      out::error() << "Solve method " << solveMethod_
                    << " not recognized ...\n";
       return 1;
     }
@@ -588,11 +588,11 @@ namespace ReSolve
   }
 
   /**
-   * @brief Sets iterative refinement method and related orthogonalization. 
-   * 
+   * @brief Sets iterative refinement method and related orthogonalization.
+   *
    * @param[in] method   - string ID for the iterative refinement method
    * @param[in] gsMethod - string ID for the orthogonalization method to be used
-   * 
+   *
    * @todo Iterative refinement temporarily disabled on CPU. Need to fix that.
    */
   void SystemSolver::setRefinementMethod(std::string method, std::string gsMethod)
@@ -602,7 +602,7 @@ namespace ReSolve
 
     if (gs_ != nullptr)
       delete gs_;
-    
+
     if (method == "none")
       return;
 
@@ -674,7 +674,7 @@ namespace ReSolve
       return -1.0;
     }
     matrixHandler_->setValuesChanged(true, ms);
-    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUSONE, ms);
+    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUS_ONE, ms);
     resnorm = std::sqrt(vectorHandler_->dot(resVector_, resVector_, ms));
     return resnorm/norm_b;
   }
@@ -703,7 +703,7 @@ namespace ReSolve
       return -1.0;
     }
     matrixHandler_->setValuesChanged(true, ms);
-    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUSONE, ms);
+    matrixHandler_->matvec(A_, x, resVector_, &ONE, &MINUS_ONE, ms);
     resnorm = vectorHandler_->infNorm(resVector_, ms);
     norm_x  = vectorHandler_->infNorm(x, ms);
     matrixHandler_->matrixInfNorm(A_, &norm_A, ms);
@@ -717,12 +717,12 @@ namespace ReSolve
 
   /**
    * @brief Select sketching method for randomized solvers
-   * 
+   *
    * This is a brute force method that will delete randomized GMRES solver
    * only to change its sketching function.
-   * 
+   *
    * @todo This needs to be moved to LinSolverIterative class and accessed from there.
-   * 
+   *
    * @param[in] sketching_method - string ID of the sketching method
    */
   int SystemSolver::setSketchingMethod(std::string sketching_method)
@@ -752,7 +752,7 @@ namespace ReSolve
       auto* sol = dynamic_cast<LinSolverIterativeRandFGMRES*>(iterativeSolver_);
       sol->setSketchingMethod(tmp);
     }
-    
+
     return 0;
   }
 

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -104,7 +104,7 @@ namespace ReSolve {
 
       status = cusparseSpMV_bufferSize(handle_cusparse,
                                        CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                       &MINUSONE,
+                                       &MINUS_ONE,
                                        matA,
                                        vecx,
                                        &ONE,

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -11,42 +11,42 @@
 namespace ReSolve {
   using out = io::Logger;
 
-  /** 
-   * @brief empty constructor that does absolutely nothing        
+  /**
+   * @brief empty constructor that does absolutely nothing
    */
   VectorHandlerCuda::VectorHandlerCuda()
   {
   }
 
-  /** 
+  /**
    * @brief constructor
-   * 
-   * @param new_workspace - workspace to be set     
+   *
+   * @param new_workspace - workspace to be set
    */
   VectorHandlerCuda:: VectorHandlerCuda(LinAlgWorkspaceCUDA* new_workspace)
   {
     workspace_ = new_workspace;
   }
 
-  /** 
-   * @brief destructor     
+  /**
+   * @brief destructor
    */
   VectorHandlerCuda::~VectorHandlerCuda()
   {
     //delete the workspace TODO
   }
 
-  /** 
+  /**
    * @brief dot product of two vectors i.e, a = x^Ty
-   * 
+   *
    * @param[in] x The first vector
    * @param[in] y The second vector
-   * 
+   *
    * @return dot product (real number) of _x_ and _y_
    */
 
   real_type VectorHandlerCuda::dot(vector::Vector* x, vector::Vector* y)
-  { 
+  {
     cublasHandle_t handle_cublas =  workspace_->getCublasHandle();
     double nrm = 0.0;
     cublasStatus_t st = cublasDdot(handle_cublas,  x->getSize(), x->getData(memory::DEVICE), 1, y->getData(memory::DEVICE), 1, &nrm);
@@ -56,12 +56,12 @@ namespace ReSolve {
     return nrm;
   }
 
-  /** 
+  /**
    * @brief scale a vector by a constant i.e, x = alpha*x where alpha is a constant
-   * 
+   *
    * @param[in] alpha The constant
    * @param[in,out] x The vector
-   * 
+   *
    */
   void VectorHandlerCuda::scal(const real_type* alpha, vector::Vector* x)
   {
@@ -72,18 +72,18 @@ namespace ReSolve {
     }
   }
 
-  /** 
+  /**
    * @brief compute infinity norm of a vector (i.e., find an entry with largest absolute value)
-   * 
+   *
    * @param[in] The vector
    *
    * @return infinity norm (real number) of _x_
-   * 
+   *
    */
   real_type VectorHandlerCuda::infNorm(vector::Vector* x)
   {
 
-    if (workspace_->getNormBufferState() == false) { // not allocated  
+    if (workspace_->getNormBufferState() == false) { // not allocated
       real_type* buffer;
       mem_.allocateArrayOnDevice(&buffer, 1024);
       workspace_->setNormBuffer(buffer);
@@ -101,14 +101,14 @@ namespace ReSolve {
     }
     return norm;
   }
-  
-  /** 
+
+  /**
    * @brief axpy i.e, y = alpha*x + y where alpha is a constant
-   * 
+   *
    * @param[in] alpha The constant
    * @param[in] x The first vector
    * @param[in,out] y The second vector (result is return in y)
-   * 
+   *
    */
   void VectorHandlerCuda::axpy(const  real_type* alpha, vector::Vector* x, vector::Vector* y)
   {
@@ -122,13 +122,13 @@ namespace ReSolve {
                 1);
   }
 
-  /** 
+  /**
    * @brief gemv computes matrix-vector product where both matrix and vectors are dense.
    *        i.e., x = beta*x +  alpha*V*y
    *
    * @param[in] Transpose - yes (T) or no (N)
    * @param[in] n Number of rows in (non-transposed) matrix
-   * @param[in] k Number of columns in (non-transposed)   
+   * @param[in] k Number of columns in (non-transposed)
    * @param[in] alpha Constant real number
    * @param[in] beta Constant real number
    * @param[in] V Multivector containing the matrix, organized columnwise
@@ -136,8 +136,8 @@ namespace ReSolve {
    * @param[in,out] x Vector, n x 1 if N and k x 1 if T
    *
    * @pre   V is stored colum-wise, _n_ > 0, _k_ > 0
-   * 
-   */  
+   *
+   */
   void VectorHandlerCuda::gemv(char transpose,
                                index_type n,
                                index_type k,
@@ -183,9 +183,9 @@ namespace ReSolve {
     }
   }
 
-  /** 
+  /**
    * @brief mass (bulk) axpy i.e, y = y - x*alpha where  alpha is a vector
-   * 
+   *
    * @param[in] size number of elements in y
    * @param[in] alpha vector size k x 1
    * @param[in] x (multi)vector size size x k
@@ -207,22 +207,22 @@ namespace ReSolve {
                   size,       // m
                   1,          // n
                   k,      // k
-                  &MINUSONE, // alpha
+                  &MINUS_ONE, // alpha
                   x->getData(memory::DEVICE), // A
                   size,       // lda
                   alpha->getData(memory::DEVICE), // B
                   k,      // ldb
                   &ONE,
                   y->getData(memory::DEVICE),          // c
-                  size);      // ldc     
+                  size);      // ldc
     }
   }
 
-  /** 
+  /**
    * @brief mass (bulk) dot product i.e,  V^T x, where V is n x k dense multivector
    * (a dense multivector consisting of k vectors size n) and x is k x 2 dense
    * multivector (a multivector consisiting of two vectors size n each)
-   * 
+   *
    * @param[in] size Number of elements in a single vector in V
    * @param[in] V Multivector; k vectors size n x 1 each
    * @param[in] k Number of vectors in V
@@ -253,7 +253,7 @@ namespace ReSolve {
                   size,    //ldb
                   &ZERO,
                   res->getData(memory::DEVICE),     //c
-                  k);  //ldc 
+                  k);  //ldc
     }
   }
 

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -10,37 +10,37 @@
 namespace ReSolve {
   using out = io::Logger;
 
-  /** 
-   * @brief empty constructor that does absolutely nothing        
+  /**
+   * @brief empty constructor that does absolutely nothing
    */
   VectorHandlerHip::VectorHandlerHip()
   {
   }
 
-  /** 
+  /**
    * @brief constructor
-   * 
-   * @param new_workspace - workspace to be set     
+   *
+   * @param new_workspace - workspace to be set
    */
   VectorHandlerHip:: VectorHandlerHip(LinAlgWorkspaceHIP* new_workspace)
   {
     workspace_ = new_workspace;
   }
 
-  /** 
-   * @brief destructor     
+  /**
+   * @brief destructor
    */
   VectorHandlerHip::~VectorHandlerHip()
   {
     //delete the workspace TODO
   }
 
-  /** 
+  /**
    * @brief dot product of two vectors i.e, a = x^Ty
-   * 
+   *
    * @param[in] x The first vector
    * @param[in] y The second vector
-   * 
+   *
    * @return dot product (real number) of _x_ and _y_
    */
 
@@ -49,60 +49,60 @@ namespace ReSolve {
     rocblas_handle handle_rocblas = workspace_->getRocblasHandle();
     double nrm = 0.0;
     rocblas_status st= rocblas_ddot (handle_rocblas,  x->getSize(), x->getData(memory::DEVICE), 1, y->getData(memory::DEVICE), 1, &nrm);
-    
+
     if (st!=0) {printf("dot product crashed with code %d \n", st);}
     return nrm;
   }
 
-  /** 
+  /**
    * @brief scale a vector by a constant i.e, x = alpha*x where alpha is a constant
-   * 
+   *
    * @param[in] alpha The constant
    * @param[in,out] x The vector
-   * 
+   *
    */
   void VectorHandlerHip::scal(const real_type* alpha, vector::Vector* x)
   {
     rocblas_handle handle_rocblas =  workspace_->getRocblasHandle();
     rocblas_status st = rocblas_dscal(handle_rocblas, x->getSize(), alpha, x->getData(memory::DEVICE), 1);
-    
+
     if (st!=0) {
       ReSolve::io::Logger::error() << "scal crashed with code " << st << "\n";
     }
   }
 
-  /** 
+  /**
    * @brief compute infinity norm of a vector (i.e., find an entry with largest absolute value)
-   * 
+   *
    * @param[in] The vector
    *
    * @return infinity norm (real number) of _x_
-   * 
+   *
    */
   real_type VectorHandlerHip::infNorm(vector::Vector* x)
   {
 
-    if (workspace_->getNormBufferState() == false) { // not allocated  
+    if (workspace_->getNormBufferState() == false) { // not allocated
       real_type* buffer;
       mem_.allocateArrayOnDevice(&buffer, 1024);
       workspace_->setNormBuffer(buffer);
       workspace_->setNormBufferState(true);
     }
     real_type norm;
-    vector_inf_norm(x->getSize(),  
-                    x->getData(memory::DEVICE), 
+    vector_inf_norm(x->getSize(),
+                    x->getData(memory::DEVICE),
                     workspace_->getNormBuffer(),
                     &norm);
     return norm;
   }
 
-  /** 
+  /**
    * @brief axpy i.e, y = alpha*x + y where alpha is a constant
-   * 
+   *
    * @param[in] alpha The constant
    * @param[in] x The first vector
    * @param[in,out] y The second vector (result is return in y)
-   * 
+   *
    */
   void VectorHandlerHip::axpy(const  real_type* alpha, vector::Vector* x, vector::Vector* y)
   {
@@ -114,16 +114,16 @@ namespace ReSolve {
                   1,
                   y->getData(memory::DEVICE),
                   1);
-    
+
   }
 
-  /** 
+  /**
    * @brief gemv computes matrix-vector product where both matrix and vectors are dense.
    *        i.e., x = beta*x +  alpha*V*y
    *
    * @param[in] Transpose - yes (T) or no (N)
    * @param[in] n Number of rows in (non-transposed) matrix
-   * @param[in] k Number of columns in (non-transposed)   
+   * @param[in] k Number of columns in (non-transposed)
    * @param[in] alpha Constant real number
    * @param[in] beta Constant real number
    * @param[in] V Multivector containing the matrix, organized columnwise
@@ -131,8 +131,8 @@ namespace ReSolve {
    * @param[in,out] x Vector, n x 1 if N and k x 1 if T
    *
    * @pre   V is stored colum-wise, _n_ > 0, _k_ > 0
-   * 
-   */  
+   *
+   */
   void VectorHandlerHip::gemv(char transpose,
                               index_type n,
                               index_type k,
@@ -178,9 +178,9 @@ namespace ReSolve {
     }
   }
 
-  /** 
+  /**
    * @brief mass (bulk) axpy i.e, y = y - x*alpha where  alpha is a vector
-   * 
+   *
    * @param[in] size number of elements in y
    * @param[in] alpha vector size k x 1
    * @param[in] x (multi)vector size size x k
@@ -194,7 +194,7 @@ namespace ReSolve {
     using namespace constants;
     if (k < 200) {
       mass_axpy(size, k, x->getData(memory::DEVICE), y->getData(memory::DEVICE),alpha->getData(memory::DEVICE));
-    
+
     } else {
       rocblas_handle handle_rocblas =  workspace_->getRocblasHandle();
       rocblas_dgemm(handle_rocblas,
@@ -203,23 +203,23 @@ namespace ReSolve {
                     size,       // m
                     1,          // n
                     k,      // k
-                    &MINUSONE, // alpha
+                    &MINUS_ONE, // alpha
                     x->getData(memory::DEVICE), // A
                     size,       // lda
                     alpha->getData(memory::DEVICE), // B
                     k,      // ldb
                     &ONE,
                     y->getData(memory::DEVICE),          // c
-                    size);      // ldc     
-    
+                    size);      // ldc
+
     }
   }
 
-  /** 
+  /**
    * @brief mass (bulk) dot product i.e,  V^T x, where V is n x k dense multivector
    * (a dense multivector consisting of k vectors size n) and x is k x 2 dense
    * multivector (a multivector consisiting of two vectors size n each)
-   * 
+   *
    * @param[in] size Number of elements in a single vector in V
    * @param[in] V Multivector; k vectors size n x 1 each
    * @param[in] k Number of vectors in V
@@ -250,8 +250,8 @@ namespace ReSolve {
                     size,    //ldb
                     &ZERO,
                     res->getData(memory::DEVICE),     //c
-                    k);  //ldc 
-    
+                    k);  //ldc
+
     }
   }
 

--- a/tests/functionality/TestHelper.hpp
+++ b/tests/functionality/TestHelper.hpp
@@ -7,7 +7,7 @@
 
 /**
  * @brief Checks the error code and prints pass/fail message.
- * 
+ *
  * @param error_sum - error code: 0 = pass, otherwise fail
  * @param test_name - test name to be displayed with pass/fail message
  */
@@ -27,26 +27,26 @@ void isTestPass(int error_sum, const std::string& test_name)
 
 /**
  * @brief Test helper class template
- * 
+ *
  * This is header-only implementation of several utility functions used by
  * multiple functionality tests, such as error norm calculations. To use,
  * simply include this header in the test.
- * 
- * @tparam workspace_type 
+ *
+ * @tparam workspace_type
  */
 template <class workspace_type>
 class TestHelper
-{    
+{
   public:
     /**
      * @brief Default constructor
-     * 
+     *
      * Initializes matrix and vector handlers.
-     * 
+     *
      * @param[in,out] workspace - workspace for matrix and vector handlers
-     * 
+     *
      * @pre Workspace handles are initialized
-     * 
+     *
      * @post Handlers are instantiated.
      * allocated
      */
@@ -61,16 +61,16 @@ class TestHelper
 
     /**
      * @brief TestHelper constructor
-     * 
+     *
      * @param A[in] - Linear system matrix
      * @param r[in] - Linear system right-hand side
      * @param x[in] - Computed solution of the linear system
      * @param[in,out] workspace - workspace for matrix and vector handlers
-     * 
+     *
      * @pre The linear solver has solved system A * x = r.
      * @pre A, r, and x are all in the same memory space as the workspace.
      * @pre Workspace handles are initialized
-     * 
+     *
      * @post Handlers are instantiated and vectors res_ and x_true_ are
      * allocated
      * @post Solution vector x_true_ elements are all set to 1.
@@ -99,9 +99,9 @@ class TestHelper
 
     /**
      * @brief Destroy the TestHelper object
-     * 
+     *
      * @post Vectors res_ and x_true_ are deleted.
-     * 
+     *
      */
     ~TestHelper()
     {
@@ -118,9 +118,9 @@ class TestHelper
     /**
      * @brief Set the new linear system together with its computed solution
      * and compute solution error and residual norms.
-     * 
+     *
      * This will set the new system A*x = r and compute related error norms.
-     * 
+     *
      * @param A[in] - Linear system matrix
      * @param r[in] - Linear system right-hand side
      * @param x[in] - Computed solution of the linear system
@@ -142,11 +142,11 @@ class TestHelper
     /**
      * @brief Set the new linear system together with its computed solution
      * and compute solution error and residual norms.
-     * 
+     *
      * This is to be used after values in A and r are updated.
-     * 
+     *
      * @todo This method probably does not need any input parameters.
-     * 
+     *
      * @param A[in] - Linear system matrix
      * @param r[in] - Linear system right-hand side
      * @param x[in] - Computed solution of the linear system
@@ -266,39 +266,39 @@ class TestHelper
 
     /**
      * @brief Verify the computation of the norm of scaled residuals.
-     * 
-     * The norm value is provided as the input. This function computes 
+     *
+     * The norm value is provided as the input. This function computes
      * the norm of scaled residuals for the system that has been set
      * by the constructor or (re)setSystem functions.
-     * 
-     * @param nsr_system - norm of scaled residuals value to be verified 
+     *
+     * @param nsr_system - norm of scaled residuals value to be verified
      * @return int - 0 if the result is correct, error code otherwise
      */
     int checkNormOfScaledResiduals(ReSolve::real_type nsr_system)
     {
       using namespace ReSolve;
       int error_sum = 0;
-      
+
       // Compute residual norm to get updated vector res_
       res_->copyDataFrom(r_, memspace_, memspace_);
       norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
       // Compute norm of scaled residuals
       real_type inf_norm_A = 0.0;
-      mh_.matrixInfNorm(A_, &inf_norm_A, memspace_); 
+      mh_.matrixInfNorm(A_, &inf_norm_A, memspace_);
       real_type inf_norm_x = vh_.infNorm(x_, memspace_);
       real_type inf_norm_res = vh_.infNorm(res_, memspace_);
       real_type nsr_norm   = inf_norm_res / (inf_norm_A * inf_norm_x);
       real_type error      = std::abs(nsr_system - nsr_norm)/nsr_norm;
 
       // Test norm of scaled residuals method in SystemSolver
-      if (error > 10.0*std::numeric_limits<real_type>::epsilon()) 
+      if (error > 10.0*std::numeric_limits<real_type>::epsilon())
       {
         std::cout << "Norm of scaled residuals computation failed:\n";
         std::cout << std::scientific << std::setprecision(16)
                   << "\tMatrix inf  norm                 : " << inf_norm_A << "\n"
-                  << "\tResidual inf norm                : " << inf_norm_res << "\n"  
-                  << "\tSolution inf norm                : " << inf_norm_x << "\n"  
+                  << "\tResidual inf norm                : " << inf_norm_res << "\n"
+                  << "\tSolution inf norm                : " << inf_norm_x << "\n"
                   << "\tNorm of scaled residuals         : " << nsr_norm   << "\n"
                   << "\tNorm of scaled residuals (system): " << nsr_system << "\n\n";
       }
@@ -307,19 +307,19 @@ class TestHelper
 
     /**
      * @brief Verify the computation of the relative residual norm.
-     * 
-     * The norm value is provided as the input. This function computes 
+     *
+     * The norm value is provided as the input. This function computes
      * the relative residual norm for the system that has been set
      * by the constructor or (re)setSystem functions.
-     * 
-     * @param rrn_system - relative residual norm value to be verified 
+     *
+     * @param rrn_system - relative residual norm value to be verified
      * @return int - 0 if the result is correct, error code otherwise
      */
     int checkRelativeResidualNorm(ReSolve::real_type rrn_system)
     {
       using namespace ReSolve;
       int error_sum = 0;
-      
+
       // Compute residual norm
       res_->copyDataFrom(r_, memspace_, memspace_);
       norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
@@ -337,19 +337,19 @@ class TestHelper
 
     /**
      * @brief Verify the computation of the residual norm.
-     * 
-     * The norm value is provided as the input. This function computes 
+     *
+     * The norm value is provided as the input. This function computes
      * the residual norm for the system that has been set by the constructor
      * or (re)setSystem functions.
-     * 
-     * @param rrn_system - residual norm value to be verified 
+     *
+     * @param rrn_system - residual norm value to be verified
      * @return int - 0 if the result is correct, error code otherwise
      */
     int checkResidualNorm(ReSolve::real_type rn_system)
     {
       using namespace ReSolve;
       int error_sum = 0;
-      
+
       // Compute residual norm
       res_->copyDataFrom(r_, memspace_, memspace_);
       norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
@@ -396,7 +396,7 @@ class TestHelper
       norm_diff_ = computeDiffNorm(*x_true_, *res_, memspace_);
     }
 
-    /// Sets all elements of the solution vector to 1. 
+    /// Sets all elements of the solution vector to 1.
     void setSolutionVector()
     {
       x_true_->allocate(memspace_);
@@ -409,13 +409,13 @@ class TestHelper
 
     /**
      * @brief Computes residual norm = || A * x - r ||_2
-     * 
-     * @param[in]     A - system matrix 
+     *
+     * @param[in]     A - system matrix
      * @param[in]     x - computed solution of the system
      * @param[in,out] r - system right-hand side, residual vector
      * @param[in]     memspace memory space where to computate the norm
-     * @return ReSolve::real_type 
-     * 
+     * @return ReSolve::real_type
+     *
      * @post r is overwritten with residual values
      */
     ReSolve::real_type computeResidualNorm(ReSolve::matrix::Sparse& A,
@@ -424,18 +424,18 @@ class TestHelper
                                            ReSolve::memory::MemorySpace memspace)
     {
       using namespace ReSolve::constants;
-      mh_.matvec(&A, &x, &r, &ONE, &MINUSONE, memspace); // r := A * x - r
+      mh_.matvec(&A, &x, &r, &ONE, &MINUS_ONE, memspace); // r := A * x - r
       return norm2(r, memspace);
     }
 
     /**
      * @brief Compute vector difference norm = || x - x_true ||_2
-     * 
+     *
      * @param[in]     x_true - The "exact" solution
      * @param[in,out] x      - Computed solution, difference vector
      * @param[in]     memspace memory space where to computate the norm
      * @return ReSolve::real_type
-     * 
+     *
      * @post x is overwritten with difference value
      */
     ReSolve::real_type computeDiffNorm(ReSolve::vector::Vector& x_true,
@@ -443,7 +443,7 @@ class TestHelper
                                        ReSolve::memory::MemorySpace memspace)
     {
       using namespace ReSolve::constants;
-      vh_.axpy(&MINUSONE, &x_true, &x, memspace); // x := -x_true + x
+      vh_.axpy(&MINUS_ONE, &x_true, &x, memspace); // x := -x_true + x
       return norm2(x, memspace);
     }
 

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -3,7 +3,7 @@
  * @author Slaven Peles (peless@ornl.gov)
  * @author Kaleb Brunhoeber
  * @brief Functionality test for LUSOL direct solver
- * 
+ *
  */
 #include <algorithm>
 #include <cmath>
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
                                      &vec_x,
                                      &vec_r,
                                      &ONE,
-                                     &MINUSONE,
+                                     &MINUS_ONE,
                                      ReSolve::memory::HOST);
 
   // Compute vector norms
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
   real_type normB = sqrt(vector_handler.dot(&vec_rhs, &vec_rhs, ReSolve::memory::HOST));
 
   // Compute vec_diff := vec_diff - vec_x
-  vector_handler.axpy(&MINUSONE, &vec_x, &vec_diff, ReSolve::memory::HOST);
+  vector_handler.axpy(&MINUS_ONE, &vec_x, &vec_diff, ReSolve::memory::HOST);
   // Compute norm of vec_diff
   real_type normDiffMatrix = sqrt(vector_handler.dot(&vec_diff, &vec_diff, ReSolve::memory::HOST));
 
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
                                      &vec_test,
                                      &vec_r,
                                      &ONE,
-                                     &MINUSONE,
+                                     &MINUS_ONE,
                                      ReSolve::memory::HOST);
   real_type exactSol_normRmatrix = sqrt(vector_handler.dot(&vec_r, &vec_r, ReSolve::memory::HOST));
 
@@ -218,7 +218,7 @@ int main(int argc, char* argv[])
                                      &vec_x,
                                      &vec_r,
                                      &ONE,
-                                     &MINUSONE,
+                                     &MINUS_ONE,
                                      ReSolve::memory::HOST);
 
   // Compute vector norms
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
   normB = sqrt(vector_handler.dot(&vec_rhs, &vec_rhs, ReSolve::memory::HOST));
 
   // Compute vec_diff := vec_diff - vec_x
-  vector_handler.axpy(&MINUSONE, &vec_x, &vec_diff, ReSolve::memory::HOST);
+  vector_handler.axpy(&MINUS_ONE, &vec_x, &vec_diff, ReSolve::memory::HOST);
   // Compute norm of vec_diff
   normDiffMatrix = sqrt(vector_handler.dot(&vec_diff, &vec_diff, ReSolve::memory::HOST));
 
@@ -238,9 +238,9 @@ int main(int argc, char* argv[])
                                      &vec_test,
                                      &vec_r,
                                      &ONE,
-                                     &MINUSONE,
+                                     &MINUS_ONE,
                                      ReSolve::memory::HOST);
-  // Compute residual error norm                                     
+  // Compute residual error norm
   exactSol_normRmatrix = sqrt(vector_handler.dot(&vec_r, &vec_r, ReSolve::memory::HOST));
 
   std::cout << "Results: \n";
@@ -274,13 +274,13 @@ int main(int argc, char* argv[])
 }
 
 /**
- * @brief 
- * 
+ * @brief
+ *
  * @param A_coo - Input COO matrix without duplicates sorted in row-major order
  * @param A_csr - Output CSR matrix
  * @param memspace - memory space in the output matrix where the data is copied
  * @return int
- * 
+ *
  * @pre A_coo and A_csr matrices must be of the same size and type.
  */
 int coo2csr(ReSolve::matrix::Coo* A_coo, ReSolve::matrix::Csr* A_csr, ReSolve::memory::MemorySpace memspace)
@@ -317,7 +317,7 @@ int coo2csr(ReSolve::matrix::Coo* A_coo, ReSolve::matrix::Csr* A_csr, ReSolve::m
   A_csr->copyDataFrom(row_csr, cols_coo, vals_coo, ReSolve::memory::HOST, memspace);
 
   delete [] row_csr;
-  
+
   return 0;
 }
 

--- a/tests/functionality/testSysGLU.cpp
+++ b/tests/functionality/testSysGLU.cpp
@@ -4,8 +4,8 @@
  * @author Slaven Peles (peless@ornl.gov)
  * @brief Functionality test for SystemSolver class
  * @date 2023-12-14
- * 
- * 
+ *
+ *
  */
 #include <string>
 #include <iostream>
@@ -103,20 +103,20 @@ int main(int argc, char *argv[])
   // but DO NOT SOLVE with KLU!
   status = solver.refactorizationSetup();
   error_sum += status;
-  std::cout << "GLU setup status: " << status << std::endl;      
+  std::cout << "GLU setup status: " << status << std::endl;
 
   // Move rhs vector data to GPU
   vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = solver.solve(vec_rhs, vec_x);
   error_sum += status;
-  std::cout << "GLU solve status: " << status << std::endl;      
+  std::cout << "GLU solve status: " << status << std::endl;
 
   // Compute residual on device
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
-  
+
   // Compute residual norm
   real_type normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
@@ -127,8 +127,8 @@ int main(int argc, char *argv[])
   real_type normB1 = sqrt(vector_handler.dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
 
   // Compute norm of scaled residuals
-  real_type inf_norm_A = 0.0;  
-  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE); 
+  real_type inf_norm_A = 0.0;
+  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE);
   real_type inf_norm_x = vector_handler.infNorm(vec_x, ReSolve::memory::DEVICE);
   real_type inf_norm_r = vector_handler.infNorm(vec_r, ReSolve::memory::DEVICE);
   real_type nsr_norm   = inf_norm_r / (inf_norm_A * inf_norm_x);
@@ -139,8 +139,8 @@ int main(int argc, char *argv[])
     std::cout << "Norm of scaled residuals computation failed:\n";
     std::cout << std::scientific << std::setprecision(16)
               << "\tMatrix inf  norm                 : " << inf_norm_A << "\n"
-              << "\tResidual inf norm                : " << inf_norm_r << "\n"  
-              << "\tSolution inf norm                : " << inf_norm_x << "\n"  
+              << "\tResidual inf norm                : " << inf_norm_r << "\n"
+              << "\tSolution inf norm                : " << inf_norm_x << "\n"
               << "\tNorm of scaled residuals         : " << nsr_norm   << "\n"
               << "\tNorm of scaled residuals (system): " << nsr_system << "\n\n";
     error_sum++;
@@ -160,19 +160,19 @@ int main(int argc, char *argv[])
 
   //compute ||x_diff|| = ||x - x_true|| norm
   vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
+  vector_handler.axpy(&MINUS_ONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix1 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
- 
+
   // Compute residual norm ON THE GPU using REFERENCE solution
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   // Compute residual norm ON THE CPU using COMPUTED solution
   vec_x->copyDataFrom(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::HOST);
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::HOST);
   error_sum += status;
   real_type normRmatrix1CPU = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::HOST));
 
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
   }
- 
+
   std::cout << "Results (first matrix): \n\n" << std::scientific << std::setprecision(16);
   std::cout << "\t ||b-A*x||_2                 : " << normRmatrix1              << " (residual norm)\n";
   std::cout << "\t ||b-A*x||_2  (CPU)          : " << normRmatrix1CPU           << " (residual norm)\n";
@@ -222,7 +222,7 @@ int main(int argc, char *argv[])
   // Refactorize and solve
   status = solver.refactorize();
   error_sum += status;
-  std::cout << "CUSOLVER GLU refactorization status: " << status << std::endl;      
+  std::cout << "CUSOLVER GLU refactorization status: " << status << std::endl;
 
   status = solver.solve(vec_rhs, vec_x);
   error_sum += status;
@@ -230,16 +230,16 @@ int main(int argc, char *argv[])
   // Compute residual norm for the second system
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
-  
+
   // Compute norm of the rhs vector for the second system
   real_type normB2 = sqrt(vector_handler.dot(vec_rhs, vec_rhs, ReSolve::memory::DEVICE));
 
   // Compute norm of scaled residuals for the second system
-  inf_norm_A = 0.0;  
-  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE); 
+  inf_norm_A = 0.0;
+  matrix_handler.matrixInfNorm(A, &inf_norm_A, ReSolve::memory::DEVICE);
   inf_norm_x = vector_handler.infNorm(vec_x, ReSolve::memory::DEVICE);
   inf_norm_r = vector_handler.infNorm(vec_r, ReSolve::memory::DEVICE);
   nsr_norm   = inf_norm_r / (inf_norm_A * inf_norm_x);
@@ -250,8 +250,8 @@ int main(int argc, char *argv[])
     std::cout << "Norm of scaled residuals computation failed:\n";
     std::cout << std::scientific << std::setprecision(16)
               << "\tMatrix inf  norm                 : " << inf_norm_A << "\n"
-              << "\tResidual inf norm                : " << inf_norm_r << "\n"  
-              << "\tSolution inf norm                : " << inf_norm_x << "\n"  
+              << "\tResidual inf norm                : " << inf_norm_r << "\n"
+              << "\tSolution inf norm                : " << inf_norm_x << "\n"
               << "\tNorm of scaled residuals         : " << nsr_norm   << "\n"
               << "\tNorm of scaled residuals (system): " << nsr_system << "\n\n";
     error_sum++;
@@ -259,15 +259,15 @@ int main(int argc, char *argv[])
 
   //compute ||x_diff|| = ||x - x_true|| norm
   vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  vector_handler.axpy(&MINUSONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
+  vector_handler.axpy(&MINUS_ONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix2 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
- 
+
   //compute the residual using exact solution
   vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUSONE, ReSolve::memory::DEVICE); 
+  status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
-  
+
   // Verify relative residual norm computation in SystemSolver
   rel_residual_norm = solver.getResidualNorm(vec_rhs, vec_x);
   error = std::abs(normB2 * rel_residual_norm - normRmatrix2)/normRmatrix2;
@@ -278,7 +278,7 @@ int main(int argc, char *argv[])
               << "\tSystemSolver computed : " << rel_residual_norm   << "\n\n";
     error_sum++;
   }
- 
+
   std::cout << "Results (second matrix): " << std::endl << std::endl;
   std::cout << std::scientific << std::setprecision(16);
   std::cout << "\t ||b-A*x||_2                 : " << normRmatrix2              << " (residual norm)\n";


### PR DESCRIPTION
## Description
 
 There is an indeterministic segfault occurring in Re::Solve tests after #260 has been merged.   

 ## Proposed changes
 
Revert #260 until the issue is identified and fixed. Reopen PR when ready.
 
 ## Checklist
  
- [ ] All tests pass. Code tested on
     - [ ] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc._

