### PR TITLE
Track updated status for each vector in multivector (second attempt)

### DIFF
--- a/resolve/MemoryUtils.hpp
+++ b/resolve/MemoryUtils.hpp
@@ -64,10 +64,26 @@ namespace ReSolve
       ///
 
       template <typename I, typename T>
+      int allocateArrayOnHost(T** v, I n)
+      {
+        std::size_t arraysize = static_cast<std::size_t>(n) * sizeof(T);
+        *v = new T[arraysize];
+        return *v == nullptr ? 1 : 0;
+      }
+
+      template <typename I, typename T>
       int copyArrayHostToHost(T* dst, const T* src, I n)
       {
         std::size_t arraysize = static_cast<std::size_t>(n) * sizeof(T);
         memcpy(dst, src, arraysize);
+        return 0;
+      }
+
+      template <typename T>
+      int deleteOnHost(T* v)
+      {
+        delete [] v;
+        v = nullptr;
         return 0;
       }
 

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -229,14 +229,33 @@ namespace ReSolve { namespace vector {
    * 
    * @param[in] memspace  - Memory space of the pointer (HOST or DEVICE)  
    *
-   * @return pointer to the vector data (HOST or DEVICE). In case of multivectors, vectors are stored column-wise.
+   * @return pointer to the vector data (HOST or DEVICE). If this is
+   * a multivector, individual vectors are stored column-wise.
    * 
-   * @note This function gives you access to the pointer, not to a copy.
-   * If you change the values using the pointer, the vector values will change too. 
+   * @note This function returns non-constant pointer to the vector data,
+   * not a copy of the vector data. If you change the values accessed through
+   * this pointer, you change the vector data.
    */
   real_type* Vector::getData(memory::MemorySpace memspace)
   {
-    return this->getData(0, memspace);
+    if ((memspace == memory::HOST) && (cpu_updated_[0] == false) && (gpu_updated_[0] == true )) {
+      syncData(memspace);  
+    } 
+
+    if ((memspace == memory::DEVICE) && (gpu_updated_[0] == false) && (cpu_updated_[0] == true )) {
+      syncData(memspace);
+    }
+
+    switch (memspace) {
+      case memory::HOST:
+        return &h_data_[0];
+        break;
+      case memory::DEVICE:
+        return &d_data_[0];
+        break;
+      default:
+        return nullptr;
+    }
   }
 
   /** 

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -58,8 +58,8 @@ namespace ReSolve { namespace vector {
       index_type n_current_; ///< if vectors dynamically changes size, "current n_" keeps track of this. Needed for some solver implementations. 
       real_type* d_data_{nullptr}; ///< DEVICE data array
       real_type* h_data_{nullptr}; ///< HOST data array
-      bool gpu_updated_; ///< DEVICE data flag (updated or not)
-      bool cpu_updated_; ///< HOST data flag (updated or not)
+      bool* gpu_updated_{nullptr}; ///< DEVICE data flags (updated or not)
+      bool* cpu_updated_{nullptr}; ///< HOST data flags (updated or not)
 
       bool owns_gpu_data_{false}; ///< data owneship flag for DEVICE data
       bool owns_cpu_data_{false}; ///< data ownership flag for HOST data

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -47,6 +47,7 @@ namespace ReSolve { namespace vector {
       void setToConst(real_type C, memory::MemorySpace memspace);
       void setToConst(index_type i, real_type C, memory::MemorySpace memspace); // set i-th vector to C  - needed for unit tests, Gram Schmidt tests
       int syncData(memory::MemorySpace memspaceOut); 
+      int syncData(index_type i, memory::MemorySpace memspaceOut); 
       int setCurrentSize(index_type new_n_current);
       real_type* getVectorData(index_type i, memory::MemorySpace memspace); // get ith vector data out of multivector   
       int copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspace);  

--- a/tests/unit/TestBase.hpp
+++ b/tests/unit/TestBase.hpp
@@ -232,8 +232,8 @@ public:
   }
 protected:
   /// Returns true if two real numbers are equal within tolerance
-  [[nodiscard]] static
-  bool isEqual(const real_type a, const real_type b)
+  [[nodiscard]] 
+  static bool isEqual(const real_type a, const real_type b)
   {
     return (std::abs(a - b)/(1.0 + std::abs(b)) < eps);
   }

--- a/tests/unit/TestBase.hpp
+++ b/tests/unit/TestBase.hpp
@@ -218,28 +218,15 @@ static const real_type eps = 10*std::numeric_limits<real_type>::epsilon();
 class TestBase
 {
 public:
-  TestBase()
-    : mem_space_("DEFAULT")
-  {
-  }
-  inline void set_mem_space(const std::string& mem_space)
-  {
-    mem_space_ = mem_space;
-  }
-  inline std::string get_mem_space() const
-  {
-    return mem_space_;
-  }
+  TestBase() = default;
+
 protected:
   /// Returns true if two real numbers are equal within tolerance
-  [[nodiscard]] 
+  //[[nodiscard]] 
   static bool isEqual(const real_type a, const real_type b)
   {
     return (std::abs(a - b)/(1.0 + std::abs(b)) < eps);
   }
-  
-protected:
-  std::string mem_space_;
 };
 
 }} // namespace ReSolve::tests

--- a/tests/unit/vector/CMakeLists.txt
+++ b/tests/unit/vector/CMakeLists.txt
@@ -7,6 +7,10 @@
 ]]
 
 # Build vector handler tests
+add_executable(runVectorTests.exe runVectorTests.cpp)
+target_link_libraries(runVectorTests.exe PRIVATE ReSolve resolve_vector)
+
+# Build vector handler tests
 add_executable(runVectorHandlerTests.exe runVectorHandlerTests.cpp)
 target_link_libraries(runVectorHandlerTests.exe PRIVATE ReSolve resolve_vector)
 
@@ -15,9 +19,10 @@ add_executable(runGramSchmidtTests.exe runGramSchmidtTests.cpp)
 target_link_libraries(runGramSchmidtTests.exe PRIVATE ReSolve resolve_vector)
 
 # Install tests
-set(installable_tests runVectorHandlerTests.exe runGramSchmidtTests.exe)
+set(installable_tests runVectorTests.exe runVectorHandlerTests.exe runGramSchmidtTests.exe)
 install(TARGETS ${installable_tests} 
         RUNTIME DESTINATION bin/resolve/tests/unit)
 
+add_test(NAME vector_test COMMAND $<TARGET_FILE:runVectorTests.exe>)
 add_test(NAME vector_handler_test COMMAND $<TARGET_FILE:runVectorHandlerTests.exe>)
 add_test(NAME gram_schmidt_test COMMAND $<TARGET_FILE:runGramSchmidtTests.exe>)

--- a/tests/unit/vector/VectorTests.hpp
+++ b/tests/unit/vector/VectorTests.hpp
@@ -5,8 +5,10 @@
 #include <sstream>
 #include <iterator>
 #include <algorithm>
+#include <resolve/MemoryUtils.hpp>
 #include <resolve/vector/Vector.hpp>
 #include <tests/unit/TestBase.hpp>
+#include <resolve/Common.hpp>
 
 namespace ReSolve { 
   namespace tests {
@@ -17,7 +19,8 @@ namespace ReSolve {
     class VectorTests : TestBase
     {
       public:       
-        VectorTests()
+        VectorTests(memory::MemorySpace memspace = memory::HOST)
+          : memspace_(memspace)
         {
         }
 
@@ -41,34 +44,78 @@ namespace ReSolve {
           return success.report(__func__);
         }
 
-        TestOutcome vectorSetToConstTest(index_type N)
+        TestOutcome vectorSetToConst(index_type N = 4)
         {
+          using constants::ZERO;
+          using constants::ONE;
+
           TestStatus success;
           success = true;
+
+          index_type vector_size = N;
+          index_type number_vectors = 3;
+
+          vector::Vector x(vector_size, number_vectors);
+
+          x.setToZero(memspace_);
+          success *= verifyAnswer(x, ZERO);
+
+          x.setToConst(1, ONE, memspace_); // set vector 1 to ones
+          success *= verifyAnswer(vector_size, x.getVectorData(0, memspace_), ZERO);
+          success *= verifyAnswer(vector_size, x.getVectorData(1, memspace_), ONE);
+          success *= verifyAnswer(vector_size, x.getVectorData(2, memspace_), ZERO);
+
+          x.setToConst(ONE, memspace_);
+          success *= verifyAnswer(x, ONE);
+
+          x.setToZero(1, memspace_); // set vector 1 to zeros
+          success *= verifyAnswer(vector_size, x.getVectorData(0, memspace_), ONE);
+          success *= verifyAnswer(vector_size, x.getVectorData(1, memspace_), ZERO);
+          success *= verifyAnswer(vector_size, x.getVectorData(2, memspace_), ONE);
 
           return success.report(__func__);
         }
 
-        TestOutcome vectorSyncDataTest(index_type N)
+        TestOutcome vectorSyncData(index_type N = 4)
         {
-          TestStatus success;
+          using constants::ZERO;
+          using constants::ONE;
 
-          return success.report(__func__);
-        }    
-
-        TestOutcome vectorGetDataTest(index_type N)
-        {
           TestStatus success;
           success = true;
 
+          if (memspace_ == memory::HOST) {
+            return success.report(__func__);
+          }
+
+          index_type vector_size = N;
+          index_type number_vectors = 3;
+
+          vector::Vector x(vector_size, number_vectors);
+
+          // Set all vectors in x on device to ones
+          x.setToConst(ONE, memspace_);
+          // Sync host (all ones on the host, as well)
+          x.syncData(memory::HOST);
+          // Set vector 1 to all zeros on host
+          x.setToZero(1, memory::HOST);
+          // Sync vector 1 on device
+          x.syncData(1, memspace_);
+
+          // Check what we have on device now is correct
+          success *= verifyAnswer(vector_size, x.getVectorData(0, memspace_), ONE);
+          success *= verifyAnswer(vector_size, x.getVectorData(1, memspace_), ZERO);
+          success *= verifyAnswer(vector_size, x.getVectorData(2, memspace_), ONE);
 
           return success.report(__func__);
         }    
 
+
       private:
         ReSolve::memory::MemorySpace memspace_{memory::HOST};
+        MemoryHandler mh_;
 
-        // we can verify through norm but that would defeat the purpose of testing vector handler ...
+        /// Check if vector elements are set to the same number
         bool verifyAnswer(vector::Vector& x, real_type answer)
         {
           bool success = true;
@@ -87,6 +134,38 @@ namespace ReSolve {
               break; 
             }
           }
+          return success;
+        }
+
+        /// Check if an array elements are set to the same number
+        bool verifyAnswer(index_type size, const real_type* data, real_type answer)
+        {
+          bool success = true;
+          real_type* x = nullptr;
+
+          // If the data is on device copy it to the host
+          if (memspace_ == memory::DEVICE) {
+            mh_.allocateArrayOnHost(&x, size);
+            mh_.copyArrayDeviceToHost(x, data, size);
+            // Set `data` to point to the host copy
+            data = x;
+          }
+
+          for (size_t i = 0; i < static_cast<size_t>(size); ++i) {
+            if (!isEqual(data[i], answer)) {
+              std::cout << std::setprecision(16);
+              success = false;
+              std::cout << "Solution vector element x[" << i << "] = " << data[i]
+                << ", expected: " << answer << "\n";
+              break; 
+            }
+          }
+
+          if (memspace_ == memory::DEVICE) {
+            mh_.deleteOnHost(x);
+            data = nullptr;
+          }
+
           return success;
         }
     };//class

--- a/tests/unit/vector/VectorTests.hpp
+++ b/tests/unit/vector/VectorTests.hpp
@@ -27,34 +27,42 @@ namespace ReSolve {
 
         TestOutcome vectorConstructor()
         {
-          TestStatus status;
-          status.skipTest();
+          TestStatus success;
+          success = true;
 
-          return status.report(__func__);
+          index_type vector_size = 4;
+          index_type number_vectors = 3;
+
+          vector::Vector x(vector_size, number_vectors);
+
+          success *= (vector_size == x.getSize());
+          success *= (number_vectors == x.getNumVectors());
+
+          return success.report(__func__);
         }
 
         TestOutcome vectorSetToConstTest(index_type N)
         {
-          TestStatus status;
-          status = true;
+          TestStatus success;
+          success = true;
 
-          return status.report(__func__);
+          return success.report(__func__);
         }
 
         TestOutcome vectorSyncDataTest(index_type N)
         {
-          TestStatus status;
+          TestStatus success;
 
-          return status.report(__func__);
+          return success.report(__func__);
         }    
 
         TestOutcome vectorGetDataTest(index_type N)
         {
-          TestStatus status;
-          status = true;
+          TestStatus success;
+          success = true;
 
 
-          return status.report(__func__);
+          return success.report(__func__);
         }    
 
       private:
@@ -63,7 +71,7 @@ namespace ReSolve {
         // we can verify through norm but that would defeat the purpose of testing vector handler ...
         bool verifyAnswer(vector::Vector& x, real_type answer)
         {
-          bool status = true;
+          bool success = true;
 
           if (memspace_ == memory::DEVICE) {
             x.syncData(memory::HOST);
@@ -73,13 +81,13 @@ namespace ReSolve {
             // std::cout << x->getData("cpu")[i] << "\n";
             if (!isEqual(x.getData(memory::HOST)[i], answer)) {
               std::cout << std::setprecision(16);
-              status = false;
+              success = false;
               std::cout << "Solution vector element x[" << i << "] = " << x.getData(memory::HOST)[i]
                 << ", expected: " << answer << "\n";
               break; 
             }
           }
-          return status;
+          return success;
         }
     };//class
   } // namespace tests

--- a/tests/unit/vector/VectorTests.hpp
+++ b/tests/unit/vector/VectorTests.hpp
@@ -1,0 +1,87 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <iomanip>
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+#include <resolve/vector/Vector.hpp>
+#include <tests/unit/TestBase.hpp>
+
+namespace ReSolve { 
+  namespace tests {
+    /**
+     * @class Tests for vector handler
+     *
+     */
+    class VectorTests : TestBase
+    {
+      public:       
+        VectorTests()
+        {
+        }
+
+        virtual ~VectorTests()
+        {
+        }
+
+        TestOutcome vectorConstructor()
+        {
+          TestStatus status;
+          status.skipTest();
+
+          return status.report(__func__);
+        }
+
+        TestOutcome vectorSetToConstTest(index_type N)
+        {
+          TestStatus status;
+          status = true;
+
+          return status.report(__func__);
+        }
+
+        TestOutcome vectorSyncDataTest(index_type N)
+        {
+          TestStatus status;
+
+          return status.report(__func__);
+        }    
+
+        TestOutcome vectorGetDataTest(index_type N)
+        {
+          TestStatus status;
+          status = true;
+
+
+          return status.report(__func__);
+        }    
+
+      private:
+        ReSolve::memory::MemorySpace memspace_{memory::HOST};
+
+        // we can verify through norm but that would defeat the purpose of testing vector handler ...
+        bool verifyAnswer(vector::Vector& x, real_type answer)
+        {
+          bool status = true;
+
+          if (memspace_ == memory::DEVICE) {
+            x.syncData(memory::HOST);
+          }
+
+          for (index_type i = 0; i < x.getSize(); ++i) {
+            // std::cout << x->getData("cpu")[i] << "\n";
+            if (!isEqual(x.getData(memory::HOST)[i], answer)) {
+              std::cout << std::setprecision(16);
+              status = false;
+              std::cout << "Solution vector element x[" << i << "] = " << x.getData(memory::HOST)[i]
+                << ", expected: " << answer << "\n";
+              break; 
+            }
+          }
+          return status;
+        }
+    };//class
+  } // namespace tests
+} //namespace ReSolve
+

--- a/tests/unit/vector/runVectorTests.cpp
+++ b/tests/unit/vector/runVectorTests.cpp
@@ -1,0 +1,26 @@
+#include <string>
+#include <iostream>
+#include <fstream>
+#include "VectorTests.hpp"
+
+int main(int, char**)
+{
+  ReSolve::tests::TestingResults result;
+
+  ReSolve::tests::VectorTests tests();
+
+  {
+    std::cout << "Running tests on CPU:\n";
+
+  }
+
+#ifdef RESOLVE_USE_GPU
+  {
+    std::cout << "Running tests on GPU:\n";
+
+  }
+#endif
+
+
+  return result.summary();
+}

--- a/tests/unit/vector/runVectorTests.cpp
+++ b/tests/unit/vector/runVectorTests.cpp
@@ -7,19 +7,22 @@ int main(int, char**)
 {
   ReSolve::tests::TestingResults result;
 
-  ReSolve::tests::VectorTests test;
-
   {
+    ReSolve::tests::VectorTests test;
+
     std::cout << "Running tests on CPU:\n";
     result += test.vectorConstructor();
-
+    result += test.vectorSetToConst();
   }
 
 #ifdef RESOLVE_USE_GPU
   {
+    ReSolve::tests::VectorTests test(ReSolve::memory::DEVICE);
+
     std::cout << "Running tests on GPU:\n";
     result += test.vectorConstructor();
-
+    result += test.vectorSetToConst();
+    result += test.vectorSyncData();
   }
 #endif
 

--- a/tests/unit/vector/runVectorTests.cpp
+++ b/tests/unit/vector/runVectorTests.cpp
@@ -7,16 +7,18 @@ int main(int, char**)
 {
   ReSolve::tests::TestingResults result;
 
-  ReSolve::tests::VectorTests tests();
+  ReSolve::tests::VectorTests test;
 
   {
     std::cout << "Running tests on CPU:\n";
+    result += test.vectorConstructor();
 
   }
 
 #ifdef RESOLVE_USE_GPU
   {
     std::cout << "Running tests on GPU:\n";
+    result += test.vectorConstructor();
 
   }
 #endif


### PR DESCRIPTION
## Description
 
`Vector` class object is a multivector that allows access to individual vectors separately. It is plausible to expect that individual vectors could be updated individually and some of them may have device, while others may have host memory space updated. However, current implementation of the `Vector` class allows only for setting update flags for all vectors together, regardless of how they are accessed and updated. This is a bug, see #259.


 ## Proposed changes
 
This PR provides following:
- Separate bookkeeping of host and device memory updates for each vector in the multivector object.
- Add `syncData` overload to sync only one vector in multivector object. Closes #259.
- Sets update flags correctly when vector elements are initialized using `setToZero` and `setToConst` methods. Closes #216. 

 ## Checklist
 
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 This is still a draft. #277, #276 and #275 need to be merged before this PR is ready.

