### PR TITLE
CPU-only build of GMRES solver no longer tries to allocate on GPU

### DIFF
--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -497,7 +497,7 @@ namespace ReSolve
       if (is_flexible) {
         vec_Z_ = new vector_type(n_, restart_ + 1);
       } else {
-        // otherwise Z is just a one vector, not multivector and we dont keep it
+        // otherwise Z is just one vector, not a multivector and we don't keep it
         vec_Z_ = new vector_type(n_);
       }
       vec_Z_->allocate(memspace_);

--- a/resolve/cpu/CpuMemory.hpp
+++ b/resolve/cpu/CpuMemory.hpp
@@ -1,6 +1,7 @@
 #pragma once
-
+#include <cassert>
 #include <resolve/utilities/logger/Logger.hpp>
+
 
 namespace ReSolve
 {
@@ -43,6 +44,7 @@ namespace ReSolve
       static int deleteOnDevice(void* /* v */)
       {
         ReSolve::io::Logger::error() << "Trying to delete on a GPU device, but GPU support not available.\n";
+        assert(false && "Trying to delete on a GPU device, but GPU support not available.");
         return -1;
       }
 

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -495,8 +495,8 @@ namespace ReSolve { namespace vector {
    */
   int Vector::resize(index_type new_n_size)
   {
-    assert(owns_cpu_data_ && owns_gpu_data_ 
-           && "Cannot resize if vector is not owning the data.");
+    assert(owns_cpu_data_ || owns_gpu_data_ 
+           && "Cannot resize if vector does not own data.");
 
     if (new_n_size > n_capacity_) {
       out::error() << "Trying to resize vector to " << new_n_size 

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -61,7 +61,7 @@ namespace ReSolve { namespace vector {
       bool gpu_updated_{false}; ///< DEVICE data flag (updated or not)
       bool cpu_updated_{false}; ///< HOST data flag (updated or not)
 
-      bool owns_gpu_data_{true}; ///< data owneship flag for DEVICE data
+      bool owns_gpu_data_{false}; ///< data owneship flag for DEVICE data
       bool owns_cpu_data_{true}; ///< data ownership flag for HOST data
 
       MemoryHandler mem_; ///< Device memory manager object

--- a/tests/functionality/testRandGmres.cpp
+++ b/tests/functionality/testRandGmres.cpp
@@ -107,7 +107,6 @@ int runTest(int argc, char *argv[])
   vector_type* vec_rhs = generateRhs(n, memspace);
 
   vector_type vec_x(A->getNumRows());
-  vec_x.allocate(memory::HOST);
   vec_x.allocate(memspace);
   vec_x.setToZero(memspace);
 


### PR DESCRIPTION
## Description
 
 _Error messages are returned when running GMRES tests suggesting the solver is trying to access GPU memory. These are benign messages as computation is carried out to completion on a CPU device and all GPU calls are ignored, but the code should not be trying to access the the device memory in the CPU mode in the first place._
 
 _Closes #286 _
 
 _@pelesh_
 

 ## Proposed changes
 
 _My changes enforce strict checks on owning gpu data. Previously this was set by default to true, which is wrong in the case of a CPU only build._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [x] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc._

