### PR TITLE
Fix compiler warnings in matrix handlers

### DIFF
--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -35,19 +35,19 @@ namespace ReSolve {
       MatrixHandlerCpu(LinAlgWorkspaceCpu* workspace);
       virtual ~MatrixHandlerCpu();
 
-      int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
+      int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr) override;
 
       int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
-      int addConst(matrix::Sparse* A, real_type alpha);
+      int addConst(matrix::Sparse* A, real_type alpha) override;
 
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,
                  const real_type* alpha,
-                 const real_type* beta);
-      virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm);
-      void setValuesChanged(bool isValuesChanged);
+                 const real_type* beta) override;
+      virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm) override;
+      void setValuesChanged(bool isValuesChanged) override;
 
     private:
       LinAlgWorkspaceCpu* workspace_{nullptr};

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -34,16 +34,16 @@ namespace ReSolve {
       MatrixHandlerCuda(LinAlgWorkspaceCUDA* workspace);
       virtual ~MatrixHandlerCuda();
 
-      int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
-      int transpose(matrix::Csr* A, matrix::Csr* At);
-      int addConst(matrix::Sparse* A, real_type alpha);
+      int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr) override;
+      int transpose(matrix::Csr* A, matrix::Csr* At) override;
+      int addConst(matrix::Sparse* A, real_type alpha) override;
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,
                  const real_type* alpha,
-                 const real_type* beta);
-      virtual int matrixInfNorm(matrix::Sparse* A, real_type* norm);
-      void setValuesChanged(bool isValuesChanged);
+                 const real_type* beta) override;
+      virtual int matrixInfNorm(matrix::Sparse* A, real_type* norm) override;
+      void setValuesChanged(bool isValuesChanged) override;
 
     private:
       LinAlgWorkspaceCUDA* workspace_{nullptr};

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -256,7 +256,6 @@ namespace ReSolve {
     index_type n = A->getNumColumns();
     index_type nnz = A->getNnz();
     rocsparse_status status;
-    void* buffer_transpose = workspace_->getTransposeBufferWorkspace();
     bool allocated = workspace_->isTransposeBufferAllocated();
     if (!allocated) {
       // allocate transpose buffer

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -35,20 +35,20 @@ namespace ReSolve {
       MatrixHandlerHip(LinAlgWorkspaceHIP* workspace);
       virtual ~MatrixHandlerHip();
 
-      int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr);
+      int csc2csr(matrix::Csc* A_csc, matrix::Csr* A_csr) override;
 
-      int transpose(matrix::Csr* A, matrix::Csr* At);
+      int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
-      int addConst(matrix::Sparse* A, real_type alpha);
+      int addConst(matrix::Sparse* A, real_type alpha) override;
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,
                          vector_type* vec_result,
                          const real_type* alpha,
-                         const real_type* beta);
+                         const real_type* beta) override;
 
-      virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm);
+      virtual int matrixInfNorm(matrix::Sparse *A, real_type* norm) override;
 
-      void setValuesChanged(bool isValuesChanged);
+      void setValuesChanged(bool isValuesChanged) override;
 
     private:
 

--- a/tests/unit/TestBase.hpp
+++ b/tests/unit/TestBase.hpp
@@ -232,7 +232,7 @@ public:
   }
 protected:
   /// Returns true if two real numbers are equal within tolerance
-  [[nodiscard]] static
+  // [[nodiscard]] static <- uncomment when we swithc to C++17
   bool isEqual(const real_type a, const real_type b)
   {
     return (std::abs(a - b)/(1.0 + std::abs(b)) < eps);

--- a/tests/unit/TestBase.hpp
+++ b/tests/unit/TestBase.hpp
@@ -232,7 +232,7 @@ public:
   }
 protected:
   /// Returns true if two real numbers are equal within tolerance
-  // [[nodiscard]] static <- uncomment when we swithc to C++17
+  // [[nodiscard]] static <- uncomment when we switch to C++17
   bool isEqual(const real_type a, const real_type b)
   {
     return (std::abs(a - b)/(1.0 + std::abs(b)) < eps);


### PR DESCRIPTION
## Description
 
Fix warnings in matrix handlers, mainly not using `override` for methods in derived classes.
 

 ## Proposed changes
 
Straightforward fix.
 
 ## Checklist
 
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 

