### PR TITLE
Fix memory access errors in CPU build.

### DIFF
--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -38,8 +38,8 @@ namespace ReSolve { namespace vector {
    */
   Vector::~Vector()
   {
-    if (owns_cpu_data_) delete [] h_data_;
-    if (owns_gpu_data_) mem_.deleteOnDevice(d_data_);
+    if (owns_cpu_data_ && h_data_) delete [] h_data_;
+    if (owns_gpu_data_ && d_data_) mem_.deleteOnDevice(d_data_);
   }
 
 

--- a/tests/functionality/CMakeLists.txt
+++ b/tests/functionality/CMakeLists.txt
@@ -112,8 +112,8 @@ add_test(NAME rand_gmres_test    COMMAND $<TARGET_FILE:rand_gmres_test.exe>)
 
 if(RESOLVE_USE_KLU)
   # Using KLU as refactorization solver
-  add_test(NAME klu_klu_test    COMMAND $<TARGET_FILE:klu_klu_test.exe> "${test_data_dir}" "-d" "${test_data_dir}")
-  add_test(NAME klu_klu_ir_test COMMAND $<TARGET_FILE:klu_klu_test.exe> "${test_data_dir}" "-d" "${test_data_dir}" "-i")
+  add_test(NAME klu_klu_test    COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}")
+  add_test(NAME klu_klu_ir_test COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-i")
 
   # CUDA-SDK specific tests
   if(RESOLVE_USE_CUDA)

--- a/tests/functionality/testKlu.cpp
+++ b/tests/functionality/testKlu.cpp
@@ -95,7 +95,6 @@ int runTest(int argc, char *argv[], std::string& solver_name)
     return -1;
   }
   ReSolve::matrix::Csr* A = ReSolve::io::createCsrFromFile(mat1);
-  A->syncData(ReSolve::memory::DEVICE);
   mat1.close();
 
   // Read first rhs vector
@@ -108,7 +107,6 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   real_type* rhs = ReSolve::io::createArrayFromFile(rhs1_file);
   vector_type vec_rhs(A->getNumRows());
   vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_rhs.syncData(ReSolve::memory::DEVICE);
   rhs1_file.close();
 
   // Allocate the solution vector
@@ -162,7 +160,6 @@ int runTest(int argc, char *argv[], std::string& solver_name)
     return -1;
   }
   ReSolve::io::updateMatrixFromFile(mat2, A);
-  A->syncData(ReSolve::memory::DEVICE);
   mat2.close();
 
   // Load the second rhs vector
@@ -174,7 +171,7 @@ int runTest(int argc, char *argv[], std::string& solver_name)
   }
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = KLU.refactorize();
   error_sum += status;


### PR DESCRIPTION
## Description

Fixed following issues:
- Vector destructor logic incorrect, tries to delete data that has not been allocated. 
- KLU test allocates and moves data to GPU without need to do so. Causes a segfault when Re::Solve is built without GPU support.

Closes #286 


 ## Proposed changes
 
- Vector destructor deletes only if data exists (pointer is not null) and vector owns that data.
- Remove commands moving data to GPU from KLU test.
 
 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc._

