### PR TITLE
Correct naming convention and default block size in GPU kernels

### DIFF
--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -306,10 +306,10 @@ namespace ReSolve {
   {
 
     // Define block size and number of blocks
-    const int blockSize = 1;
-    int numBlocks = (n + blockSize - 1) / blockSize;
+    const int block_size = 1;
+    int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftDiagScale<<<numBlocks, blockSize>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -330,10 +330,10 @@ namespace ReSolve {
                       const real_type* d_val)
   {
     // Define block size and number of blocks
-    const int blockSize = 256;
-    int numBlocks = (n + blockSize - 1) / blockSize;
+    const int block_size = 256;
+    int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightDiagScale<<<numBlocks, blockSize>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
 

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -536,10 +536,10 @@ namespace ReSolve {
                      const real_type* d_val)
   {
     // Define block size and number of blocks
-    const int blockSize = 1;
-    int numBlocks = (n + blockSize - 1) / blockSize;
+    const int block_size = 1;
+    int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftDiagScale<<<numBlocks, blockSize>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -560,10 +560,10 @@ namespace ReSolve {
                       const real_type* d_val)
   {
     // Define block size and number of blocks
-    const int blockSize = 256;
-    int numBlocks = (n + blockSize - 1) / blockSize;
+    const int block_size = 256;
+    int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightDiagScale<<<numBlocks, blockSize>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
 } // namespace ReSolve


### PR DESCRIPTION
## Description
 
 _The code does not currently obey ReSolve naming conventions._

 ## Proposed changes
 
 _I changed the variable names to follow conventions. I also changed the default block size._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [x] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
