### PR TITLE
Kernels for scaling a vector by a diagonal matrix

### DIFF
--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -360,7 +360,7 @@ namespace ReSolve {
   }
 
   /**
-   * @brief Scales a vector by a diagonal matrix
+   * @brief Wrapper that scales a vector by a diagonal matrix
    *
    * @param[in]  n      - size of the vector
    * @param[in, out] vec - vector to be scaled. Changes in place.
@@ -369,14 +369,14 @@ namespace ReSolve {
    * @todo Decide how to allow user to configure grid and block sizes.
    */
   void vectorDiagScale(index_type n,
-                      const real_type* d_val,
+                      const real_type* diag,
                       real_type* vec)
   {
     // Define block size and number of blocks
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::vectorDiagScale<<<num_blocks, block_size>>>(n, d_val, vec);
+    kernels::vectorDiagScale<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
   /**

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -244,6 +244,29 @@ namespace ReSolve {
         }
       }
     }
+
+    /**
+     * @brief Scales a vector by a diagonal matrix
+     *
+     * @param[in]  n      - size of the vector
+     * @param[in, out] vec - vector to be scaled. Changes in place.
+     * @param[in]  d_val  - diagonal values
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    __global__ void vectorDiagScale(index_type n,
+                                    const real_type* d_val,
+                                    real_type* vec)
+    {
+      // Get the index of the element to be processed
+      index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+      // Check if the index is within bounds
+      if (idx < n) {
+        // Scale the vector element by the corresponding diagonal value
+        vec[idx] *= d_val[idx];
+      }
+    }
   } // namespace kernels
 
   //
@@ -336,7 +359,25 @@ namespace ReSolve {
     kernels::rightDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
-
+  /**
+   * @brief Scales a vector by a diagonal matrix
+   *
+   * @param[in]  n      - size of the vector
+   * @param[in, out] vec - vector to be scaled. Changes in place.
+   * @param[in]  d_val  - diagonal values
+   *
+   * @todo Decide how to allow user to configure grid and block sizes.
+   */
+  void vectorDiagScale(index_type n,
+                      const real_type* d_val,
+                      real_type* vec)
+  {
+    // Define block size and number of blocks
+    const int block_size = 256;
+    int num_blocks = (n + block_size - 1) / block_size;
+    // Launch the kernel
+    kernels::vectorDiagScale<<<num_blocks, block_size>>>(n, d_val, vec);
+  }
 
   /**
    * @brief

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -33,6 +33,10 @@ namespace ReSolve {
                       real_type* a_val,
                       const real_type* diag);
 
+  void vectorDiagScale(index_type n, 
+                       const real_type* diag,
+                       real_type* vec);
+
   //needed for matrix inf nrm
   void matrix_row_sums(index_type n,
                        index_type nnz,

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -33,6 +33,10 @@ namespace ReSolve {
                       real_type* a_val,
                       const real_type* diag);
 
+  void vectorDiagScale(index_type n,
+                       const real_type* diag,
+                       real_type* vec);
+
   //needed for matrix inf nrm
   void matrix_row_sums(index_type n,
                        index_type nnz,

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -367,6 +367,29 @@ namespace ReSolve {
       }
     }
 
+    /**
+     * @brief Scales a vector by a diagonal matrix
+     *
+     * @param[in]  n      - size of the vector
+     * @param[in, out] vec - vector to be scaled. Changes in place.
+     * @param[in]  d_val  - diagonal values
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    __global__ void vectorDiagScale(index_type n,
+                                    const real_type* diag,
+                                    real_type* vec)
+    {
+      // Get the index of the element to be processed
+      index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+      // Check if the index is within bounds
+      if (idx < n) {
+        // Scale the vector element by the corresponding diagonal value
+        vec[idx] *= diag[idx];
+      }
+    }
+
   } // namespace kernels
 
   //
@@ -564,6 +587,26 @@ namespace ReSolve {
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
     kernels::rightDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+  }
+
+  /**
+   * @brief Wrapper that scales a vector by a diagonal matrix
+   *
+   * @param[in]  n      - size of the vector
+   * @param[in, out] vec - vector to be scaled. Changes in place.
+   * @param[in]  d_val  - diagonal values
+   *
+   * @todo Decide how to allow user to configure grid and block sizes.
+   */
+  void vectorDiagScale(index_type n,
+                      const real_type* diag,
+                      real_type* vec)
+  {
+    // Define block size and number of blocks
+    const int block_size = 256;
+    int num_blocks = (n + block_size - 1) / block_size;
+    // Launch the kernel
+    kernels::vectorDiagScale<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -320,6 +320,35 @@ namespace ReSolve {
   }
 
   /**
+   * @brief Scale a vector by a diagonal matrix
+   *
+   * @param[in] diag - vector representing the diagonal matrix
+   * @param[in,out] vec - vector to be scaled
+   * @param[in] memspace - Device where the operation is computed
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @invariant diag
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int MatrixHandler::vectorDiagonalScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace)
+  {
+    assert(diag->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
+    assert(diag->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
+    assert(vec->getData(memspace) != nullptr && "Vector data is null!\n");
+    using namespace ReSolve::memory;
+    switch (memspace) {
+      case HOST:
+        return cpuImpl_->vectorDiagonalScale(diag, vec);
+        break;
+      case DEVICE:
+        return devImpl_->vectorDiagonalScale(diag, vec);
+        break;
+    }
+    return 1;
+  }
+
+  /**
    * @brief Add a constant to the nonzero values of a csr matrix.
    * @param[in,out] A - Sparse matrix
    * @param[in] alpha - scalar parameter

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -60,6 +60,8 @@ namespace ReSolve {
 
       int rightDiagonalScale(matrix::Csr* A, vector_type* diag, memory::MemorySpace memspace);
 
+      int vectorDiagonalScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace);
+
       void addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
 
       /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -345,6 +345,31 @@ namespace ReSolve
     }
     return 0;
   }
+
+  /**
+   * @brief Scale a vector by a diagonal matrix
+   *
+   * @param[in] diag - vector representing the diagonal matrix
+   * @param[in, out] vec - vector to be scaled
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @invariant diag
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int MatrixHandlerCpu::vectorDiagonalScale(vector_type* diag, vector_type* vec)
+  {
+    real_type* diag_data = diag->getData(memory::HOST);
+    real_type* vec_data = vec->getData(memory::HOST);
+    index_type n = vec->getSize();
+
+    for (index_type i = 0; i < n; ++i) {
+      vec_data[i] *= diag_data[i];
+    }
+    vec->setDataUpdated(memory::HOST);
+    return 0;
+  }
+
   /**
    * @brief Add a constant to all nonzero values in the matrix
    *

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -43,6 +43,8 @@ namespace ReSolve {
 
       int rightDiagonalScale(matrix::Csr* A, vector_type* diag) override;
 
+      int vectorDiagonalScale(vector_type* diag, vector_type* vec) override;
+
       int addConst(matrix::Sparse* A, real_type alpha) override;
 
       virtual int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -375,6 +375,27 @@ namespace ReSolve {
     return 0;
   }
 
+  /**
+   * @brief Scale a vector by a diagonal matrix
+   *
+   * @param[in] diag - vector representing the diagonal matrix
+   * @param[in, out] vec - vector to be scaled
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @invariant diag
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int MatrixHandlerCuda::vectorDiagonalScale(vector_type* diag, vector_type* vec)
+  {
+    real_type* diag_data = diag->getData(memory::DEVICE);
+    real_type* vec_data = vec->getData(memory::DEVICE);
+    index_type n = vec->getSize();
+    vectorDiagScale(n, diag_data, vec_data);
+    vec->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 
   /**
    * @brief Add a constant to all nonzero values in the matrix

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -44,6 +44,8 @@ namespace ReSolve {
 
       int rightDiagonalScale(matrix::Csr* A, vector_type* diag) override;
 
+      int vectorDiagonalScale(vector_type* diag, vector_type* vec) override;
+
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -357,4 +357,27 @@ namespace ReSolve {
     return 0;
   }
 
+  /**
+   * @brief Scale a vector by a diagonal matrix in HIP
+   *
+   * @param[in]  diag - vector representing the diagonal matrix
+   * @param[in, out]  vec - vector to be scaled
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @pre vec is unscaled
+   * @post vec is scaled
+   * @invariant diag
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int MatrixHandlerHip::vectorDiagonalScale(vector_type* diag, vector_type* vec)
+  {
+    real_type* diag_data = diag->getData(memory::DEVICE);
+    real_type* vec_data = vec->getData(memory::DEVICE);
+    index_type n = vec->getSize();
+    vectorDiagScale(n, diag_data, vec_data);
+    vec->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -43,6 +43,8 @@ namespace ReSolve {
 
       int rightDiagonalScale(matrix::Csr* A, vector_type* diag) override;
 
+      int vectorDiagonalScale(vector_type* diag, vector_type* vec) override;
+
       int addConst(matrix::Sparse* A, real_type alpha) override;
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -40,6 +40,8 @@ namespace ReSolve {
 
       virtual int rightDiagonalScale(matrix::Csr* A, vector_type* diag) = 0;
 
+      virtual int vectorDiagonalScale(vector_type* diag, vector_type* vec) = 0;
+
       virtual int addConst(matrix::Sparse* A, real_type alpha) = 0;
 
       virtual int matvec(matrix::Sparse* A,

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -729,7 +729,7 @@ private:
 
     // Verify values - each element should be scaled by (i+1.0)
     for (index_type i = 0; i < n; ++i) {
-      real_type expected = original_data[i] * static_cast<real_type>(i + 1);
+      real_type expected = original_data[i] * static_cast<real_type>(i + 1.0);
       if (!isEqual(data[i], expected)) {
         std::cout << "Mismatch at index " << i << ": value = " << data[i]
                   << ", expected = " << expected << "\n";

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -51,6 +51,7 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.rightDiagScale(1024, 1024);
   result += test.rightDiagScale(1024, 2048);
   result += test.rightDiagScale(2048, 1024);
+  result += test.vectorDiagScale(1024);
   std::cout << "\n";
 }
 


### PR DESCRIPTION
## Description
 
Implements HIP and CUDA kernels to scale vectors by diagonal matrices (element-wise product).
 
 Closes #280
 

 ## Proposed changes
 
Implements the kernels and a test that scales the incrementing vector of length `n` by itself.
 
 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 

