### PR TITLE
Prohibit sloppy syncing

### DIFF
--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -223,7 +223,9 @@ namespace ReSolve
         // vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vec_rv_->setDataUpdated(memspace_);
-        vec_rv_->syncData(memory::HOST);
+        if (memspace_ == memory::DEVICE) {
+          vec_rv_->syncData(memory::HOST);
+        }
 
         vec_rv_->copyDataTo(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);
@@ -271,7 +273,9 @@ namespace ReSolve
 
         vector_handler_->massDot2Vec(n, V, i + 1, vec_v_, vec_rv_, memspace_);
         vec_rv_->setDataUpdated(memspace_);
-        vec_rv_->syncData(memory::HOST);
+        if (memspace_ == memory::DEVICE) {
+          vec_rv_->syncData(memory::HOST);
+        }
 
         vec_rv_->copyDataTo(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
         h_rv = vec_rv_->getVectorData(1, memory::HOST);

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -312,9 +312,10 @@ namespace ReSolve
                "In Coo::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::misc() << "Coo::syncData is trying to sync host, but host already up to date!\n"
+          out::error() << "Coo::syncData is trying to sync host, but host already up to date!\n"
                       << "Function call ignored!\n";
-          return 0;
+          assert(!h_data_updated_);
+          return 1;
         }
         if (!d_data_updated_) {
           out::error() << "Coo::syncData is trying to sync host with device, but device is out of date!\n"
@@ -340,9 +341,10 @@ namespace ReSolve
                "In Coo::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::misc() << "Coo::syncData is trying to sync device, but device already up to date!\n"
+          out::error() << "Coo::syncData is trying to sync device, but device already up to date!\n"
                       << "Function call ignored!\n";
-          return 0;
+          assert(!d_data_updated_);
+          return 1;
         }
         if (!h_data_updated_) {
           out::error() << "Coo::syncData is trying to sync device with host, but host is out of date!\n"

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -312,8 +312,7 @@ namespace ReSolve
                "In Coo::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::error() << "Coo::syncData is trying to sync host, but host already up to date!\n"
-                      << "Function call ignored!\n";
+          out::error() << "Coo::syncData is trying to sync host, but host already up to date!\n";
           assert(!h_data_updated_);
           return 1;
         }

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -340,8 +340,7 @@ namespace ReSolve
                "In Coo::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::error() << "Coo::syncData is trying to sync device, but device already up to date!\n"
-                      << "Function call ignored!\n";
+          out::error() << "Coo::syncData is trying to sync device, but device already up to date!\n";
           assert(!d_data_updated_);
           return 1;
         }

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -243,8 +243,7 @@ namespace ReSolve
                "In Csc::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::error() << "Csc::syncData is trying to sync device, but device already up to date!\n"
-                       << "Function call ignored!\n";
+          out::error() << "Csc::syncData is trying to sync device, but device already up to date!\n";
           assert(!d_data_updated_);
           return 1;
         }

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -215,8 +215,7 @@ namespace ReSolve
                "In Csc::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::error() << "Csc::syncData is trying to sync host, but host already up to date!\n"
-                       << "Function call ignored!\n";
+          out::error() << "Csc::syncData is trying to sync host, but host already up to date!\n";
           assert(!h_data_updated_);
           return 1;
         }

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -215,9 +215,10 @@ namespace ReSolve
                "In Csc::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::misc() << "Csc::syncData is trying to sync host, but host already up to date!\n"
-                      << "Function call ignored!\n";
-          return 0;
+          out::error() << "Csc::syncData is trying to sync host, but host already up to date!\n"
+                       << "Function call ignored!\n";
+          assert(!h_data_updated_);
+          return 1;
         }
         if (!d_data_updated_) {
           out::error() << "Csc::syncData is trying to sync host with device, but device is out of date!\n"
@@ -243,9 +244,10 @@ namespace ReSolve
                "In Csc::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::misc() << "Csc::syncData is trying to sync device, but device already up to date!\n"
-                      << "Function call ignored!\n";
-          return 0;
+          out::error() << "Csc::syncData is trying to sync device, but device already up to date!\n"
+                       << "Function call ignored!\n";
+          assert(!d_data_updated_);
+          return 1;
         }
         if (!h_data_updated_) {
           out::error() << "Csc::syncData is trying to sync device with host, but host is out of date!\n"

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -332,8 +332,7 @@ namespace ReSolve
                "In Csr::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::error() << "Csr::syncData is trying to sync host, but host already up to date!\n"
-                       << "Function call ignored!\n";
+          out::error() << "Csr::syncData is trying to sync host, but host already up to date!\n";
           assert(!h_data_updated_);
           return 1;
         }

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -360,8 +360,7 @@ namespace ReSolve
                "In Csr::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::error() << "Csr::syncData is trying to sync device, but device already up to date!\n"
-                       << "Function call ignored!\n";
+          out::error() << "Csr::syncData is trying to sync device, but device already up to date!\n";
           assert(!d_data_updated_);
           return 1;
         }

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -332,9 +332,10 @@ namespace ReSolve
                "In Csr::syncData one of host row or column data is null!\n");
 
         if (h_data_updated_) {
-          out::misc() << "Csr::syncData is trying to sync host, but host already up to date!\n"
-                      << "Function call ignored!\n";
-          return 0;
+          out::error() << "Csr::syncData is trying to sync host, but host already up to date!\n"
+                       << "Function call ignored!\n";
+          assert(!h_data_updated_);
+          return 1;
         }
         if (!d_data_updated_) {
           out::error() << "Csr::syncData is trying to sync host with device, but device is out of date!\n"
@@ -360,9 +361,10 @@ namespace ReSolve
                "In Csr::syncData one of device row or column data is null!\n");
 
         if (d_data_updated_) {
-          out::misc() << "Csr::syncData is trying to sync device, but device already up to date!\n"
-                      << "Function call ignored!\n";
-          return 0;
+          out::error() << "Csr::syncData is trying to sync device, but device already up to date!\n"
+                       << "Function call ignored!\n";
+          assert(!d_data_updated_);
+          return 1;
         }
         if (!h_data_updated_) {
           out::error() << "Csr::syncData is trying to sync device with host, but host is out of date!\n"

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -280,7 +280,7 @@ namespace ReSolve { namespace vector {
         if (gpu_updated_) {
           out::error() << "Trying to sync device, but device already up to date!\n";
           assert(!gpu_updated_);
-          return 0;
+          return 1;
         }
         if (!cpu_updated_) {
           out::error() << "Trying to sync device with host, but host is out of date!\n";
@@ -297,7 +297,7 @@ namespace ReSolve { namespace vector {
         if (cpu_updated_) {
           out::error() << "Trying to sync host, but host already up to date!\n";
           assert(!cpu_updated_);
-          return 0;
+          return 1;
         }
         if (!gpu_updated_) {
           out::error() << "Trying to sync host with device, but device is out of date!\n";

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -278,7 +278,8 @@ namespace ReSolve { namespace vector {
     switch(memspaceOut)  {
       case DEVICE: // cpu->gpu
         if (gpu_updated_) {
-          out::misc() << "Trying to sync device, but device already up to date!\n";
+          out::error() << "Trying to sync device, but device already up to date!\n";
+          assert(!gpu_updated_);
           return 0;
         }
         if (!cpu_updated_) {
@@ -294,7 +295,8 @@ namespace ReSolve { namespace vector {
         break;
       case HOST: //cuda->cpu
         if (cpu_updated_) {
-          out::misc() << "Trying to sync host, but host already up to date!\n";
+          out::error() << "Trying to sync host, but host already up to date!\n";
+          assert(!cpu_updated_);
           return 0;
         }
         if (!gpu_updated_) {
@@ -498,7 +500,7 @@ namespace ReSolve { namespace vector {
 
     if (new_n_size > n_capacity_) {
       out::error() << "Trying to resize vector to " << new_n_size 
-                   << " elements but memory allocated only for " << n_capacity_ << elements. << "\n";
+                   << " elements but memory allocated only for " << n_capacity_ << " elements. \n";
       return 1;
     } else {
       n_size_ = new_n_size;

--- a/tests/functionality/TestHelper.hpp
+++ b/tests/functionality/TestHelper.hpp
@@ -384,9 +384,9 @@ class TestHelper
 
       // Compute residual norm on CPU
       if (memspace_ == ReSolve::memory::DEVICE) {
-        A_->syncData(ReSolve::memory::HOST);
-        r_->syncData(ReSolve::memory::HOST);
-        x_->syncData(ReSolve::memory::HOST);
+        // A_->syncData(ReSolve::memory::HOST);
+        // r_->syncData(ReSolve::memory::HOST);
+        // x_->syncData(ReSolve::memory::HOST);
         res_->copyDataFrom(r_, memspace_, ReSolve::memory::HOST);
         norm_res_cpu_ = computeResidualNorm(*A_, *x_, *res_, ReSolve::memory::HOST);
       }
@@ -402,7 +402,9 @@ class TestHelper
       x_true_->allocate(memspace_);
       x_true_->setToConst(static_cast<ReSolve::real_type>(1.0), memspace_);
       x_true_->setDataUpdated(memspace_);
-      x_true_->syncData(ReSolve::memory::HOST);
+      if (memspace_ == ReSolve::memory::DEVICE) {
+        x_true_->syncData(ReSolve::memory::HOST);
+      }
       norm_true_ = norm2(*x_true_, memspace_);
       solution_set_ = true;
     }

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -103,8 +103,10 @@ namespace ReSolve
               aux_data[i] = var2;
             }
           }
-          V.setDataUpdated(memory::HOST); 
-          V.syncData(memspace_);
+          V.setDataUpdated(memory::HOST);
+          if (memspace_ == memory::DEVICE) {
+            V.syncData(memspace_);
+          }
 
           // Set the first vector to all 1s and normalize it. 
           V.setToConst(0, 1.0, memspace_);


### PR DESCRIPTION
## Description
 
Prohibit synchronizing memory space if it is already updated. Only memory space that is out of date can be synchronized with the updated space. For example, if host is up to date and device is out of date, then function `syncData(DEVICE);` will copy data from the host to the device. If the device is up-to-date (i.e. flag `gpu_updated_ == true`), Re::Solve will return an error. The user is required to keep track of which memory space is current.

Current behavior in Re::Solve is to do nothing if user tries to sync the memory space that is up to date. This provides a convenience for users -- if in doubt whether memory space has been synced, just sync again. This sloppy approach makes certain bugs difficult to track. For example, consider a case where `cpu_updated_ == false` and `gpu_updated_ == true`.  If user changes vector elements on the host by accessing its raw data and forgets to to mark the host memory as updated, the device memory flag will still show that memory space is the current one. Then, if trying to sync the device with host, function `syncData` will quietly do nothing. By prohibiting sloppy syncing, this function will return an error alerting user something is wrong.

Closes #282 

 ## Proposed changes
 
- Remove all instances of sloppy syncing inthe code.
- Function `syncData` returns an error when trying to sync the memory space which is up-to-date.
 
 ## Checklist
  
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 


