### PR TITLE
Adjust resizing in vector::Vector class

### DIFF
--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -177,7 +177,7 @@ namespace ReSolve
 
         // copy H_col to aux, we will need it later
         vec_Hcolumn_->setDataUpdated(memspace_);
-        vec_Hcolumn_->setCurrentSize(i + 1);
+        vec_Hcolumn_->resize(i + 1);
         vec_Hcolumn_->copyDataTo(h_aux_, 0, memory::HOST);
         mem_.deviceSynchronize();
 
@@ -218,7 +218,7 @@ namespace ReSolve
         // V[1:i]^T[V[i] w]
         vec_v_->setData(V->getVectorData(i, memspace_), memspace_);
         vec_w_->setData(V->getVectorData(i + 1, memspace_), memspace_);
-        vec_rv_->setCurrentSize(i + 1);
+        vec_rv_->resize(i + 1);
 
         // vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
@@ -240,7 +240,7 @@ namespace ReSolve
           } // for k
           H[ idxmap(i, j, num_vecs_ + 1) ] -= s;
         }   // for j
-        vec_Hcolumn_->setCurrentSize(i + 1);
+        vec_Hcolumn_->resize(i + 1);
         vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
         vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V, vec_w_, memspace_);
 
@@ -267,7 +267,7 @@ namespace ReSolve
       case MGS_PM:
         vec_v_->setData(V->getVectorData(i, memspace_), memspace_);
         vec_w_->setData(V->getVectorData(i + 1, memspace_), memspace_);
-        vec_rv_->setCurrentSize(i + 1);
+        vec_rv_->resize(i + 1);
 
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vec_rv_->setDataUpdated(memspace_);
@@ -316,7 +316,7 @@ namespace ReSolve
           H[ idxmap(i, j, num_vecs_ + 1) ] -= h_aux_[j];
         }
 
-        vec_Hcolumn_->setCurrentSize(i + 1);
+        vec_Hcolumn_->resize(i + 1);
         vec_Hcolumn_->copyDataFrom(&H[ idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
 
         vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V,  vec_w_, memspace_);
@@ -345,7 +345,7 @@ namespace ReSolve
 
         // copy H_col to H
         vec_Hcolumn_->setDataUpdated(memspace_);
-        vec_Hcolumn_->setCurrentSize(i + 1);
+        vec_Hcolumn_->resize(i + 1);
         vec_Hcolumn_->copyDataTo(&H[ idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         mem_.deviceSynchronize();
 

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -252,7 +252,7 @@ namespace ReSolve
         GS_->orthogonalize(k_rand_, vec_S_, h_H_, i);
 
         // now post-process
-        vec_aux_->setCurrentSize(i + 1);
+        vec_aux_->resize(i + 1);
         vec_aux_->copyDataFrom(&h_H_[i * (restart_ + 1)], memory::HOST, memspace_);
 
         // V(:, i+1) = w - V(:, 1:i)*d_H_col = V(:, i+1) - d_H_col*V(:,1:i);

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -47,7 +47,7 @@ namespace ReSolve { namespace vector {
    * @brief Get capacity of a single vector.
    * 
    * Vector memory is allocated to `n_capacity_*k_`. This is the maximum
-   * size of elements that (multi)vector can hold.
+   * number of elements that the (multi)vector can hold.
    * 
    * @return `n_capacity_` maximum number of elements in the vector.
    */

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -482,6 +482,8 @@ namespace ReSolve { namespace vector {
    * Use for vectors and multivectors that change size throughout computation.
    * 
    * @note Vector needs to have capacity set to maximum expected size.
+   * @warning This method is not to be used in vectors who do not own their
+   * data.
    * 
    * @param[in] new_n_size - New vector length
    *
@@ -493,9 +495,7 @@ namespace ReSolve { namespace vector {
   {
     assert(owns_cpu_data_ && owns_gpu_data_ 
            && "Cannot resize if vector is not owning the data.");
-    // if (!owns_cpu_data_ || !owns_gpu_data_) {
-    //   out::error() << "Cannot resize if not owning the data.\n";
-    // }
+
     if (new_n_size > n_capacity_) {
       out::error() << "Trying to resize vector to " << new_n_size 
                    << " elements but memory allocated only for " << n_capacity_ << "\n";

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -498,7 +498,7 @@ namespace ReSolve { namespace vector {
 
     if (new_n_size > n_capacity_) {
       out::error() << "Trying to resize vector to " << new_n_size 
-                   << " elements but memory allocated only for " << n_capacity_ << "\n";
+                   << " elements but memory allocated only for " << n_capacity_ << elements. << "\n";
       return 1;
     } else {
       n_size_ = new_n_size;

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -49,7 +49,7 @@ namespace ReSolve { namespace vector {
    * Vector memory is allocated to `n_capacity_*k_`. This is the maximum
    * number of elements that the (multi)vector can hold.
    * 
-   * @return `n_capacity_` maximum number of elements in the vector.
+   * @return `n_capacity_` the maximum number of elements in the vector.
    */
   index_type Vector::getCapacity() const
   {

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -60,7 +60,7 @@ namespace ReSolve { namespace vector {
    * @brief get the number of elements in a single vector.
    * 
    * For vectors with changing sizes, set the vector capacity to
-   * maximum expected size.
+   * the maximum expected size.
    * 
    * @return `n_size_` number of elements currently in the vector.
    */

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -460,7 +460,7 @@ namespace ReSolve { namespace vector {
    * @param[in] i          - Index of a vector in a multivector
    * @param[in] memspace   - Memory space of the pointer (HOST or DEVICE)  
    *
-   * @return pointer to the `i`th vector data (HOST or DEVICE).
+   * @return A pointer to the `i`th vector data (HOST or DEVICE).
    *
    * @pre `i` < `k_`, i.e. `i` is smaller than the total number of vectors in multivector.
    * 

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -72,8 +72,8 @@ namespace ReSolve { namespace vector {
   /** 
    * @brief Get the number of vectors in multivector.
    * 
-   * @return _k_, number of vectors in multivector, or 1 if the vector is not
-   * a multivector.
+   * @return _k_, number of vectors in the multivector, 
+   * or 1 if the vector is not a multivector.
    */
   index_type Vector::getNumVectors() const
   {

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -19,8 +19,8 @@ namespace ReSolve { namespace vector {
     h_data_(nullptr),
     gpu_updated_(false),
     cpu_updated_(false),
-    owns_gpu_data_(false),
-    owns_cpu_data_(false)
+    owns_gpu_data_(true),
+    owns_cpu_data_(true)
   {
   }
 
@@ -38,8 +38,8 @@ namespace ReSolve { namespace vector {
       h_data_(nullptr),
       gpu_updated_(false),
       cpu_updated_(false),
-      owns_gpu_data_(false),
-      owns_cpu_data_(false)
+      owns_gpu_data_(true),
+      owns_cpu_data_(true)
   {
   }
 
@@ -494,8 +494,15 @@ namespace ReSolve { namespace vector {
    */
   int Vector::setCurrentSize(index_type new_n_current)
   {
+    assert(owns_cpu_data_ && owns_gpu_data_ 
+           && "Cannot resize if not owning the data.");
+    if (!owns_cpu_data_ || !owns_gpu_data_) {
+      out::error() << "Cannot resize if not owning the data.\n";
+    }
     if (new_n_current > n_) {
-      return -1;
+      out::error() << "Trying to resize vector to " << new_n_current 
+                   << " elements but memory allocated only for " << n_ << "\n";
+      return 1;
     } else {
       n_current_ = new_n_current;
       return 0;

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -35,9 +35,9 @@ namespace ReSolve { namespace vector {
       real_type* getData(memory::MemorySpace memspace);
       real_type* getData(index_type i, memory::MemorySpace memspace); // get pointer to i-th vector in multivector
 
+      index_type getCapacity() const;
       index_type getSize() const;
-      index_type getCurrentSize();
-      index_type getNumVectors();
+      index_type getNumVectors() const;
 
       void setDataUpdated(memory::MemorySpace memspace);
       int setData(real_type* data, memory::MemorySpace memspace);
@@ -47,22 +47,22 @@ namespace ReSolve { namespace vector {
       void setToConst(real_type C, memory::MemorySpace memspace);
       void setToConst(index_type i, real_type C, memory::MemorySpace memspace); // set i-th vector to C  - needed for unit tests, Gram Schmidt tests
       int syncData(memory::MemorySpace memspaceOut); 
-      int setCurrentSize(index_type new_n_current);
+      int resize(index_type new_n_current);
       real_type* getVectorData(index_type i, memory::MemorySpace memspace); // get ith vector data out of multivector   
       int copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspace);  
       int copyDataTo(real_type* dest, memory::MemorySpace memspace);  //copy FULL multivector 
     
     private:
-      index_type n_{0}; ///< size
+      index_type n_capacity_{0}; ///< vector capacity
       index_type k_{0}; ///< k_ = 1 for vectors and k_>1 for multivectors (multivectors are accessed column-wise). 
-      index_type n_current_; ///< if vectors dynamically changes size, "current n_" keeps track of this. Needed for some solver implementations. 
+      index_type n_size_; ///< actual size of the vector
       real_type* d_data_{nullptr}; ///< DEVICE data array
       real_type* h_data_{nullptr}; ///< HOST data array
       bool gpu_updated_; ///< DEVICE data flag (updated or not)
       bool cpu_updated_; ///< HOST data flag (updated or not)
 
-      bool owns_gpu_data_{false}; ///< data owneship flag for DEVICE data
-      bool owns_cpu_data_{false}; ///< data ownership flag for HOST data
+      bool owns_gpu_data_{true}; ///< data owneship flag for DEVICE data
+      bool owns_cpu_data_{true}; ///< data ownership flag for HOST data
 
       MemoryHandler mem_; ///< Device memory manager object
   };

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -58,8 +58,8 @@ namespace ReSolve { namespace vector {
       index_type n_size_; ///< actual size of the vector
       real_type* d_data_{nullptr}; ///< DEVICE data array
       real_type* h_data_{nullptr}; ///< HOST data array
-      bool gpu_updated_; ///< DEVICE data flag (updated or not)
-      bool cpu_updated_; ///< HOST data flag (updated or not)
+      bool gpu_updated_{false}; ///< DEVICE data flag (updated or not)
+      bool cpu_updated_{false}; ///< HOST data flag (updated or not)
 
       bool owns_gpu_data_{true}; ///< data owneship flag for DEVICE data
       bool owns_cpu_data_{true}; ///< data ownership flag for HOST data


### PR DESCRIPTION
## Description
 
This PR addresses several minor issues in `vector::Vector` class:
- Changes ambiguous member variable and function names.
- `getSize()` now returns vector length rather than the size of allocated memory (vector capacity)
- Default values to data ownership flags are set to `true` now.
- Resizing of vectors who do not own data (i.e. vector views of external data) is not allowed anymore.
- `getData` does not set the data ownership.

Closes #274
 

 ## Proposed changes
 
### Renamed:

Old        |    New
--------|---------
`setCurrentSize`       |  `resize`
`n_`                            | `n_capacity_`
`n_current_`             |  `n_size_`
`getSize`                   | `getCapacity`
`getCurrentSize`    | `getSize`

### Changed defaults:

Member boolean variables `owns_gpu_data_` and `owns_cpu_data_` have default values `true`. They are set to `false` only when `setData` method is invoked. Therefore `false` values of these flags indicate that the vector object is used as a "view" of data external to the vector.

Resizing of vectors who do not own their data is not allowed anymore. The owner of the data should be the only one responsible for resizing it.

### Data ownership

Public method `getData(MemorySpace m)` has the ability to bring the data to the memory space requested (host or device). It now relies on `syncData` method to copy data to the requested memory space and set correct data ownership flags, if needed.


 
 ## Checklist
  
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 
