### PR TITLE
Simplify LinSolverIterativeRandFGMRES

### DIFF
--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -120,6 +120,16 @@ namespace ReSolve
     return 0;
   }
 
+  /**
+   * @brief Solve linear system A * x = rhs
+   * 
+   * @param rhs - right hand side vector
+   * @param x   - solution vector
+   * @return int - zero if successful, error code otherwise
+   * 
+   * @invariant rhs vector is unchanged.
+   * @post x is overwritten with the solution to the linear system.
+   */
   int  LinSolverIterativeRandFGMRES::solve(vector_type* rhs, vector_type* x)
   {
     using namespace constants;
@@ -137,7 +147,6 @@ namespace ReSolve
     real_type t;
     real_type rnorm;
     real_type bnorm;
-    // real_type rnorm_aux;
     real_type tolrel;
     vector_type* vec_v = new vector_type(n_);
     vector_type* vec_z = new vector_type(n_);
@@ -206,6 +215,7 @@ namespace ReSolve
       vector_handler_->scal(&t, vec_S_, memspace_);
 
       mem_.deviceSynchronize();
+
       // initialize norm history
       h_rs_[0] = rnorm;
       i = -1;
@@ -240,7 +250,9 @@ namespace ReSolve
         }
         mem_.deviceSynchronize();
         GS_->orthogonalize(k_rand_, vec_S_, h_H_, i);
+
         // now post-process
+        vec_aux_->setCurrentSize(i + 1);
         vec_aux_->copyDataFrom(&h_H_[i * (restart_ + 1)], memory::HOST, memspace_);
 
         // V(:, i+1) = w - V(:, 1:i)*d_H_col = V(:, i+1) - d_H_col*V(:,1:i);
@@ -326,7 +338,6 @@ namespace ReSolve
 
       /* test solution */
       if(rnorm <= tolrel || it >= maxit_) {
-        // rnorm_aux = rnorm;
         outer_flag = 0;
       }
 

--- a/resolve/LinSolverIterativeRandFGMRES.hpp
+++ b/resolve/LinSolverIterativeRandFGMRES.hpp
@@ -108,7 +108,7 @@ namespace ReSolve
       real_type* h_c_{nullptr};
       real_type* h_s_{nullptr};
       real_type* h_rs_{nullptr};
-      real_type* d_aux_{nullptr};
+      vector_type* vec_aux_{nullptr};
 
       GramSchmidt* GS_{nullptr};
       LinSolverDirect* LU_solver_{nullptr};


### PR DESCRIPTION
## Description

Class  `LinSolverIterativeRandFGMRES` uses local variable `vec_z` for two different purposes -- as a vector view for a select vector in multivector `vec_Z_` and as a vector view for an auxiliary data array `d_aux_`. The two different uses of `vec_z` make the code difficult to read. In such implementation, a couple of calls to `setData` and `setCurrentSize` are required. These methods (as implemented now) are error prone and should be avoided, if possible.

This was also mentioned in #274.

 ## Proposed changes
 
Instead of allocating member data array `d_aux_` and then attaching a vector view `vec_z` to it, one can simply create and allocate a member vector `vec_aux_` and use it instead. This simplifies the code as it eliminates unnecessary `setData` call, removes one `setCurrentSize`call, and does not require any additional memory allocation.

 
 ## Checklist
 
- [X] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
When copying data from Hessenberg matrix to the auxiliary data array `d_aux_`, there are `i+2` elements copied while the vector view of the data array is configured with `i+1` elements. It seems only `i+1` elements are used later on in the computation. This PR does not address this discrepancy.

