### PR TITLE
Update redundant scaling kernel names

### DIFF
--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -86,9 +86,6 @@ namespace ReSolve
     matrix::Csr* L_csr = nullptr;
     matrix::Csr* U_csr = nullptr;
 
-    matrix::Sparse::SparseFormat matrix_format = L->getSparseFormat();
-    // std::cout << "Matrix format is " << matrix_format << "\n";
-
     switch (L->getSparseFormat()) {
       case matrix::Sparse::COMPRESSED_SPARSE_COLUMN:
         // std::cout << "converting L and U factors from CSC to CSR format ...\n";

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -306,7 +306,7 @@ namespace ReSolve
       mem_.deviceSynchronize();
     } else {
       // not implemented yet
-      permuteVectorP(A_->getNumRows(), d_P_, rhs->getData(ReSolve::memory::DEVICE), d_aux1_);
+      hip::permuteVectorP(A_->getNumRows(), d_P_, rhs->getData(ReSolve::memory::DEVICE), d_aux1_);
       mem_.deviceSynchronize();
       rocsparse_dcsrsv_solve(workspace_->getRocsparseHandle(),
                              rocsparse_operation_none,
@@ -340,7 +340,7 @@ namespace ReSolve
                              U_buffer_);
       error_sum += status_rocsparse_;
 
-      permuteVectorQ(A_->getNumRows(), d_Q_,d_aux1_,rhs->getData(ReSolve::memory::DEVICE));
+      hip::permuteVectorQ(A_->getNumRows(), d_Q_,d_aux1_,rhs->getData(ReSolve::memory::DEVICE));
       mem_.deviceSynchronize();
     }
     RESOLVE_RANGE_POP(__FUNCTION__);
@@ -380,7 +380,7 @@ namespace ReSolve
     } else {
       // not implemented yet
 
-      permuteVectorP(A_->getNumRows(), d_P_, rhs->getData(ReSolve::memory::DEVICE), d_aux1_);
+      hip::permuteVectorP(A_->getNumRows(), d_P_, rhs->getData(ReSolve::memory::DEVICE), d_aux1_);
       mem_.deviceSynchronize();
 
       rocsparse_dcsrsv_solve(workspace_->getRocsparseHandle(),
@@ -415,7 +415,7 @@ namespace ReSolve
                              U_buffer_);
       error_sum += status_rocsparse_;
 
-      permuteVectorQ(A_->getNumRows(), d_Q_,d_aux1_,x->getData(ReSolve::memory::DEVICE));
+      hip::permuteVectorQ(A_->getNumRows(), d_Q_,d_aux1_,x->getData(ReSolve::memory::DEVICE));
       mem_.deviceSynchronize();
     }
     RESOLVE_RANGE_POP(__FUNCTION__);

--- a/resolve/cuda/CudaMemory.hpp
+++ b/resolve/cuda/CudaMemory.hpp
@@ -111,7 +111,7 @@ namespace ReSolve
       template <typename I, typename T>
       static int setArrayToConstOnDevice(T* v, T c, I n)
       {
-        cuda::cuda_set_array_const(n, c, v);
+        cuda::setArrayConst(n, c, v);
         return checkCudaErrors(0);
       }
 

--- a/resolve/cuda/CudaMemory.hpp
+++ b/resolve/cuda/CudaMemory.hpp
@@ -111,7 +111,7 @@ namespace ReSolve
       template <typename I, typename T>
       static int setArrayToConstOnDevice(T* v, T c, I n)
       {
-        cuda_set_array_const(n, c, v);
+        cuda::cuda_set_array_const(n, c, v);
         return checkCudaErrors(0);
       }
 

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -323,7 +323,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void leftScaleWrapper(index_type n,
+    void leftScale(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* d_val)
@@ -347,7 +347,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void rightScaleWrapper(index_type n,
+    void rightScale(index_type n,
                         const index_type* a_row_ptr,
                         const index_type* a_col_ind,
                         real_type* a_val,
@@ -369,7 +369,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void scaleWrapper(index_type n,
+    void scale(index_type n,
                         const real_type* diag,
                         real_type* vec)
     {

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -12,174 +12,309 @@
 
 
 namespace ReSolve {
-  namespace kernels {
+  namespace cuda {
+    namespace kernels {
 
-    /**
-     * @brief Computes v^T * [u1 u2] where v is n x k multivector
-     * and u1 and u2 are n x 1 vectors.
-     *
-     * @tparam Tv5 - Size of shared memory
-     *
-     * @param[in] u1      - (n x 1) vector
-     * @param[in] u2      - (n x 1) vector
-     * @param[in] v       - (n x k) multivector
-     * @param[out] result - (k x 2) multivector
-     * @param[in] k       - dimension of the subspace
-     * @param[in] N       - size of vectors u1, u2
-     */
-    template <size_t Tv5 = 1024>
-    __global__ void MassIPTwoVec(const real_type* __restrict__ u1,
-                                 const real_type* __restrict__ u2,
-                                 const real_type* __restrict__ v,
-                                 real_type* result,
-                                 const index_type k,
-                                 const index_type N)
-    {
-      index_type t = threadIdx.x;
-      index_type bsize = blockDim.x;
-
-      // assume T threads per thread block (and k reductions to be performed)
-      volatile __shared__ real_type s_tmp1[Tv5];
-      volatile __shared__ real_type s_tmp2[Tv5];
-
-      // map between thread index space and the problem index space
-      index_type j = blockIdx.x;
-      s_tmp1[t] = 0.0;
-      s_tmp2[t] = 0.0;
-      index_type nn = t;
-      real_type can1, can2, cbn;
-
-      while(nn < N) {
-        can1 = u1[nn];
-        can2 = u2[nn];
-
-        cbn = v[N * j + nn];
-        s_tmp1[t] += can1 * cbn;
-        s_tmp2[t] += can2 * cbn;
-
-        nn += bsize;
-      }
-
-      __syncthreads();
-
-      if(Tv5 >= 1024) {
-        if(t < 512) {
-          s_tmp1[t] += s_tmp1[t + 512];
-          s_tmp2[t] += s_tmp2[t + 512];
-        }
-        __syncthreads();
-      }
-      if(Tv5 >= 512) {
-        if(t < 256) {
-          s_tmp1[t] += s_tmp1[t + 256];
-          s_tmp2[t] += s_tmp2[t + 256];
-        }
-        __syncthreads();
-      }
+      /**
+       * @brief Computes v^T * [u1 u2] where v is n x k multivector
+       * and u1 and u2 are n x 1 vectors.
+       *
+       * @tparam Tv5 - Size of shared memory
+       *
+       * @param[in] u1      - (n x 1) vector
+       * @param[in] u2      - (n x 1) vector
+       * @param[in] v       - (n x k) multivector
+       * @param[out] result - (k x 2) multivector
+       * @param[in] k       - dimension of the subspace
+       * @param[in] N       - size of vectors u1, u2
+       */
+      template <size_t Tv5 = 1024>
+      __global__ void MassIPTwoVec(const real_type* __restrict__ u1,
+                                  const real_type* __restrict__ u2,
+                                  const real_type* __restrict__ v,
+                                  real_type* result,
+                                  const index_type k,
+                                  const index_type N)
       {
-        if(t < 128) {
-          s_tmp1[t] += s_tmp1[t + 128];
-          s_tmp2[t] += s_tmp2[t + 128];
+        index_type t = threadIdx.x;
+        index_type bsize = blockDim.x;
+
+        // assume T threads per thread block (and k reductions to be performed)
+        volatile __shared__ real_type s_tmp1[Tv5];
+        volatile __shared__ real_type s_tmp2[Tv5];
+
+        // map between thread index space and the problem index space
+        index_type j = blockIdx.x;
+        s_tmp1[t] = 0.0;
+        s_tmp2[t] = 0.0;
+        index_type nn = t;
+        real_type can1, can2, cbn;
+
+        while(nn < N) {
+          can1 = u1[nn];
+          can2 = u2[nn];
+
+          cbn = v[N * j + nn];
+          s_tmp1[t] += can1 * cbn;
+          s_tmp2[t] += can2 * cbn;
+
+          nn += bsize;
         }
+
         __syncthreads();
+
+        if(Tv5 >= 1024) {
+          if(t < 512) {
+            s_tmp1[t] += s_tmp1[t + 512];
+            s_tmp2[t] += s_tmp2[t + 512];
+          }
+          __syncthreads();
+        }
+        if(Tv5 >= 512) {
+          if(t < 256) {
+            s_tmp1[t] += s_tmp1[t + 256];
+            s_tmp2[t] += s_tmp2[t + 256];
+          }
+          __syncthreads();
+        }
+        {
+          if(t < 128) {
+            s_tmp1[t] += s_tmp1[t + 128];
+            s_tmp2[t] += s_tmp2[t + 128];
+          }
+          __syncthreads();
+        }
+        {
+          if(t < 64) {
+            s_tmp1[t] += s_tmp1[t + 64];
+            s_tmp2[t] += s_tmp2[t + 64];
+          }
+          __syncthreads();
+        }
+
+        if(t < 32) {
+          s_tmp1[t] += s_tmp1[t + 32];
+          s_tmp2[t] += s_tmp2[t + 32];
+
+          s_tmp1[t] += s_tmp1[t + 16];
+          s_tmp2[t] += s_tmp2[t + 16];
+
+          s_tmp1[t] += s_tmp1[t + 8];
+          s_tmp2[t] += s_tmp2[t + 8];
+
+          s_tmp1[t] += s_tmp1[t + 4];
+          s_tmp2[t] += s_tmp2[t + 4];
+
+          s_tmp1[t] += s_tmp1[t + 2];
+          s_tmp2[t] += s_tmp2[t + 2];
+
+          s_tmp1[t] += s_tmp1[t + 1];
+          s_tmp2[t] += s_tmp2[t + 1];
+        }
+        if(t == 0) {
+          result[blockIdx.x] = s_tmp1[0];
+          result[blockIdx.x + k] = s_tmp2[0];
+        }
       }
+
+
+      /**
+       * @brief AXPY y = y - x*alpha where alpha is [k x 1], and x is [N x k] needed in 1 and 2 synch GMRES
+       *
+       * @tparam Tmaxk
+       *
+       * @param[in]  N      - number of rows in x
+       * @param[in]  k      - number of columns in x
+       * @param[in]  x_data - double array, size [N x k]
+       * @param[out] y_data - double array, size [N x 1]
+       * @param[in]  alpha  - doble array, size [k x 1]
+       */
+      template <size_t Tmaxk = 1024>
+      __global__ void massAxpy3(index_type N,
+                                index_type k,
+                                const real_type* x_data,
+                                real_type* y_data,
+                                const real_type* alpha)
       {
-        if(t < 64) {
-          s_tmp1[t] += s_tmp1[t + 64];
-          s_tmp2[t] += s_tmp2[t + 64];
+        index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+        index_type t = threadIdx.x;
+        __shared__ real_type s_alpha[Tmaxk];
+
+        if(t < k) {
+          s_alpha[t] = alpha[t];
         }
         __syncthreads();
-      }
 
-      if(t < 32) {
-        s_tmp1[t] += s_tmp1[t + 32];
-        s_tmp2[t] += s_tmp2[t + 32];
-
-        s_tmp1[t] += s_tmp1[t + 16];
-        s_tmp2[t] += s_tmp2[t + 16];
-
-        s_tmp1[t] += s_tmp1[t + 8];
-        s_tmp2[t] += s_tmp2[t + 8];
-
-        s_tmp1[t] += s_tmp1[t + 4];
-        s_tmp2[t] += s_tmp2[t + 4];
-
-        s_tmp1[t] += s_tmp1[t + 2];
-        s_tmp2[t] += s_tmp2[t + 2];
-
-        s_tmp1[t] += s_tmp1[t + 1];
-        s_tmp2[t] += s_tmp2[t + 1];
-      }
-      if(t == 0) {
-        result[blockIdx.x] = s_tmp1[0];
-        result[blockIdx.x + k] = s_tmp2[0];
-      }
-    }
-
-
-    /**
-     * @brief AXPY y = y - x*alpha where alpha is [k x 1], and x is [N x k] needed in 1 and 2 synch GMRES
-     *
-     * @tparam Tmaxk
-     *
-     * @param[in]  N      - number of rows in x
-     * @param[in]  k      - number of columns in x
-     * @param[in]  x_data - double array, size [N x k]
-     * @param[out] y_data - double array, size [N x 1]
-     * @param[in]  alpha  - doble array, size [k x 1]
-     */
-    template <size_t Tmaxk = 1024>
-    __global__ void massAxpy3(index_type N,
-                              index_type k,
-                              const real_type* x_data,
-                              real_type* y_data,
-                              const real_type* alpha)
-    {
-      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-      index_type t = threadIdx.x;
-      __shared__ real_type s_alpha[Tmaxk];
-
-      if(t < k) {
-        s_alpha[t] = alpha[t];
-      }
-      __syncthreads();
-
-      if(i < N) {
-        real_type temp = 0.0;
-        for(index_type j = 0; j < k; ++j) {
-          temp += x_data[j * N + i] * s_alpha[j];
+        if(i < N) {
+          real_type temp = 0.0;
+          for(index_type j = 0; j < k; ++j) {
+            temp += x_data[j * N + i] * s_alpha[j];
+          }
+          y_data[i] -= temp;
         }
-        y_data[i] -= temp;
       }
+
+      /**
+       * @brief Pass through matrix rows and sum each as \sum_{j=1}^m abs(a_{ij})
+       *
+       * @param[in]  n      - number of rows in the matrix.
+       * @param[in]  nnz    - number of non-zero values in the matrix
+       * @param[in]  a_ia   - row pointers (CSR storage)
+       * @param[in]  a_val  - values (CSR storage)
+       * @param[out] result - array size [n x 1] containing sums of values in each row.
+       */
+      __global__ void matrixInfNormPart1(const index_type n,
+                                        const index_type nnz,
+                                        const index_type* a_ia,
+                                        const real_type* a_val,
+                                        real_type* result)
+      {
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+        while (idx < n) {
+          real_type sum = 0.0;
+          for (index_type i = a_ia[idx]; i < a_ia[idx + 1]; ++i) {
+            sum = sum + fabs(a_val[i]);
+          }
+          result[idx] = sum;
+          idx += (blockDim.x * gridDim.x);
+        }
+      }
+      /**
+       * @brief Scales a csr matrix on the left by a diagonal matrix
+       *
+       * @param[in]  n      - number of rows in the matrix
+       * @param[in]  a_row_ptr - row pointers (CSR storage)
+       * @param[in, out]  a_val    - values (CSR storage). Changes in place.
+       * @param[in]  d_val    - diagonal values
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void leftScale(index_type n,
+                        const index_type* a_row_ptr,
+                        real_type* a_val,
+                        const real_type* d_val)
+      {
+        // Get row index from thread and block indices
+        index_type row = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the thread's row is within matrix bounds
+        if (row < n) {
+          // Get the start and end positions for this row in the CSR format
+          index_type row_start = a_row_ptr[row];
+          index_type row_end = a_row_ptr[row + 1];
+
+          // Get the scaling factor for this row from the diagonal matrix
+          real_type scale = d_val[row];
+
+          // Scale all non-zero elements in this row
+          for (index_type i = row_start; i < row_end; i++) {
+            a_val[i] *= scale;
+          }
+        }
+      }
+
+      /**
+       * @brief Scales a csr matrix on the right by a diagonal matrix
+       *
+       * @param[in]  n      - number of rows in the matrix
+       * @param[in]  a_row_ptr - row pointers (CSR storage)
+       * @param[in]  a_col_ind - column indices (CSR storage)
+       * @param[in, out]  a_val    - values (CSR storage). Changes in place.
+       * @param[in]  d_val    - diagonal values
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void rightScale(index_type n,
+                        const index_type* a_row_ptr,
+                        const index_type* a_col_ind,
+                        real_type* a_val,
+                        const real_type* d_val)
+      {
+        // Get row index from thread and block indices
+        index_type row = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the thread's row is within matrix bounds
+        if (row < n) {
+          // Get the start and end positions for this row in the CSR format
+          index_type row_start = a_row_ptr[row];
+          index_type row_end = a_row_ptr[row + 1];
+
+          // Scale all non-zero elements in this row
+          for (index_type i = row_start; i < row_end; i++) {
+            a_val[i] *= d_val[a_col_ind[i]];
+          }
+        }
+      }
+
+      /**
+       * @brief Scales a vector by a diagonal matrix
+       *
+       * @param[in]  n      - size of the vector
+       * @param[in, out] vec - vector to be scaled. Changes in place.
+       * @param[in]  d_val  - diagonal values
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void scale(index_type n,
+                                      const real_type* d_val,
+                                      real_type* vec)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n) {
+          // Scale the vector element by the corresponding diagonal value
+          vec[idx] *= d_val[idx];
+        }
+      }
+    } // namespace kernels
+
+    //
+    // Kernel wrappers
+    //
+
+    /**
+     * @brief Computes result = mvec^T * [vec1 vec2]
+     *
+     * @param n      - size of vectors vec1, vec2
+     * @param i      -
+     * @param vec1   - (n x 1) vector
+     * @param vec2   - (n x 1) vector
+     * @param mvec   - (n x (i+1)) multivector
+     * @param result - ((i+1) x 2) multivector
+     *
+     * @todo Input data should be `const`.
+     * @todo Is it coincidence that the block size is equal to the default
+     * value of Tv5?
+     * @todo Should we use dynamic shared memory here instead?
+     */
+    void mass_inner_product_two_vectors(index_type n,
+                                        index_type i,
+                                        const real_type* vec1,
+                                        const real_type* vec2,
+                                        const real_type* mvec,
+                                        real_type* result)
+    {
+      kernels::MassIPTwoVec<<<i, 1024>>>(vec1, vec2, mvec, result, i, n);
     }
 
     /**
-     * @brief Pass through matrix rows and sum each as \sum_{j=1}^m abs(a_{ij})
+     * @brief Computes y := y - x*alpha
      *
-     * @param[in]  n      - number of rows in the matrix.
-     * @param[in]  nnz    - number of non-zero values in the matrix
-     * @param[in]  a_ia   - row pointers (CSR storage)
-     * @param[in]  a_val  - values (CSR storage)
-     * @param[out] result - array size [n x 1] containing sums of values in each row.
+     * @param[in]  n     - vector size
+     * @param[in]  i     - number of vectors in the multivector
+     * @param[in]  x     - (n x (i+1)) multivector
+     * @param[out] y     - (n x (i+1)) multivector
+     * @param[in]  alpha - ((i+1) x 1) vector
      */
-    __global__ void matrixInfNormPart1(const index_type n,
-                                       const index_type nnz,
-                                       const index_type* a_ia,
-                                       const real_type* a_val,
-                                       real_type* result)
+    void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha)
     {
-      index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
-      while (idx < n) {
-        real_type sum = 0.0;
-        for (index_type i = a_ia[idx]; i < a_ia[idx + 1]; ++i) {
-          sum = sum + fabs(a_val[i]);
-        }
-        result[idx] = sum;
-        idx += (blockDim.x * gridDim.x);
-      }
+      kernels::massAxpy3<<<(n + 384 - 1) / 384, 384>>>(n, i, x, y, alpha);
     }
+
     /**
-     * @brief Scales a csr matrix on the left by a diagonal matrix
+     * @brief Wrapper that scales a csr matrix on the left by a diagonal matrix
      *
      * @param[in]  n      - number of rows in the matrix
      * @param[in]  a_row_ptr - row pointers (CSR storage)
@@ -188,32 +323,21 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void leftScale(index_type n,
+    void leftScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* d_val)
     {
-      // Get row index from thread and block indices
-      index_type row = blockIdx.x * blockDim.x + threadIdx.x;
 
-      // Check if the thread's row is within matrix bounds
-      if (row < n) {
-        // Get the start and end positions for this row in the CSR format
-        index_type row_start = a_row_ptr[row];
-        index_type row_end = a_row_ptr[row + 1];
-
-        // Get the scaling factor for this row from the diagonal matrix
-        real_type scale = d_val[row];
-
-        // Scale all non-zero elements in this row
-        for (index_type i = row_start; i < row_end; i++) {
-          a_val[i] *= scale;
-        }
-      }
+      // Define block size and number of blocks
+      const int block_size = 1;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
     }
 
     /**
-     * @brief Scales a csr matrix on the right by a diagonal matrix
+     * @brief Wrapper that scales a csr matrix on the right by a diagonal matrix
      *
      * @param[in]  n      - number of rows in the matrix
      * @param[in]  a_row_ptr - row pointers (CSR storage)
@@ -223,30 +347,21 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void rightScale(index_type n,
-                      const index_type* a_row_ptr,
-                      const index_type* a_col_ind,
-                      real_type* a_val,
-                      const real_type* d_val)
+    void rightScaleWrapper(index_type n,
+                        const index_type* a_row_ptr,
+                        const index_type* a_col_ind,
+                        real_type* a_val,
+                        const real_type* d_val)
     {
-      // Get row index from thread and block indices
-      index_type row = blockIdx.x * blockDim.x + threadIdx.x;
-
-      // Check if the thread's row is within matrix bounds
-      if (row < n) {
-        // Get the start and end positions for this row in the CSR format
-        index_type row_start = a_row_ptr[row];
-        index_type row_end = a_row_ptr[row + 1];
-
-        // Scale all non-zero elements in this row
-        for (index_type i = row_start; i < row_end; i++) {
-          a_val[i] *= d_val[a_col_ind[i]];
-        }
-      }
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
     }
 
     /**
-     * @brief Scales a vector by a diagonal matrix
+     * @brief Wrapper that scales a vector by a diagonal matrix
      *
      * @param[in]  n      - size of the vector
      * @param[in, out] vec - vector to be scaled. Changes in place.
@@ -254,149 +369,35 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void scale(index_type n,
-                                    const real_type* d_val,
-                                    real_type* vec)
+    void scaleWrapper(index_type n,
+                        const real_type* diag,
+                        real_type* vec)
     {
-      // Get the index of the element to be processed
-      index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
-
-      // Check if the index is within bounds
-      if (idx < n) {
-        // Scale the vector element by the corresponding diagonal value
-        vec[idx] *= d_val[idx];
-      }
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
     }
-  } // namespace kernels
 
-  //
-  // Kernel wrappers
-  //
-
-  /**
-   * @brief Computes result = mvec^T * [vec1 vec2]
-   *
-   * @param n      - size of vectors vec1, vec2
-   * @param i      -
-   * @param vec1   - (n x 1) vector
-   * @param vec2   - (n x 1) vector
-   * @param mvec   - (n x (i+1)) multivector
-   * @param result - ((i+1) x 2) multivector
-   *
-   * @todo Input data should be `const`.
-   * @todo Is it coincidence that the block size is equal to the default
-   * value of Tv5?
-   * @todo Should we use dynamic shared memory here instead?
-   */
-  void mass_inner_product_two_vectors(index_type n,
-                                      index_type i,
-                                      const real_type* vec1,
-                                      const real_type* vec2,
-                                      const real_type* mvec,
-                                      real_type* result)
-  {
-    kernels::MassIPTwoVec<<<i, 1024>>>(vec1, vec2, mvec, result, i, n);
-  }
-
-  /**
-   * @brief Computes y := y - x*alpha
-   *
-   * @param[in]  n     - vector size
-   * @param[in]  i     - number of vectors in the multivector
-   * @param[in]  x     - (n x (i+1)) multivector
-   * @param[out] y     - (n x (i+1)) multivector
-   * @param[in]  alpha - ((i+1) x 1) vector
-   */
-  void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha)
-  {
-    kernels::massAxpy3<<<(n + 384 - 1) / 384, 384>>>(n, i, x, y, alpha);
-  }
-
-  /**
-   * @brief Wrapper that scales a csr matrix on the left by a diagonal matrix
-   *
-   * @param[in]  n      - number of rows in the matrix
-   * @param[in]  a_row_ptr - row pointers (CSR storage)
-   * @param[in, out]  a_val    - values (CSR storage). Changes in place.
-   * @param[in]  d_val    - diagonal values
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void leftScaleWrapper(index_type n,
-                     const index_type* a_row_ptr,
-                     real_type* a_val,
-                     const real_type* d_val)
-  {
-
-    // Define block size and number of blocks
-    const int block_size = 1;
-    int num_blocks = (n + block_size - 1) / block_size;
-    // Launch the kernel
-    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
-  }
-
-  /**
-   * @brief Wrapper that scales a csr matrix on the right by a diagonal matrix
-   *
-   * @param[in]  n      - number of rows in the matrix
-   * @param[in]  a_row_ptr - row pointers (CSR storage)
-   * @param[in]  a_col_ind - column indices (CSR storage)
-   * @param[in, out]  a_val    - values (CSR storage). Changes in place.
-   * @param[in]  d_val    - diagonal values
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void rightScaleWrapper(index_type n,
-                      const index_type* a_row_ptr,
-                      const index_type* a_col_ind,
-                      real_type* a_val,
-                      const real_type* d_val)
-  {
-    // Define block size and number of blocks
-    const int block_size = 256;
-    int num_blocks = (n + block_size - 1) / block_size;
-    // Launch the kernel
-    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
-  }
-
-  /**
-   * @brief Wrapper that scales a vector by a diagonal matrix
-   *
-   * @param[in]  n      - size of the vector
-   * @param[in, out] vec - vector to be scaled. Changes in place.
-   * @param[in]  d_val  - diagonal values
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void scaleWrapper(index_type n,
-                      const real_type* diag,
-                      real_type* vec)
-  {
-    // Define block size and number of blocks
-    const int block_size = 256;
-    int num_blocks = (n + block_size - 1) / block_size;
-    // Launch the kernel
-    kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
-  }
-
-  /**
-   * @brief
-   *
-   * @param[in]  n      -
-   * @param[in]  nnz    -
-   * @param[in]  a_ia   -
-   * @param[in]  a_val  -
-   * @param[out] result -
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void matrix_row_sums(index_type n,
-                       index_type nnz,
-                       const index_type* a_ia,
-                       const real_type* a_val,
-                       real_type* result)
-  {
-    kernels::matrixInfNormPart1<<<1000, 1024>>>(n, nnz, a_ia, a_val, result);
-  }
-
+    /**
+     * @brief
+     *
+     * @param[in]  n      -
+     * @param[in]  nnz    -
+     * @param[in]  a_ia   -
+     * @param[in]  a_val  -
+     * @param[out] result -
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void matrix_row_sums(index_type n,
+                        index_type nnz,
+                        const index_type* a_ia,
+                        const real_type* a_val,
+                        real_type* result)
+    {
+      kernels::matrixInfNormPart1<<<1000, 1024>>>(n, nnz, a_ia, a_val, result);
+    }
+  } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -254,7 +254,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void vectorScaleKernel(index_type n,
+    __global__ void scaleKernel(index_type n,
                                     const real_type* d_val,
                                     real_type* vec)
     {
@@ -368,7 +368,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void vectorScaleWrapper(index_type n,
+  void scaleWrapper(index_type n,
                       const real_type* diag,
                       real_type* vec)
   {
@@ -376,7 +376,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::vectorScaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::scaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
   /**

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -188,7 +188,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void leftDiagScale(index_type n,
+    __global__ void leftScale(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* d_val)
@@ -223,7 +223,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void rightDiagScale(index_type n,
+    __global__ void rightScale(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_ind,
                       real_type* a_val,
@@ -254,7 +254,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void vectorDiagScale(index_type n,
+    __global__ void vectorScale(index_type n,
                                     const real_type* d_val,
                                     real_type* vec)
     {
@@ -322,7 +322,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void leftDiagScale(index_type n,
+  void leftScale(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* d_val)
@@ -332,7 +332,7 @@ namespace ReSolve {
     const int block_size = 1;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -346,7 +346,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void rightDiagScale(index_type n,
+  void rightScale(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_ind,
                       real_type* a_val,
@@ -356,7 +356,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
   /**
@@ -368,7 +368,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void vectorDiagScale(index_type n,
+  void vectorScale(index_type n,
                       const real_type* diag,
                       real_type* vec)
   {
@@ -376,7 +376,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::vectorDiagScale<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::vectorScale<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
   /**

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -188,7 +188,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void leftScale(index_type n,
+    __global__ void leftScaleKernel(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* d_val)
@@ -223,7 +223,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void rightScale(index_type n,
+    __global__ void rightScaleKernel(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_ind,
                       real_type* a_val,
@@ -254,7 +254,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void vectorScale(index_type n,
+    __global__ void vectorScaleKernel(index_type n,
                                     const real_type* d_val,
                                     real_type* vec)
     {
@@ -322,7 +322,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void leftScale(index_type n,
+  void leftScaleWrapper(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* d_val)
@@ -332,7 +332,7 @@ namespace ReSolve {
     const int block_size = 1;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -346,7 +346,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void rightScale(index_type n,
+  void rightScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_ind,
                       real_type* a_val,
@@ -356,7 +356,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
   /**
@@ -368,7 +368,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void vectorScale(index_type n,
+  void vectorScaleWrapper(index_type n,
                       const real_type* diag,
                       real_type* vec)
   {
@@ -376,7 +376,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::vectorScale<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::vectorScaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
   /**

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -245,29 +245,6 @@ namespace ReSolve {
           }
         }
       }
-
-      /**
-       * @brief Scales a vector by a diagonal matrix
-       *
-       * @param[in]  n      - size of the vector
-       * @param[in, out] vec - vector to be scaled. Changes in place.
-       * @param[in]  d_val  - diagonal values
-       *
-       * @todo Decide how to allow user to configure grid and block sizes.
-       */
-      __global__ void scale(index_type n,
-                                      const real_type* d_val,
-                                      real_type* vec)
-      {
-        // Get the index of the element to be processed
-        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
-
-        // Check if the index is within bounds
-        if (idx < n) {
-          // Scale the vector element by the corresponding diagonal value
-          vec[idx] *= d_val[idx];
-        }
-      }
     } // namespace kernels
 
     //
@@ -358,26 +335,6 @@ namespace ReSolve {
       int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
-    }
-
-    /**
-     * @brief Wrapper that scales a vector by a diagonal matrix
-     *
-     * @param[in]  n      - size of the vector
-     * @param[in, out] vec - vector to be scaled. Changes in place.
-     * @param[in]  d_val  - diagonal values
-     *
-     * @todo Decide how to allow user to configure grid and block sizes.
-     */
-    void scale(index_type n,
-                        const real_type* diag,
-                        real_type* vec)
-    {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int num_blocks = (n + block_size - 1) / block_size;
-      // Launch the kernel
-      kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
     }
 
     /**

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -30,11 +30,11 @@ namespace ReSolve {
        */
       template <size_t Tv5 = 1024>
       __global__ void MassIPTwoVec(const real_type* __restrict__ u1,
-                                  const real_type* __restrict__ u2,
-                                  const real_type* __restrict__ v,
-                                  real_type* result,
-                                  const index_type k,
-                                  const index_type N)
+                                   const real_type* __restrict__ u2,
+                                   const real_type* __restrict__ v,
+                                   real_type* result,
+                                   const index_type k,
+                                   const index_type N)
       {
         index_type t = threadIdx.x;
         index_type bsize = blockDim.x;
@@ -164,10 +164,10 @@ namespace ReSolve {
        * @param[out] result - array size [n x 1] containing sums of values in each row.
        */
       __global__ void matrixInfNormPart1(const index_type n,
-                                        const index_type nnz,
-                                        const index_type* a_ia,
-                                        const real_type* a_val,
-                                        real_type* result)
+                                         const index_type nnz,
+                                         const index_type* a_ia,
+                                         const real_type* a_val,
+                                         real_type* result)
       {
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
         while (idx < n) {
@@ -190,9 +190,9 @@ namespace ReSolve {
        * @todo Decide how to allow user to configure grid and block sizes.
        */
       __global__ void leftScale(index_type n,
-                        const index_type* a_row_ptr,
-                        real_type* a_val,
-                        const real_type* d_val)
+                                const index_type* a_row_ptr,
+                                real_type* a_val,
+                                const real_type* d_val)
       {
         // Get row index from thread and block indices
         index_type row = blockIdx.x * blockDim.x + threadIdx.x;
@@ -225,10 +225,10 @@ namespace ReSolve {
        * @todo Decide how to allow user to configure grid and block sizes.
        */
       __global__ void rightScale(index_type n,
-                        const index_type* a_row_ptr,
-                        const index_type* a_col_ind,
-                        real_type* a_val,
-                        const real_type* d_val)
+                                 const index_type* a_row_ptr,
+                                 const index_type* a_col_ind,
+                                 real_type* a_val,
+                                 const real_type* d_val)
       {
         // Get row index from thread and block indices
         index_type row = blockIdx.x * blockDim.x + threadIdx.x;

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -188,7 +188,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void leftScaleKernel(index_type n,
+    __global__ void leftScale(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* d_val)
@@ -223,7 +223,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void rightScaleKernel(index_type n,
+    __global__ void rightScale(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_ind,
                       real_type* a_val,
@@ -254,7 +254,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void scaleKernel(index_type n,
+    __global__ void scale(index_type n,
                                     const real_type* d_val,
                                     real_type* vec)
     {
@@ -332,7 +332,7 @@ namespace ReSolve {
     const int block_size = 1;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -356,7 +356,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
   /**
@@ -376,7 +376,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::scaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
   /**

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -33,7 +33,7 @@ namespace ReSolve {
                       real_type* a_val,
                       const real_type* diag);
 
-  void vectorScaleWrapper(index_type n,
+  void scaleWrapper(index_type n,
                        const real_type* diag,
                        real_type* vec);
 

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -22,18 +22,18 @@ namespace ReSolve {
 
   void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha);
 
-  void leftScale(index_type n,
+  void leftScaleWrapper(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* diag);
 
-  void rightScale(index_type n,
+  void rightScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_idx,
                       real_type* a_val,
                       const real_type* diag);
 
-  void vectorScale(index_type n, 
+  void vectorScaleWrapper(index_type n,
                        const real_type* diag,
                        real_type* vec);
 

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -22,18 +22,18 @@ namespace ReSolve {
 
   void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha);
 
-  void leftDiagScale(index_type n,
+  void leftScale(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* diag);
 
-  void rightDiagScale(index_type n,
+  void rightScale(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_idx,
                       real_type* a_val,
                       const real_type* diag);
 
-  void vectorDiagScale(index_type n, 
+  void vectorScale(index_type n, 
                        const real_type* diag,
                        real_type* vec);
 

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -22,18 +22,18 @@ namespace ReSolve {
 
     void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha);
 
-    void leftScaleWrapper(index_type n,
+    void leftScale(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* diag);
 
-    void rightScaleWrapper(index_type n,
+    void rightScale(index_type n,
                         const index_type* a_row_ptr,
                         const index_type* a_col_idx,
                         real_type* a_val,
                         const real_type* diag);
 
-    void scaleWrapper(index_type n,
+    void scale(index_type n,
                         const real_type* diag,
                         real_type* vec);
 

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -12,36 +12,37 @@
 #include <resolve/Common.hpp>
 
 namespace ReSolve {
+  namespace cuda {
+    void mass_inner_product_two_vectors(index_type n,
+                                        index_type i,
+                                        const real_type* vec1,
+                                        const real_type* vec2,
+                                        const real_type* mvec,
+                                        real_type* result);
 
-  void mass_inner_product_two_vectors(index_type n,
-                                      index_type i,
-                                      const real_type* vec1,
-                                      const real_type* vec2,
-                                      const real_type* mvec,
-                                      real_type* result);
+    void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha);
 
-  void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha);
-
-  void leftScaleWrapper(index_type n,
-                     const index_type* a_row_ptr,
-                     real_type* a_val,
-                     const real_type* diag);
-
-  void rightScaleWrapper(index_type n,
+    void leftScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
-                      const index_type* a_col_idx,
                       real_type* a_val,
                       const real_type* diag);
 
-  void scaleWrapper(index_type n,
-                       const real_type* diag,
-                       real_type* vec);
+    void rightScaleWrapper(index_type n,
+                        const index_type* a_row_ptr,
+                        const index_type* a_col_idx,
+                        real_type* a_val,
+                        const real_type* diag);
 
-  //needed for matrix inf nrm
-  void matrix_row_sums(index_type n,
-                       index_type nnz,
-                       const index_type* a_ia,
-                       const real_type* a_val,
-                       real_type* result);
+    void scaleWrapper(index_type n,
+                        const real_type* diag,
+                        real_type* vec);
 
+    //needed for matrix inf nrm
+    void matrix_row_sums(index_type n,
+                        index_type nnz,
+                        const index_type* a_ia,
+                        const real_type* a_val,
+                        real_type* result);
+
+  } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -33,10 +33,6 @@ namespace ReSolve {
                         real_type* a_val,
                         const real_type* diag);
 
-    void scale(index_type n,
-                        const real_type* diag,
-                        real_type* vec);
-
     //needed for matrix inf nrm
     void matrix_row_sums(index_type n,
                         index_type nnz,

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -23,22 +23,22 @@ namespace ReSolve {
     void mass_axpy(index_type n, index_type i, const real_type* x, real_type* y, const real_type* alpha);
 
     void leftScale(index_type n,
-                      const index_type* a_row_ptr,
-                      real_type* a_val,
-                      const real_type* diag);
+                   const index_type* a_row_ptr,
+                   real_type* a_val,
+                   const real_type* diag);
 
     void rightScale(index_type n,
-                        const index_type* a_row_ptr,
-                        const index_type* a_col_idx,
-                        real_type* a_val,
-                        const real_type* diag);
+                    const index_type* a_row_ptr,
+                    const index_type* a_col_idx,
+                    real_type* a_val,
+                    const real_type* diag);
 
     //needed for matrix inf nrm
     void matrix_row_sums(index_type n,
-                        index_type nnz,
-                        const index_type* a_ia,
-                        const real_type* a_val,
-                        real_type* result);
+                         index_type nnz,
+                         const index_type* a_ia,
+                         const real_type* a_val,
+                         real_type* result);
 
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -58,7 +58,7 @@ namespace ReSolve
 
     } // namespace kernels
 
-    void cuda_set_array_const(index_type n, real_type val, real_type* arr)
+    void setArrayConst(index_type n, real_type val, real_type* arr)
     {
       index_type num_blocks;
       index_type block_size = 512;
@@ -66,7 +66,7 @@ namespace ReSolve
       kernels::set_const<<<num_blocks, block_size>>>(n, val, arr);
     }
 
-    void cudaAddConst(index_type n, real_type val, real_type* arr)
+    void addConst(index_type n, real_type val, real_type* arr)
     {
       index_type num_blocks;
       index_type block_size = 512;

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -10,66 +10,68 @@
 #include <cuda_runtime.h>
 
 #include <resolve/cuda/cudaVectorKernels.h>
-
+#include <resolve/cuda/cudaKernels.h>
 
 namespace ReSolve
 {
-  namespace kernels
-  {
-
-    /**
-     * @brief CUDA kernel that sets values of an array to a constant.
-     *
-     * @param[in]  n   - length of the array
-     * @param[in]  val - the value the array is set to
-     * @param[out] arr - a pointer to the array
-     *
-     * @pre  `arr` is allocated to size `n`
-     * @post `arr` elements are set to `val`
-     */
-    __global__ void set_const(index_type n, real_type val, real_type* arr)
+  namespace cuda {
+    namespace kernels
     {
-      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-      if(i < n)
+
+      /**
+       * @brief CUDA kernel that sets values of an array to a constant.
+       *
+       * @param[in]  n   - length of the array
+       * @param[in]  val - the value the array is set to
+       * @param[out] arr - a pointer to the array
+       *
+       * @pre  `arr` is allocated to size `n`
+       * @post `arr` elements are set to `val`
+       */
+      __global__ void set_const(index_type n, real_type val, real_type* arr)
       {
-        arr[i] = val;
+        index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+        if(i < n)
+        {
+          arr[i] = val;
+        }
       }
+
+      /**
+       * @brief CUDA kernel that adds a constant to each element of an array.
+       *
+       * @param[in]       n   - length of the array
+       * @param[in]       val - the value to add to each element
+       * @param[in, out]  arr - a pointer to the array
+       *
+       * @pre  `arr` is allocated to size `n`
+       * @post `val` is added to each element of `arr`
+       */
+      __global__ void addConst(index_type n, real_type val, real_type* arr)
+      {
+        index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+        if(i < n)
+        {
+          arr[i] += val;
+        }
+      }
+
+    } // namespace kernels
+
+    void cuda_set_array_const(index_type n, real_type val, real_type* arr)
+    {
+      index_type num_blocks;
+      index_type block_size = 512;
+      num_blocks = (n + block_size - 1) / block_size;
+      kernels::set_const<<<num_blocks, block_size>>>(n, val, arr);
     }
 
-    /**
-     * @brief CUDA kernel that adds a constant to each element of an array.
-     *
-     * @param[in]       n   - length of the array
-     * @param[in]       val - the value to add to each element
-     * @param[in, out]  arr - a pointer to the array
-     *
-     * @pre  `arr` is allocated to size `n`
-     * @post `val` is added to each element of `arr`
-     */
-    __global__ void addConst(index_type n, real_type val, real_type* arr)
+    void cudaAddConst(index_type n, real_type val, real_type* arr)
     {
-      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-      if(i < n)
-      {
-        arr[i] += val;
-      }
+      index_type num_blocks;
+      index_type block_size = 512;
+      num_blocks = (n + block_size - 1) / block_size;
+      kernels::addConst<<<num_blocks, block_size>>>(n, val, arr);
     }
-
-  } // namespace kernels
-
-  void cuda_set_array_const(index_type n, real_type val, real_type* arr)
-  {
-    index_type num_blocks;
-    index_type block_size = 512;
-    num_blocks = (n + block_size - 1) / block_size;
-    kernels::set_const<<<num_blocks, block_size>>>(n, val, arr);
-  }
-
-  void cudaAddConst(index_type n, real_type val, real_type* arr)
-  {
-    index_type num_blocks;
-    index_type block_size = 512;
-    num_blocks = (n + block_size - 1) / block_size;
-    kernels::addConst<<<num_blocks, block_size>>>(n, val, arr);
-  }
+  } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -57,7 +57,7 @@ namespace ReSolve
       }
 
       /**
-       * @brief Scales a vector by a diagonal matrix
+       * @brief Scales a vector by a diagonal matrix represented by a vector
        *
        * @param[in]  n      - size of the vector
        * @param[in, out] vec - vector to be scaled. Changes in place.

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -56,6 +56,29 @@ namespace ReSolve
         }
       }
 
+      /**
+       * @brief Scales a vector by a diagonal matrix
+       *
+       * @param[in]  n      - size of the vector
+       * @param[in, out] vec - vector to be scaled. Changes in place.
+       * @param[in]  d_val  - diagonal values
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void scale(index_type n,
+                                      const real_type* d_val,
+                                      real_type* vec)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n) {
+          // Scale the vector element by the corresponding diagonal value
+          vec[idx] *= d_val[idx];
+        }
+      }
+
     } // namespace kernels
 
     void setArrayConst(index_type n, real_type val, real_type* arr)
@@ -72,6 +95,26 @@ namespace ReSolve
       index_type block_size = 512;
       num_blocks = (n + block_size - 1) / block_size;
       kernels::addConst<<<num_blocks, block_size>>>(n, val, arr);
+    }
+
+    /**
+     * @brief Wrapper that scales a vector by a diagonal matrix
+     *
+     * @param[in]  n      - size of the vector
+     * @param[in, out] vec - vector to be scaled. Changes in place.
+     * @param[in]  d_val  - diagonal values
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void scale(index_type n,
+                        const real_type* diag,
+                        real_type* vec)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
     }
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -16,5 +16,6 @@ namespace ReSolve
   namespace cuda {
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
+    void scale(index_type n, const real_type* diag, real_type* vec);
   }
 }

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -14,7 +14,7 @@
 namespace ReSolve
 {
   namespace cuda {
-    void cuda_set_array_const(index_type n, real_type val, real_type* arr);
-    void cudaAddConst(index_type n, real_type val, real_type* arr);
+    void setArrayConst(index_type n, real_type val, real_type* arr);
+    void addConst(index_type n, real_type val, real_type* arr);
   }
 }

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -13,6 +13,8 @@
 
 namespace ReSolve
 {
-  void cuda_set_array_const(index_type n, real_type val, real_type* arr);
-  void cudaAddConst(index_type n, real_type val, real_type* arr);
+  namespace cuda {
+    void cuda_set_array_const(index_type n, real_type val, real_type* arr);
+    void cudaAddConst(index_type n, real_type val, real_type* arr);
+  }
 }

--- a/resolve/hip/HipMemory.hpp
+++ b/resolve/hip/HipMemory.hpp
@@ -111,7 +111,7 @@ namespace ReSolve
       template <typename I, typename T>
       static int setArrayToConstOnDevice(T* v, T c, I n)
       {
-        hip::hip_set_array_const(n, c, v);
+        hip::setArrayConst(n, c, v);
         return checkHipErrors(0);
       }
 

--- a/resolve/hip/HipMemory.hpp
+++ b/resolve/hip/HipMemory.hpp
@@ -111,7 +111,7 @@ namespace ReSolve
       template <typename I, typename T>
       static int setArrayToConstOnDevice(T* v, T c, I n)
       {
-        hip_set_array_const(n, c, v);
+        hip::hip_set_array_const(n, c, v);
         return checkHipErrors(0);
       }
 

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -22,18 +22,18 @@ namespace ReSolve {
                                       real_type* result);
   void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha);
 
-  void leftDiagScale(index_type n,
+  void leftScale(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* diag);
 
-  void rightDiagScale(index_type n,
+  void rightScale(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_idx,
                       real_type* a_val,
                       const real_type* diag);
 
-  void vectorDiagScale(index_type n,
+  void vectorScale(index_type n,
                        const real_type* diag,
                        real_type* vec);
 

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -33,7 +33,7 @@ namespace ReSolve {
                       real_type* a_val,
                       const real_type* diag);
 
-  void vectorScaleWrapper(index_type n,
+  void scaleWrapper(index_type n,
                        const real_type* diag,
                        real_type* vec);
 

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -22,18 +22,18 @@ namespace ReSolve {
                                       real_type* result);
   void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha);
 
-  void leftScale(index_type n,
+  void leftScaleWrapper(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* diag);
 
-  void rightScale(index_type n,
+  void rightScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_idx,
                       real_type* a_val,
                       const real_type* diag);
 
-  void vectorScale(index_type n,
+  void vectorScaleWrapper(index_type n,
                        const real_type* diag,
                        real_type* vec);
 

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -22,18 +22,18 @@ namespace ReSolve {
                                         real_type* result);
     void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha);
 
-    void leftScaleWrapper(index_type n,
+    void leftScale(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* diag);
 
-    void rightScaleWrapper(index_type n,
+    void rightScale(index_type n,
                         const index_type* a_row_ptr,
                         const index_type* a_col_idx,
                         real_type* a_val,
                         const real_type* diag);
 
-    void scaleWrapper(index_type n,
+    void scale(index_type n,
                         const real_type* diag,
                         real_type* vec);
 

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -13,52 +13,53 @@
 #include <resolve/Common.hpp>
 
 namespace ReSolve {
+  namespace hip {
+    void mass_inner_product_two_vectors(index_type n,
+                                        index_type i,
+                                        real_type* vec1,
+                                        real_type* vec2,
+                                        real_type* mvec,
+                                        real_type* result);
+    void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha);
 
-  void mass_inner_product_two_vectors(index_type n,
-                                      index_type i,
-                                      real_type* vec1,
-                                      real_type* vec2,
-                                      real_type* mvec,
-                                      real_type* result);
-  void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha);
-
-  void leftScaleWrapper(index_type n,
-                     const index_type* a_row_ptr,
-                     real_type* a_val,
-                     const real_type* diag);
-
-  void rightScaleWrapper(index_type n,
+    void leftScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
-                      const index_type* a_col_idx,
                       real_type* a_val,
                       const real_type* diag);
 
-  void scaleWrapper(index_type n,
-                       const real_type* diag,
-                       real_type* vec);
+    void rightScaleWrapper(index_type n,
+                        const index_type* a_row_ptr,
+                        const index_type* a_col_idx,
+                        real_type* a_val,
+                        const real_type* diag);
 
-  //needed for matrix inf nrm
-  void matrix_row_sums(index_type n,
-                       index_type nnz,
-                       index_type* a_ia,
-                       real_type* a_val,
-                       real_type* result);
+    void scaleWrapper(index_type n,
+                        const real_type* diag,
+                        real_type* vec);
 
-  // needed for triangular solve
+    //needed for matrix inf nrm
+    void matrix_row_sums(index_type n,
+                        index_type nnz,
+                        index_type* a_ia,
+                        real_type* a_val,
+                        real_type* result);
 
-  void permuteVectorP(index_type n,
-                      index_type* perm_vector,
-                      real_type* vec_in,
-                      real_type* vec_out);
+    // needed for triangular solve
 
-  void permuteVectorQ(index_type n,
-                      index_type* perm_vector,
-                      real_type* vec_in,
-                      real_type* vec_out);
+    void permuteVectorP(index_type n,
+                        index_type* perm_vector,
+                        real_type* vec_in,
+                        real_type* vec_out);
+
+    void permuteVectorQ(index_type n,
+                        index_type* perm_vector,
+                        real_type* vec_in,
+                        real_type* vec_out);
 
 
-  void vector_inf_norm(index_type n,
-                       real_type* input,
-                       real_type * buffer,
-                       real_type* result);
+    void vector_inf_norm(index_type n,
+                        real_type* input,
+                        real_type * buffer,
+                        real_type* result);
+  } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -23,22 +23,22 @@ namespace ReSolve {
     void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha);
 
     void leftScale(index_type n,
-                      const index_type* a_row_ptr,
-                      real_type* a_val,
-                      const real_type* diag);
+                   const index_type* a_row_ptr,
+                   real_type* a_val,
+                   const real_type* diag);
 
     void rightScale(index_type n,
-                        const index_type* a_row_ptr,
-                        const index_type* a_col_idx,
-                        real_type* a_val,
-                        const real_type* diag);
+                    const index_type* a_row_ptr,
+                    const index_type* a_col_idx,
+                    real_type* a_val,
+                    const real_type* diag);
 
     //needed for matrix inf nrm
     void matrix_row_sums(index_type n,
-                        index_type nnz,
-                        index_type* a_ia,
-                        real_type* a_val,
-                        real_type* result);
+                         index_type nnz,
+                         index_type* a_ia,
+                         real_type* a_val,
+                         real_type* result);
 
     // needed for triangular solve
 
@@ -54,8 +54,8 @@ namespace ReSolve {
 
 
     void vector_inf_norm(index_type n,
-                        real_type* input,
-                        real_type * buffer,
-                        real_type* result);
+                         real_type* input,
+                         real_type * buffer,
+                         real_type* result);
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -33,10 +33,6 @@ namespace ReSolve {
                         real_type* a_val,
                         const real_type* diag);
 
-    void scale(index_type n,
-                        const real_type* diag,
-                        real_type* vec);
-
     //needed for matrix inf nrm
     void matrix_row_sums(index_type n,
                         index_type nnz,

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -376,7 +376,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void vectorScaleKernel(index_type n,
+    __global__ void scaleKernel(index_type n,
                                     const real_type* diag,
                                     real_type* vec)
     {
@@ -598,7 +598,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void vectorScaleWrapper(index_type n,
+  void scaleWrapper(index_type n,
                       const real_type* diag,
                       real_type* vec)
   {
@@ -606,7 +606,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::vectorScaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::scaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -310,7 +310,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void leftDiagScale(index_type n,
+    __global__ void leftScale(index_type n,
                                   const index_type* a_row_ptr,
                                   real_type* a_val,
                                   const real_type* d_val)
@@ -345,7 +345,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void rightDiagScale(index_type n,
+    __global__ void rightScale(index_type n,
                                    const index_type* a_row_ptr,
                                    const index_type* a_col_ind,
                                    real_type* a_val,
@@ -376,7 +376,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void vectorDiagScale(index_type n,
+    __global__ void vectorScale(index_type n,
                                     const real_type* diag,
                                     real_type* vec)
     {
@@ -553,7 +553,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void leftDiagScale(index_type n,
+  void leftScale(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* d_val)
@@ -562,7 +562,7 @@ namespace ReSolve {
     const int block_size = 1;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -576,7 +576,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void rightDiagScale(index_type n,
+  void rightScale(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_ind,
                       real_type* a_val,
@@ -586,7 +586,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightDiagScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
   /**
@@ -598,7 +598,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void vectorDiagScale(index_type n,
+  void vectorScale(index_type n,
                       const real_type* diag,
                       real_type* vec)
   {
@@ -606,7 +606,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::vectorDiagScale<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::vectorScale<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -554,7 +554,7 @@ namespace ReSolve {
     *
     * @todo Decide how to allow user to configure grid and block sizes.
     */
-    void leftScaleWrapper(index_type n,
+    void leftScale(index_type n,
                       const index_type* a_row_ptr,
                       real_type* a_val,
                       const real_type* d_val)
@@ -577,7 +577,7 @@ namespace ReSolve {
     *
     * @todo Decide how to allow user to configure grid and block sizes.
     */
-    void rightScaleWrapper(index_type n,
+    void rightScale(index_type n,
                         const index_type* a_row_ptr,
                         const index_type* a_col_ind,
                         real_type* a_val,
@@ -599,7 +599,7 @@ namespace ReSolve {
     *
     * @todo Decide how to allow user to configure grid and block sizes.
     */
-    void scaleWrapper(index_type n,
+  void scale(index_type n,
                         const real_type* diag,
                         real_type* vec)
     {

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -367,30 +367,6 @@ namespace ReSolve {
           }
         }
       }
-
-      /**
-      * @brief Scales a vector by a diagonal matrix
-      *
-      * @param[in]  n      - size of the vector
-      * @param[in, out] vec - vector to be scaled. Changes in place.
-      * @param[in]  d_val  - diagonal values
-      *
-      * @todo Decide how to allow user to configure grid and block sizes.
-      */
-      __global__ void scale(index_type n,
-                                      const real_type* diag,
-                                      real_type* vec)
-      {
-        // Get the index of the element to be processed
-        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
-
-        // Check if the index is within bounds
-        if (idx < n) {
-          // Scale the vector element by the corresponding diagonal value
-          vec[idx] *= diag[idx];
-        }
-      }
-
     } // namespace kernels
 
     //
@@ -588,26 +564,6 @@ namespace ReSolve {
       int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
-    }
-
-    /**
-    * @brief Wrapper that scales a vector by a diagonal matrix
-    *
-    * @param[in]  n      - size of the vector
-    * @param[in, out] vec - vector to be scaled. Changes in place.
-    * @param[in]  d_val  - diagonal values
-    *
-    * @todo Decide how to allow user to configure grid and block sizes.
-    */
-  void scale(index_type n,
-                        const real_type* diag,
-                        real_type* vec)
-    {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int num_blocks = (n + block_size - 1) / block_size;
-      // Launch the kernel
-      kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
     }
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -310,7 +310,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void leftScaleKernel(index_type n,
+    __global__ void leftScale(index_type n,
                                   const index_type* a_row_ptr,
                                   real_type* a_val,
                                   const real_type* d_val)
@@ -345,7 +345,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void rightScaleKernel(index_type n,
+    __global__ void rightScale(index_type n,
                                    const index_type* a_row_ptr,
                                    const index_type* a_col_ind,
                                    real_type* a_val,
@@ -376,7 +376,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void scaleKernel(index_type n,
+    __global__ void scale(index_type n,
                                     const real_type* diag,
                                     real_type* vec)
     {
@@ -562,7 +562,7 @@ namespace ReSolve {
     const int block_size = 1;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -586,7 +586,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
   /**
@@ -606,7 +606,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::scaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -13,600 +13,601 @@
 #include <hip/hip_cooperative_groups.h>
 
 namespace ReSolve {
-  namespace kernels {
+  namespace hip {
+    namespace kernels {
 
-    /**
-     * @brief Computes v^T * [u1 u2] where v is n x k multivector
-     * and u1 and u2 are n x 1 vectors.
-     *
-     * @tparam Tv5 - Size of shared memory
-     *
-     * @param[in] u1      - (n x 1) vector
-     * @param[in] u2      - (n x 1) vector
-     * @param[in] v       - (n x k) multivector
-     * @param[out] result - (k x 2) multivector
-     * @param[in] k       - dimension of the subspace
-     * @param[in] N       - size of vectors u1, u2
-     */
-    template <size_t Tv5 = 1024>
-    __global__ void MassIPTwoVec_kernel(const real_type* __restrict__ u1,
-                                        const real_type* __restrict__ u2,
-                                        const real_type* __restrict__ v,
-                                        real_type* result,
-                                        const index_type k,
-                                        const index_type N)
-    {
-      index_type t = threadIdx.x;
-      index_type bsize = blockDim.x;
-
-      // assume T threads per thread block (and k reductions to be performed)
-      volatile __shared__ real_type s_tmp1[Tv5];
-
-      volatile __shared__ real_type s_tmp2[Tv5];
-      // map between thread index space and the problem index space
-      index_type j = blockIdx.x;
-      s_tmp1[t] = 0.0;
-      s_tmp2[t] = 0.0;
-      index_type nn = t;
-      real_type can1, can2, cbn;
-
-      while (nn < N) {
-        can1 = u1[nn];
-        can2 = u2[nn];
-
-        cbn = v[N * j + nn];
-        s_tmp1[t] += can1 * cbn;
-        s_tmp2[t] += can2 * cbn;
-
-        nn += bsize;
-      }
-
-      __syncthreads();
-
-      if (Tv5 >= 1024) {
-        if(t < 512) {
-          s_tmp1[t] += s_tmp1[t + 512];
-          s_tmp2[t] += s_tmp2[t + 512];
-        }
-        __syncthreads();
-      }
-      if (Tv5 >= 512) {
-        if(t < 256) {
-          s_tmp1[t] += s_tmp1[t + 256];
-          s_tmp2[t] += s_tmp2[t + 256];
-        }
-        __syncthreads();
-      }
+      /**
+      * @brief Computes v^T * [u1 u2] where v is n x k multivector
+      * and u1 and u2 are n x 1 vectors.
+      *
+      * @tparam Tv5 - Size of shared memory
+      *
+      * @param[in] u1      - (n x 1) vector
+      * @param[in] u2      - (n x 1) vector
+      * @param[in] v       - (n x k) multivector
+      * @param[out] result - (k x 2) multivector
+      * @param[in] k       - dimension of the subspace
+      * @param[in] N       - size of vectors u1, u2
+      */
+      template <size_t Tv5 = 1024>
+      __global__ void MassIPTwoVec_kernel(const real_type* __restrict__ u1,
+                                          const real_type* __restrict__ u2,
+                                          const real_type* __restrict__ v,
+                                          real_type* result,
+                                          const index_type k,
+                                          const index_type N)
       {
-        if (t < 128) {
-          s_tmp1[t] += s_tmp1[t + 128];
-          s_tmp2[t] += s_tmp2[t + 128];
+        index_type t = threadIdx.x;
+        index_type bsize = blockDim.x;
+
+        // assume T threads per thread block (and k reductions to be performed)
+        volatile __shared__ real_type s_tmp1[Tv5];
+
+        volatile __shared__ real_type s_tmp2[Tv5];
+        // map between thread index space and the problem index space
+        index_type j = blockIdx.x;
+        s_tmp1[t] = 0.0;
+        s_tmp2[t] = 0.0;
+        index_type nn = t;
+        real_type can1, can2, cbn;
+
+        while (nn < N) {
+          can1 = u1[nn];
+          can2 = u2[nn];
+
+          cbn = v[N * j + nn];
+          s_tmp1[t] += can1 * cbn;
+          s_tmp2[t] += can2 * cbn;
+
+          nn += bsize;
+        }
+
+        __syncthreads();
+
+        if (Tv5 >= 1024) {
+          if(t < 512) {
+            s_tmp1[t] += s_tmp1[t + 512];
+            s_tmp2[t] += s_tmp2[t + 512];
+          }
+          __syncthreads();
+        }
+        if (Tv5 >= 512) {
+          if(t < 256) {
+            s_tmp1[t] += s_tmp1[t + 256];
+            s_tmp2[t] += s_tmp2[t + 256];
+          }
+          __syncthreads();
+        }
+        {
+          if (t < 128) {
+            s_tmp1[t] += s_tmp1[t + 128];
+            s_tmp2[t] += s_tmp2[t + 128];
+          }
+          __syncthreads();
+        }
+        {
+          if (t < 64) {
+            s_tmp1[t] += s_tmp1[t + 64];
+            s_tmp2[t] += s_tmp2[t + 64];
+          }
+          __syncthreads();
+        }
+
+        if (t < 32) {
+          s_tmp1[t] += s_tmp1[t + 32];
+          s_tmp2[t] += s_tmp2[t + 32];
+
+          s_tmp1[t] += s_tmp1[t + 16];
+          s_tmp2[t] += s_tmp2[t + 16];
+
+          s_tmp1[t] += s_tmp1[t + 8];
+          s_tmp2[t] += s_tmp2[t + 8];
+
+          s_tmp1[t] += s_tmp1[t + 4];
+          s_tmp2[t] += s_tmp2[t + 4];
+
+          s_tmp1[t] += s_tmp1[t + 2];
+          s_tmp2[t] += s_tmp2[t + 2];
+
+          s_tmp1[t] += s_tmp1[t + 1];
+          s_tmp2[t] += s_tmp2[t + 1];
+        }
+        if (t == 0) {
+          result[blockIdx.x] = s_tmp1[0];
+          result[blockIdx.x + k] = s_tmp2[0];
+        }
+      }
+
+
+      /**
+      * @brief AXPY y = y - x*alpha where alpha is [k x 1], needed in 1 and 2 synch GMRES
+      *
+      * @tparam Tmaxk
+      *
+      * @param[in]  N      -
+      * @param[in]  k      -
+      * @param[in]  x_data -
+      * @param[out] y_data -
+      * @param[in]  alpha  -
+      */
+      template <size_t Tmaxk = 1024>
+      __global__ void massAxpy3_kernel(index_type N,
+                                      index_type k,
+                                      const real_type* x_data,
+                                      real_type* y_data,
+                                      const real_type* alpha)
+      {
+        index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+        index_type t = threadIdx.x;
+
+        __shared__ real_type s_alpha[Tmaxk];
+        if (t < k) {
+          s_alpha[t] = alpha[t];
         }
         __syncthreads();
+        while (i < N) {
+          real_type temp = 0.0;
+          for(index_type j = 0; j < k; ++j) {
+            temp += x_data[j * N + i] * s_alpha[j];
+          }
+          y_data[i] -= temp;
+          i += (blockDim.x*gridDim.x);
+        }
       }
+
+      /**
+      * @brief Pass through matrix rows and sum each as \sum_{j=1}^m abs(a_{ij})
+      *
+      * @param[in]  n      -
+      * @param[in]  nnz    -
+      * @param[in]  a_ia   -
+      * @param[in]  a_val  -
+      * @param[out] result -
+      */
+      __global__ void matrixInfNormPart1(const index_type n,
+                                        const index_type nnz,
+                                        const index_type* a_ia,
+                                        const real_type* a_val,
+                                        real_type* result)
       {
+        index_type idx = blockIdx.x*blockDim.x + threadIdx.x;
+        while (idx < n) {
+          real_type sum = 0.0;
+          for (index_type i = a_ia[idx]; i < a_ia[idx+1]; ++i) {
+            sum = sum + fabs(a_val[i]);
+          }
+          result[idx] = sum;
+          idx += (blockDim.x * gridDim.x);
+        }
+      }
+
+      /**
+      * @brief
+      *
+      * @param[in]  n      - vector size
+      * @param[in]  input  -
+      * @param[out] result -
+      */
+      __global__ void vectorInfNorm(const index_type n,
+                                    const real_type* input,
+                                    real_type* result)
+      {
+
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        volatile __shared__ real_type s_max[1024];
+        index_type t = threadIdx.x;
+        index_type bsize = blockDim.x;
+        real_type local_max = 0.0;
+        if (idx < n) {
+          local_max = fabs(input[idx]);
+        }
+
+        idx += (blockDim.x*gridDim.x);
+
+        while (idx < n) {
+          local_max = fmax(fabs(input[idx]), local_max);
+          idx += (blockDim.x * gridDim.x);
+        }
+        s_max[t] = local_max;
+        __syncthreads();
+
+        // reduction
+
+        if (bsize >= 1024) {
+          if(t < 512) {
+            s_max[t] = fmax(s_max[t], s_max[t + 512]);
+          }
+          __syncthreads();
+        }
+        if (bsize >= 512) {
+          if(t < 256) {
+            s_max[t] = fmax(s_max[t], s_max[t + 256]);
+          }
+          __syncthreads();
+        }
+
+        if (bsize >= 256) {
+          if(t < 128) {
+            s_max[t] = fmax(s_max[t], s_max[t + 128]);
+          }
+          __syncthreads();
+        }
+
+        if (bsize >= 128) {
+          if(t < 64) {
+            s_max[t] = fmax(s_max[t], s_max[t + 64]);
+          }
+          __syncthreads();
+        }
+        //unroll for last warp
         if (t < 64) {
-          s_tmp1[t] += s_tmp1[t + 64];
-          s_tmp2[t] += s_tmp2[t + 64];
-        }
-        __syncthreads();
-      }
-
-      if (t < 32) {
-        s_tmp1[t] += s_tmp1[t + 32];
-        s_tmp2[t] += s_tmp2[t + 32];
-
-        s_tmp1[t] += s_tmp1[t + 16];
-        s_tmp2[t] += s_tmp2[t + 16];
-
-        s_tmp1[t] += s_tmp1[t + 8];
-        s_tmp2[t] += s_tmp2[t + 8];
-
-        s_tmp1[t] += s_tmp1[t + 4];
-        s_tmp2[t] += s_tmp2[t + 4];
-
-        s_tmp1[t] += s_tmp1[t + 2];
-        s_tmp2[t] += s_tmp2[t + 2];
-
-        s_tmp1[t] += s_tmp1[t + 1];
-        s_tmp2[t] += s_tmp2[t + 1];
-      }
-      if (t == 0) {
-        result[blockIdx.x] = s_tmp1[0];
-        result[blockIdx.x + k] = s_tmp2[0];
-      }
-    }
-
-
-    /**
-     * @brief AXPY y = y - x*alpha where alpha is [k x 1], needed in 1 and 2 synch GMRES
-     *
-     * @tparam Tmaxk
-     *
-     * @param[in]  N      -
-     * @param[in]  k      -
-     * @param[in]  x_data -
-     * @param[out] y_data -
-     * @param[in]  alpha  -
-     */
-    template <size_t Tmaxk = 1024>
-    __global__ void massAxpy3_kernel(index_type N,
-                                    index_type k,
-                                    const real_type* x_data,
-                                    real_type* y_data,
-                                    const real_type* alpha)
-    {
-      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-      index_type t = threadIdx.x;
-
-      __shared__ real_type s_alpha[Tmaxk];
-      if (t < k) {
-        s_alpha[t] = alpha[t];
-      }
-      __syncthreads();
-      while (i < N) {
-        real_type temp = 0.0;
-        for(index_type j = 0; j < k; ++j) {
-          temp += x_data[j * N + i] * s_alpha[j];
-        }
-        y_data[i] -= temp;
-        i += (blockDim.x*gridDim.x);
-      }
-    }
-
-    /**
-     * @brief Pass through matrix rows and sum each as \sum_{j=1}^m abs(a_{ij})
-     *
-     * @param[in]  n      -
-     * @param[in]  nnz    -
-     * @param[in]  a_ia   -
-     * @param[in]  a_val  -
-     * @param[out] result -
-     */
-    __global__ void matrixInfNormPart1(const index_type n,
-                                       const index_type nnz,
-                                       const index_type* a_ia,
-                                       const real_type* a_val,
-                                       real_type* result)
-    {
-      index_type idx = blockIdx.x*blockDim.x + threadIdx.x;
-      while (idx < n) {
-        real_type sum = 0.0;
-        for (index_type i = a_ia[idx]; i < a_ia[idx+1]; ++i) {
-          sum = sum + fabs(a_val[i]);
-        }
-        result[idx] = sum;
-        idx += (blockDim.x * gridDim.x);
-      }
-    }
-
-    /**
-     * @brief
-     *
-     * @param[in]  n      - vector size
-     * @param[in]  input  -
-     * @param[out] result -
-     */
-    __global__ void vectorInfNorm(const index_type n,
-                                  const real_type* input,
-                                  real_type* result)
-    {
-
-      index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
-
-      volatile __shared__ real_type s_max[1024];
-      index_type t = threadIdx.x;
-      index_type bsize = blockDim.x;
-      real_type local_max = 0.0;
-      if (idx < n) {
-        local_max = fabs(input[idx]);
-      }
-
-      idx += (blockDim.x*gridDim.x);
-
-      while (idx < n) {
-        local_max = fmax(fabs(input[idx]), local_max);
-        idx += (blockDim.x * gridDim.x);
-      }
-      s_max[t] = local_max;
-      __syncthreads();
-
-      // reduction
-
-      if (bsize >= 1024) {
-        if(t < 512) {
-          s_max[t] = fmax(s_max[t], s_max[t + 512]);
-        }
-        __syncthreads();
-      }
-      if (bsize >= 512) {
-        if(t < 256) {
-          s_max[t] = fmax(s_max[t], s_max[t + 256]);
-        }
-        __syncthreads();
-      }
-
-      if (bsize >= 256) {
-        if(t < 128) {
-          s_max[t] = fmax(s_max[t], s_max[t + 128]);
-        }
-        __syncthreads();
-      }
-
-      if (bsize >= 128) {
-        if(t < 64) {
           s_max[t] = fmax(s_max[t], s_max[t + 64]);
+          s_max[t] = fmax(s_max[t], s_max[t + 32]);
+          s_max[t] = fmax(s_max[t], s_max[t + 16]);
+          s_max[t] = fmax(s_max[t], s_max[t + 8]);
+          s_max[t] = fmax(s_max[t], s_max[t + 4]);
+          s_max[t] = fmax(s_max[t], s_max[t + 2]);
+          s_max[t] = fmax(s_max[t], s_max[t + 1]);
+
         }
-        __syncthreads();
-      }
-      //unroll for last warp
-      if (t < 64) {
-        s_max[t] = fmax(s_max[t], s_max[t + 64]);
-        s_max[t] = fmax(s_max[t], s_max[t + 32]);
-        s_max[t] = fmax(s_max[t], s_max[t + 16]);
-        s_max[t] = fmax(s_max[t], s_max[t + 8]);
-        s_max[t] = fmax(s_max[t], s_max[t + 4]);
-        s_max[t] = fmax(s_max[t], s_max[t + 2]);
-        s_max[t] = fmax(s_max[t], s_max[t + 1]);
-
-      }
-      if (t == 0) {
-        index_type bid = blockIdx.x;
-        index_type gid = gridDim.x;
-        result[blockIdx.x] = s_max[0];
-      }
-    }
-
-
-    /**
-     * @brief
-     *
-     * @param n           - vector size
-     * @param perm_vector - permutation map
-     * @param vec_in      - input vector
-     * @param vec_out     - permuted vector
-     */
-    __global__ void permuteVectorP_kernel(const index_type n,
-                                          const index_type* perm_vector,
-                                          const real_type* vec_in,
-                                          real_type* vec_out)
-    {
-      //one thread per vector entry, pass through rows
-      index_type idx = blockIdx.x*blockDim.x + threadIdx.x;
-      while (idx < n) {
-        vec_out[idx] = vec_in[perm_vector[idx]];
-        idx += (blockDim.x * gridDim.x);
-      }
-    }
-
-    /**
-     * @brief
-     *
-     * @param n           - vector size
-     * @param perm_vector - permutation map
-     * @param vec_in      - input vector
-     * @param vec_out     - permuted vector
-     */
-    __global__ void permuteVectorQ_kernel(const index_type n,
-                                          const index_type* perm_vector,
-                                          const real_type* vec_in,
-                                          real_type* vec_out)
-    {
-      //one thread per vector entry, pass through rows
-      index_type idx = blockIdx.x*blockDim.x + threadIdx.x;
-      while (idx < n) {
-        vec_out[perm_vector[idx]] = vec_in[idx];
-        idx += (blockDim.x * gridDim.x);
-      }
-    }
-
-    /**
-     * @brief Scales a csr matrix on the left by a diagonal matrix
-     *
-     * @param[in]  n      - number of rows in the matrix
-     * @param[in]  a_row_ptr - row pointers (CSR storage)
-     * @param[in, out]  a_val    - values (CSR storage). Changes in place.
-     * @param[in]  d_val    - diagonal values
-     *
-     * @todo Decide how to allow user to configure grid and block sizes.
-     */
-    __global__ void leftScale(index_type n,
-                                  const index_type* a_row_ptr,
-                                  real_type* a_val,
-                                  const real_type* d_val)
-    {
-      // Get row index from thread and block indices
-      index_type row = blockIdx.x * blockDim.x + threadIdx.x;
-
-      // Check if the thread's row is within matrix bounds
-      if (row < n) {
-        // Get the start and end positions for this row in the CSR format
-        index_type row_start = a_row_ptr[row];
-        index_type row_end = a_row_ptr[row + 1];
-
-        // Get the scaling factor for this row from the diagonal matrix
-        real_type scale = d_val[row];
-
-        // Scale all non-zero elements in this row
-        for (index_type i = row_start; i < row_end; i++) {
-          a_val[i] *= scale;
+        if (t == 0) {
+          index_type bid = blockIdx.x;
+          index_type gid = gridDim.x;
+          result[blockIdx.x] = s_max[0];
         }
       }
-    }
 
-    /**
-     * @brief Scales a csr matrix on the right by a diagonal matrix
-     *
-     * @param[in]  n      - number of rows in the matrix
-     * @param[in]  a_row_ptr - row pointers (CSR storage)
-     * @param[in]  a_col_ind - column indices (CSR storage)
-     * @param[in, out]  a_val    - values (CSR storage). Changes in place.
-     * @param[in]  d_val    - diagonal values
-     *
-     * @todo Decide how to allow user to configure grid and block sizes.
-     */
-    __global__ void rightScale(index_type n,
-                                   const index_type* a_row_ptr,
-                                   const index_type* a_col_ind,
-                                   real_type* a_val,
-                                   const real_type* d_val)
-    {
-      // Get row index from thread and block indices
-      index_type row = blockIdx.x * blockDim.x + threadIdx.x;
 
-      // Check if the thread's row is within matrix bounds
-      if (row < n) {
-        // Get the start and end positions for this row in the CSR format
-        index_type row_start = a_row_ptr[row];
-        index_type row_end = a_row_ptr[row + 1];
-
-        // Scale all non-zero elements in this row
-        for (index_type i = row_start; i < row_end; i++) {
-          a_val[i] *= d_val[a_col_ind[i]];
+      /**
+      * @brief
+      *
+      * @param n           - vector size
+      * @param perm_vector - permutation map
+      * @param vec_in      - input vector
+      * @param vec_out     - permuted vector
+      */
+      __global__ void permuteVectorP_kernel(const index_type n,
+                                            const index_type* perm_vector,
+                                            const real_type* vec_in,
+                                            real_type* vec_out)
+      {
+        //one thread per vector entry, pass through rows
+        index_type idx = blockIdx.x*blockDim.x + threadIdx.x;
+        while (idx < n) {
+          vec_out[idx] = vec_in[perm_vector[idx]];
+          idx += (blockDim.x * gridDim.x);
         }
       }
+
+      /**
+      * @brief
+      *
+      * @param n           - vector size
+      * @param perm_vector - permutation map
+      * @param vec_in      - input vector
+      * @param vec_out     - permuted vector
+      */
+      __global__ void permuteVectorQ_kernel(const index_type n,
+                                            const index_type* perm_vector,
+                                            const real_type* vec_in,
+                                            real_type* vec_out)
+      {
+        //one thread per vector entry, pass through rows
+        index_type idx = blockIdx.x*blockDim.x + threadIdx.x;
+        while (idx < n) {
+          vec_out[perm_vector[idx]] = vec_in[idx];
+          idx += (blockDim.x * gridDim.x);
+        }
+      }
+
+      /**
+      * @brief Scales a csr matrix on the left by a diagonal matrix
+      *
+      * @param[in]  n      - number of rows in the matrix
+      * @param[in]  a_row_ptr - row pointers (CSR storage)
+      * @param[in, out]  a_val    - values (CSR storage). Changes in place.
+      * @param[in]  d_val    - diagonal values
+      *
+      * @todo Decide how to allow user to configure grid and block sizes.
+      */
+      __global__ void leftScale(index_type n,
+                                    const index_type* a_row_ptr,
+                                    real_type* a_val,
+                                    const real_type* d_val)
+      {
+        // Get row index from thread and block indices
+        index_type row = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the thread's row is within matrix bounds
+        if (row < n) {
+          // Get the start and end positions for this row in the CSR format
+          index_type row_start = a_row_ptr[row];
+          index_type row_end = a_row_ptr[row + 1];
+
+          // Get the scaling factor for this row from the diagonal matrix
+          real_type scale = d_val[row];
+
+          // Scale all non-zero elements in this row
+          for (index_type i = row_start; i < row_end; i++) {
+            a_val[i] *= scale;
+          }
+        }
+      }
+
+      /**
+      * @brief Scales a csr matrix on the right by a diagonal matrix
+      *
+      * @param[in]  n      - number of rows in the matrix
+      * @param[in]  a_row_ptr - row pointers (CSR storage)
+      * @param[in]  a_col_ind - column indices (CSR storage)
+      * @param[in, out]  a_val    - values (CSR storage). Changes in place.
+      * @param[in]  d_val    - diagonal values
+      *
+      * @todo Decide how to allow user to configure grid and block sizes.
+      */
+      __global__ void rightScale(index_type n,
+                                    const index_type* a_row_ptr,
+                                    const index_type* a_col_ind,
+                                    real_type* a_val,
+                                    const real_type* d_val)
+      {
+        // Get row index from thread and block indices
+        index_type row = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the thread's row is within matrix bounds
+        if (row < n) {
+          // Get the start and end positions for this row in the CSR format
+          index_type row_start = a_row_ptr[row];
+          index_type row_end = a_row_ptr[row + 1];
+
+          // Scale all non-zero elements in this row
+          for (index_type i = row_start; i < row_end; i++) {
+            a_val[i] *= d_val[a_col_ind[i]];
+          }
+        }
+      }
+
+      /**
+      * @brief Scales a vector by a diagonal matrix
+      *
+      * @param[in]  n      - size of the vector
+      * @param[in, out] vec - vector to be scaled. Changes in place.
+      * @param[in]  d_val  - diagonal values
+      *
+      * @todo Decide how to allow user to configure grid and block sizes.
+      */
+      __global__ void scale(index_type n,
+                                      const real_type* diag,
+                                      real_type* vec)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n) {
+          // Scale the vector element by the corresponding diagonal value
+          vec[idx] *= diag[idx];
+        }
+      }
+
+    } // namespace kernels
+
+    //
+    // Kernel wrappers
+    //
+
+    /**
+    * @brief Computes result = mvec^T * [vec1 vec2]
+    *
+    * @param n      - size of vectors vec1, vec2
+    * @param i      -
+    * @param vec1   - (n x 1) vector
+    * @param vec2   - (n x 1) vector
+    * @param mvec   - (n x (i+1)) multivector
+    * @param result - ((i+1) x 2) multivector
+    *
+    * @todo Input data should be `const`.
+    * @todo Is it coincidence that the block size is equal to the default
+    * value of Tv5?
+    * @todo Should we use dynamic shared memory here instead?
+    */
+    void mass_inner_product_two_vectors(index_type n,
+                                        index_type i,
+                                        real_type* vec1,
+                                        real_type* vec2,
+                                        real_type* mvec,
+                                        real_type* result)
+    {
+      hipLaunchKernelGGL(kernels::MassIPTwoVec_kernel,
+                        dim3(i),
+                        dim3(1024),
+                        0,
+                        0,
+                        vec1,
+                        vec2,
+                        mvec,
+                        result,
+                        i,
+                        n);
     }
 
     /**
-     * @brief Scales a vector by a diagonal matrix
-     *
-     * @param[in]  n      - size of the vector
-     * @param[in, out] vec - vector to be scaled. Changes in place.
-     * @param[in]  d_val  - diagonal values
-     *
-     * @todo Decide how to allow user to configure grid and block sizes.
-     */
-    __global__ void scale(index_type n,
-                                    const real_type* diag,
-                                    real_type* vec)
+    * @brief Computes y := y - x*alpha
+    *
+    * @param[in]  n     - vector size
+    * @param[in]  i     - number of vectors in the multivector
+    * @param[in]  x     - (n x (i+1)) multivector
+    * @param[out] y     - (n x (i+1)) multivector
+    * @param[in]  alpha - ((i+1) x 1) vector
+    */
+    void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha)
     {
-      // Get the index of the element to be processed
-      index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
-
-      // Check if the index is within bounds
-      if (idx < n) {
-        // Scale the vector element by the corresponding diagonal value
-        vec[idx] *= diag[idx];
-      }
+      hipLaunchKernelGGL(kernels::massAxpy3_kernel,
+                        dim3((n + 384 - 1) / 384),
+                        dim3(384),
+                        0,
+                        0,
+                        n,
+                        i,
+                        x,
+                        y,
+                        alpha);
     }
 
-  } // namespace kernels
+    /**
+    * @brief
+    *
+    * @param[in]  n      -
+    * @param[in]  nnz    -
+    * @param[in]  a_ia   -
+    * @param[in]  a_val  -
+    * @param[out] result -
+    *
+    * @todo Decide how to allow user to configure grid and block sizes.
+    */
+    void matrix_row_sums(index_type n,
+                        index_type nnz,
+                        index_type* a_ia,
+                        real_type* a_val,
+                        real_type* result)
+    {
+      hipLaunchKernelGGL(kernels::matrixInfNormPart1, dim3(1000), dim3(1024), 0, 0, n, nnz, a_ia, a_val, result);
+    }
 
-  //
-  // Kernel wrappers
-  //
+    /**
+    * @brief
+    *
+    * @param n      -
+    * @param input  -
+    * @param buffer -
+    * @param result -
+    *
+    * @todo Decide how to allow user to configure grid and block sizes.
+    */
+    void vector_inf_norm(index_type n,
+                        real_type* input,
+                        real_type* buffer,
+                        real_type* result)
+    {
+      hipLaunchKernelGGL(kernels::vectorInfNorm, dim3(1024), dim3(1024), 0, 0, n, input, buffer);
+      hipDeviceSynchronize();
+      hipLaunchKernelGGL(kernels::vectorInfNorm, dim3(1), dim3(1024), 0, 0, 1024, buffer, buffer);
+      hipMemcpy(result, buffer, sizeof(real_type) * 1, hipMemcpyDeviceToHost);
+    }
 
-  /**
-   * @brief Computes result = mvec^T * [vec1 vec2]
-   *
-   * @param n      - size of vectors vec1, vec2
-   * @param i      -
-   * @param vec1   - (n x 1) vector
-   * @param vec2   - (n x 1) vector
-   * @param mvec   - (n x (i+1)) multivector
-   * @param result - ((i+1) x 2) multivector
-   *
-   * @todo Input data should be `const`.
-   * @todo Is it coincidence that the block size is equal to the default
-   * value of Tv5?
-   * @todo Should we use dynamic shared memory here instead?
-   */
-  void mass_inner_product_two_vectors(index_type n,
-                                      index_type i,
-                                      real_type* vec1,
-                                      real_type* vec2,
-                                      real_type* mvec,
-                                      real_type* result)
-  {
-    hipLaunchKernelGGL(kernels::MassIPTwoVec_kernel,
-                       dim3(i),
-                       dim3(1024),
-                       0,
-                       0,
-                       vec1,
-                       vec2,
-                       mvec,
-                       result,
-                       i,
-                       n);
-  }
+    /**
+    * @brief
+    *
+    * @param n           - vector size
+    * @param perm_vector - permutation map
+    * @param vec_in      - input vector
+    * @param vec_out     - permuted vector
+    */
+    void permuteVectorP(index_type n,
+                        index_type* perm_vector,
+                        real_type* vec_in,
+                        real_type* vec_out)
+    {
+      hipLaunchKernelGGL(kernels::permuteVectorP_kernel,
+                        dim3(1000),
+                        dim3(1024),
+                        0,
+                        0,
+                        n,
+                        perm_vector,
+                        vec_in,
+                        vec_out);
+    }
 
-  /**
-   * @brief Computes y := y - x*alpha
-   *
-   * @param[in]  n     - vector size
-   * @param[in]  i     - number of vectors in the multivector
-   * @param[in]  x     - (n x (i+1)) multivector
-   * @param[out] y     - (n x (i+1)) multivector
-   * @param[in]  alpha - ((i+1) x 1) vector
-   */
-  void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha)
-  {
-    hipLaunchKernelGGL(kernels::massAxpy3_kernel,
-                       dim3((n + 384 - 1) / 384),
-                       dim3(384),
-                       0,
-                       0,
-                       n,
-                       i,
-                       x,
-                       y,
-                       alpha);
-  }
+    /**
+    * @brief
+    *
+    * @param n           - vector size
+    * @param perm_vector - permutation map
+    * @param vec_in      - input vector
+    * @param vec_out     - permuted vector
+    */
+    void permuteVectorQ(index_type n,
+                        index_type* perm_vector,
+                        real_type* vec_in,
+                        real_type* vec_out)
+    {
+      hipLaunchKernelGGL(kernels::permuteVectorQ_kernel,
+                        dim3(1000),
+                        dim3(1024),
+                        0,
+                        0,
+                        n,
+                        perm_vector,
+                        vec_in,
+                        vec_out);
+    }
 
-  /**
-   * @brief
-   *
-   * @param[in]  n      -
-   * @param[in]  nnz    -
-   * @param[in]  a_ia   -
-   * @param[in]  a_val  -
-   * @param[out] result -
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void matrix_row_sums(index_type n,
-                       index_type nnz,
-                       index_type* a_ia,
-                       real_type* a_val,
-                       real_type* result)
-  {
-    hipLaunchKernelGGL(kernels::matrixInfNormPart1, dim3(1000), dim3(1024), 0, 0, n, nnz, a_ia, a_val, result);
-  }
-
-  /**
-   * @brief
-   *
-   * @param n      -
-   * @param input  -
-   * @param buffer -
-   * @param result -
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void vector_inf_norm(index_type n,
-                       real_type* input,
-                       real_type* buffer,
-                       real_type* result)
-  {
-    hipLaunchKernelGGL(kernels::vectorInfNorm, dim3(1024), dim3(1024), 0, 0, n, input, buffer);
-    hipDeviceSynchronize();
-    hipLaunchKernelGGL(kernels::vectorInfNorm, dim3(1), dim3(1024), 0, 0, 1024, buffer, buffer);
-    hipMemcpy(result, buffer, sizeof(real_type) * 1, hipMemcpyDeviceToHost);
-  }
-
-  /**
-   * @brief
-   *
-   * @param n           - vector size
-   * @param perm_vector - permutation map
-   * @param vec_in      - input vector
-   * @param vec_out     - permuted vector
-   */
-  void permuteVectorP(index_type n,
-                      index_type* perm_vector,
-                      real_type* vec_in,
-                      real_type* vec_out)
-  {
-    hipLaunchKernelGGL(kernels::permuteVectorP_kernel,
-                       dim3(1000),
-                       dim3(1024),
-                       0,
-                       0,
-                       n,
-                       perm_vector,
-                       vec_in,
-                       vec_out);
-  }
-
-  /**
-   * @brief
-   *
-   * @param n           - vector size
-   * @param perm_vector - permutation map
-   * @param vec_in      - input vector
-   * @param vec_out     - permuted vector
-   */
-  void permuteVectorQ(index_type n,
-                      index_type* perm_vector,
-                      real_type* vec_in,
-                      real_type* vec_out)
-  {
-    hipLaunchKernelGGL(kernels::permuteVectorQ_kernel,
-                       dim3(1000),
-                       dim3(1024),
-                       0,
-                       0,
-                       n,
-                       perm_vector,
-                       vec_in,
-                       vec_out);
-  }
-
-  /**
-   * @brief Wrapper that scales a csr matrix on the left by a diagonal matrix
-   *
-   * @param[in]  n      - number of rows in the matrix
-   * @param[in]  a_row_ptr - row pointers (CSR storage)
-   * @param[in, out]  a_val    - values (CSR storage). Changes in place.
-   * @param[in]  d_val    - diagonal values
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void leftScaleWrapper(index_type n,
-                     const index_type* a_row_ptr,
-                     real_type* a_val,
-                     const real_type* d_val)
-  {
-    // Define block size and number of blocks
-    const int block_size = 1;
-    int num_blocks = (n + block_size - 1) / block_size;
-    // Launch the kernel
-    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
-  }
-
-  /**
-   * @brief Wrapper that scales a csr matrix on the right by a diagonal matrix
-   *
-   * @param[in]  n      - number of rows in the matrix
-   * @param[in]  a_row_ptr - row pointers (CSR storage)
-   * @param[in]  a_col_ind - column indices (CSR storage)
-   * @param[in, out]  a_val    - values (CSR storage). Changes in place.
-   * @param[in]  d_val    - diagonal values
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void rightScaleWrapper(index_type n,
+    /**
+    * @brief Wrapper that scales a csr matrix on the left by a diagonal matrix
+    *
+    * @param[in]  n      - number of rows in the matrix
+    * @param[in]  a_row_ptr - row pointers (CSR storage)
+    * @param[in, out]  a_val    - values (CSR storage). Changes in place.
+    * @param[in]  d_val    - diagonal values
+    *
+    * @todo Decide how to allow user to configure grid and block sizes.
+    */
+    void leftScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
-                      const index_type* a_col_ind,
                       real_type* a_val,
                       const real_type* d_val)
-  {
-    // Define block size and number of blocks
-    const int block_size = 256;
-    int num_blocks = (n + block_size - 1) / block_size;
-    // Launch the kernel
-    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
-  }
+    {
+      // Define block size and number of blocks
+      const int block_size = 1;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
+    }
 
-  /**
-   * @brief Wrapper that scales a vector by a diagonal matrix
-   *
-   * @param[in]  n      - size of the vector
-   * @param[in, out] vec - vector to be scaled. Changes in place.
-   * @param[in]  d_val  - diagonal values
-   *
-   * @todo Decide how to allow user to configure grid and block sizes.
-   */
-  void scaleWrapper(index_type n,
-                      const real_type* diag,
-                      real_type* vec)
-  {
-    // Define block size and number of blocks
-    const int block_size = 256;
-    int num_blocks = (n + block_size - 1) / block_size;
-    // Launch the kernel
-    kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
-  }
+    /**
+    * @brief Wrapper that scales a csr matrix on the right by a diagonal matrix
+    *
+    * @param[in]  n      - number of rows in the matrix
+    * @param[in]  a_row_ptr - row pointers (CSR storage)
+    * @param[in]  a_col_ind - column indices (CSR storage)
+    * @param[in, out]  a_val    - values (CSR storage). Changes in place.
+    * @param[in]  d_val    - diagonal values
+    *
+    * @todo Decide how to allow user to configure grid and block sizes.
+    */
+    void rightScaleWrapper(index_type n,
+                        const index_type* a_row_ptr,
+                        const index_type* a_col_ind,
+                        real_type* a_val,
+                        const real_type* d_val)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    }
 
+    /**
+    * @brief Wrapper that scales a vector by a diagonal matrix
+    *
+    * @param[in]  n      - size of the vector
+    * @param[in, out] vec - vector to be scaled. Changes in place.
+    * @param[in]  d_val  - diagonal values
+    *
+    * @todo Decide how to allow user to configure grid and block sizes.
+    */
+    void scaleWrapper(index_type n,
+                        const real_type* diag,
+                        real_type* vec)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
+    }
+  } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -132,10 +132,10 @@ namespace ReSolve {
       */
       template <size_t Tmaxk = 1024>
       __global__ void massAxpy3_kernel(index_type N,
-                                      index_type k,
-                                      const real_type* x_data,
-                                      real_type* y_data,
-                                      const real_type* alpha)
+                                       index_type k,
+                                       const real_type* x_data,
+                                       real_type* y_data,
+                                       const real_type* alpha)
       {
         index_type i = blockIdx.x * blockDim.x + threadIdx.x;
         index_type t = threadIdx.x;
@@ -165,10 +165,10 @@ namespace ReSolve {
       * @param[out] result -
       */
       __global__ void matrixInfNormPart1(const index_type n,
-                                        const index_type nnz,
-                                        const index_type* a_ia,
-                                        const real_type* a_val,
-                                        real_type* result)
+                                         const index_type nnz,
+                                         const index_type* a_ia,
+                                         const real_type* a_val,
+                                         real_type* result)
       {
         index_type idx = blockIdx.x*blockDim.x + threadIdx.x;
         while (idx < n) {
@@ -312,9 +312,9 @@ namespace ReSolve {
       * @todo Decide how to allow user to configure grid and block sizes.
       */
       __global__ void leftScale(index_type n,
-                                    const index_type* a_row_ptr,
-                                    real_type* a_val,
-                                    const real_type* d_val)
+                                const index_type* a_row_ptr,
+                                real_type* a_val,
+                                const real_type* d_val)
       {
         // Get row index from thread and block indices
         index_type row = blockIdx.x * blockDim.x + threadIdx.x;
@@ -347,10 +347,10 @@ namespace ReSolve {
       * @todo Decide how to allow user to configure grid and block sizes.
       */
       __global__ void rightScale(index_type n,
-                                    const index_type* a_row_ptr,
-                                    const index_type* a_col_ind,
-                                    real_type* a_val,
-                                    const real_type* d_val)
+                                 const index_type* a_row_ptr,
+                                 const index_type* a_col_ind,
+                                 real_type* a_val,
+                                 const real_type* d_val)
       {
         // Get row index from thread and block indices
         index_type row = blockIdx.x * blockDim.x + threadIdx.x;
@@ -396,16 +396,16 @@ namespace ReSolve {
                                         real_type* result)
     {
       hipLaunchKernelGGL(kernels::MassIPTwoVec_kernel,
-                        dim3(i),
-                        dim3(1024),
-                        0,
-                        0,
-                        vec1,
-                        vec2,
-                        mvec,
-                        result,
-                        i,
-                        n);
+                         dim3(i),
+                         dim3(1024),
+                         0,
+                         0,
+                         vec1,
+                         vec2,
+                         mvec,
+                         result,
+                         i,
+                         n);
     }
 
     /**
@@ -420,15 +420,15 @@ namespace ReSolve {
     void mass_axpy(index_type n, index_type i, real_type* x, real_type* y, real_type* alpha)
     {
       hipLaunchKernelGGL(kernels::massAxpy3_kernel,
-                        dim3((n + 384 - 1) / 384),
-                        dim3(384),
-                        0,
-                        0,
-                        n,
-                        i,
-                        x,
-                        y,
-                        alpha);
+                         dim3((n + 384 - 1) / 384),
+                         dim3(384),
+                         0,
+                         0,
+                         n,
+                         i,
+                         x,
+                         y,
+                         alpha);
     }
 
     /**
@@ -486,14 +486,14 @@ namespace ReSolve {
                         real_type* vec_out)
     {
       hipLaunchKernelGGL(kernels::permuteVectorP_kernel,
-                        dim3(1000),
-                        dim3(1024),
-                        0,
-                        0,
-                        n,
-                        perm_vector,
-                        vec_in,
-                        vec_out);
+                         dim3(1000),
+                         dim3(1024),
+                         0,
+                         0,
+                         n,
+                         perm_vector,
+                         vec_in,
+                         vec_out);
     }
 
     /**
@@ -510,14 +510,14 @@ namespace ReSolve {
                         real_type* vec_out)
     {
       hipLaunchKernelGGL(kernels::permuteVectorQ_kernel,
-                        dim3(1000),
-                        dim3(1024),
-                        0,
-                        0,
-                        n,
-                        perm_vector,
-                        vec_in,
-                        vec_out);
+                         dim3(1000),
+                         dim3(1024),
+                         0,
+                         0,
+                         n,
+                         perm_vector,
+                         vec_in,
+                         vec_out);
     }
 
     /**
@@ -554,10 +554,10 @@ namespace ReSolve {
     * @todo Decide how to allow user to configure grid and block sizes.
     */
     void rightScale(index_type n,
-                        const index_type* a_row_ptr,
-                        const index_type* a_col_ind,
-                        real_type* a_val,
-                        const real_type* d_val)
+                    const index_type* a_row_ptr,
+                    const index_type* a_col_ind,
+                    real_type* a_val,
+                    const real_type* d_val)
     {
       // Define block size and number of blocks
       const int block_size = 256;

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -310,7 +310,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void leftScale(index_type n,
+    __global__ void leftScaleKernel(index_type n,
                                   const index_type* a_row_ptr,
                                   real_type* a_val,
                                   const real_type* d_val)
@@ -345,7 +345,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void rightScale(index_type n,
+    __global__ void rightScaleKernel(index_type n,
                                    const index_type* a_row_ptr,
                                    const index_type* a_col_ind,
                                    real_type* a_val,
@@ -376,7 +376,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    __global__ void vectorScale(index_type n,
+    __global__ void vectorScaleKernel(index_type n,
                                     const real_type* diag,
                                     real_type* vec)
     {
@@ -553,7 +553,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void leftScale(index_type n,
+  void leftScaleWrapper(index_type n,
                      const index_type* a_row_ptr,
                      real_type* a_val,
                      const real_type* d_val)
@@ -562,7 +562,7 @@ namespace ReSolve {
     const int block_size = 1;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::leftScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
+    kernels::leftScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_val, d_val);
   }
 
   /**
@@ -576,7 +576,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void rightScale(index_type n,
+  void rightScaleWrapper(index_type n,
                       const index_type* a_row_ptr,
                       const index_type* a_col_ind,
                       real_type* a_val,
@@ -586,7 +586,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::rightScale<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
+    kernels::rightScaleKernel<<<num_blocks, block_size>>>(n, a_row_ptr, a_col_ind, a_val, d_val);
   }
 
   /**
@@ -598,7 +598,7 @@ namespace ReSolve {
    *
    * @todo Decide how to allow user to configure grid and block sizes.
    */
-  void vectorScale(index_type n,
+  void vectorScaleWrapper(index_type n,
                       const real_type* diag,
                       real_type* vec)
   {
@@ -606,7 +606,7 @@ namespace ReSolve {
     const int block_size = 256;
     int num_blocks = (n + block_size - 1) / block_size;
     // Launch the kernel
-    kernels::vectorScale<<<num_blocks, block_size>>>(n, diag, vec);
+    kernels::vectorScaleKernel<<<num_blocks, block_size>>>(n, diag, vec);
   }
 
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -17,5 +17,6 @@ namespace ReSolve
   {
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
+    void scale(index_type n, const real_type* diag, real_type* vec);
   }
 }

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -15,7 +15,7 @@ namespace ReSolve
 {
   namespace hip
   {
-    void hip_set_array_const(index_type n, real_type val, real_type* arr);
-    void hipAddConst(index_type n, real_type val, real_type* arr);
+    void setArrayConst(index_type n, real_type val, real_type* arr);
+    void addConst(index_type n, real_type val, real_type* arr);
   }
 }

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -13,6 +13,9 @@
 
 namespace ReSolve
 {
-  void hip_set_array_const(index_type n, real_type c, real_type* v);
-  void hipAddConst(index_type n, real_type val, real_type* arr);
+  namespace hip
+  {
+    void hip_set_array_const(index_type n, real_type val, real_type* arr);
+    void hipAddConst(index_type n, real_type val, real_type* arr);
+  }
 }

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -48,7 +48,7 @@ namespace ReSolve {
       }
     } // namespace kernels
 
-    void hip_set_array_const(index_type n, real_type c, real_type* v)
+    void setArrayConst(index_type n, real_type c, real_type* v)
     {
       index_type num_blocks;
       index_type block_size = 512;
@@ -56,7 +56,7 @@ namespace ReSolve {
       hipLaunchKernelGGL(kernels::set_array_to_const, dim3(num_blocks), dim3(block_size), 0, 0, n, c, v);
     }
 
-    void hipAddConst(index_type n, real_type val, real_type* arr)
+    void addConst(index_type n, real_type val, real_type* arr)
     {
       index_type num_blocks;
       index_type block_size = 512;

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -46,6 +46,29 @@ namespace ReSolve {
           arr[i] += val;
         }
       }
+
+      /**
+      * @brief Scales a vector by a diagonal matrix
+      *
+      * @param[in]  n      - size of the vector
+      * @param[in, out] vec - vector to be scaled. Changes in place.
+      * @param[in]  d_val  - diagonal values
+      *
+      * @todo Decide how to allow user to configure grid and block sizes.
+      */
+      __global__ void scale(index_type n,
+                                      const real_type* diag,
+                                      real_type* vec)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n) {
+          // Scale the vector element by the corresponding diagonal value
+          vec[idx] *= diag[idx];
+        }
+      }
     } // namespace kernels
 
     void setArrayConst(index_type n, real_type c, real_type* v)
@@ -62,6 +85,26 @@ namespace ReSolve {
       index_type block_size = 512;
       num_blocks = (n + block_size - 1) / block_size;
       hipLaunchKernelGGL(kernels::addConst, dim3(num_blocks), dim3(block_size), 0, 0, n, val, arr);
+    }
+
+    /**
+    * @brief Wrapper that scales a vector by a diagonal matrix
+    *
+    * @param[in]  n      - size of the vector
+    * @param[in, out] vec - vector to be scaled. Changes in place.
+    * @param[in]  d_val  - diagonal values
+    *
+    * @todo Decide how to allow user to configure grid and block sizes.
+    */
+    void scale(index_type n,
+                        const real_type* diag,
+                        real_type* vec)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
     }
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -15,53 +15,53 @@
 #include <resolve/hip/hipVectorKernels.h>
 
 namespace ReSolve {
+  namespace hip {
+    namespace kernels {
 
-  namespace kernels {
-
-    __global__ void set_array_to_const(index_type n, real_type val, real_type* arr)
-    {
-      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-      while (i < n)
+      __global__ void set_array_to_const(index_type n, real_type val, real_type* arr)
       {
-        arr[i] = val;
-        i += blockDim.x * gridDim.x;
+        index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+        while (i < n)
+        {
+          arr[i] = val;
+          i += blockDim.x * gridDim.x;
+        }
       }
+
+      /**
+      * @brief HIP kernel that adds a constant to each element of an array.
+      *
+      * @param[in]       n   - length of the array
+      * @param[in]       val - the value to add to each element
+      * @param[in, out]  arr - a pointer to the array
+      *
+      * @pre  `arr` is allocated to size `n`
+      * @post `val` is added to each element of `arr`
+      */
+      __global__ void addConst(index_type n, real_type val, real_type* arr)
+      {
+        index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+        if(i < n)
+        {
+          arr[i] += val;
+        }
+      }
+    } // namespace kernels
+
+    void hip_set_array_const(index_type n, real_type c, real_type* v)
+    {
+      index_type num_blocks;
+      index_type block_size = 512;
+      num_blocks = (n + block_size - 1) / block_size;
+      hipLaunchKernelGGL(kernels::set_array_to_const, dim3(num_blocks), dim3(block_size), 0, 0, n, c, v);
     }
 
-    /**
-     * @brief HIP kernel that adds a constant to each element of an array.
-     *
-     * @param[in]       n   - length of the array
-     * @param[in]       val - the value to add to each element
-     * @param[in, out]  arr - a pointer to the array
-     *
-     * @pre  `arr` is allocated to size `n`
-     * @post `val` is added to each element of `arr`
-     */
-    __global__ void addConst(index_type n, real_type val, real_type* arr)
+    void hipAddConst(index_type n, real_type val, real_type* arr)
     {
-      index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-      if(i < n)
-      {
-        arr[i] += val;
-      }
+      index_type num_blocks;
+      index_type block_size = 512;
+      num_blocks = (n + block_size - 1) / block_size;
+      hipLaunchKernelGGL(kernels::addConst, dim3(num_blocks), dim3(block_size), 0, 0, n, val, arr);
     }
-  } // namespace kernels
-
-  void hip_set_array_const(index_type n, real_type c, real_type* v)
-  {
-    index_type num_blocks;
-    index_type block_size = 512;
-    num_blocks = (n + block_size - 1) / block_size;
-    hipLaunchKernelGGL(kernels::set_array_to_const, dim3(num_blocks), dim3(block_size), 0, 0, n, c, v);
-  }
-
-  void hipAddConst(index_type n, real_type val, real_type* arr)
-  {
-    index_type num_blocks;
-    index_type block_size = 512;
-    num_blocks = (n + block_size - 1) / block_size;
-    hipLaunchKernelGGL(kernels::addConst, dim3(num_blocks), dim3(block_size), 0, 0, n, val, arr);
-  }
-
+  } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -48,7 +48,7 @@ namespace ReSolve {
       }
 
       /**
-      * @brief Scales a vector by a diagonal matrix
+      * @brief Scales a vector by a diagonal matrix represented by a vector
       *
       * @param[in]  n      - size of the vector
       * @param[in, out] vec - vector to be scaled. Changes in place.

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -8,6 +8,7 @@
 #include <resolve/workspace/LinAlgWorkspace.hpp>
 #include "MatrixHandler.hpp"
 #include "MatrixHandlerCpu.hpp"
+#include "MatrixHandlerImpl.hpp"
 
 #ifdef RESOLVE_USE_CUDA
 #include "MatrixHandlerCuda.hpp"
@@ -266,7 +267,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandler::leftDiagonalScale(vector_type* diag, matrix::Csr* A, memory::MemorySpace memspace)
+  int MatrixHandler::leftScale(vector_type* diag, matrix::Csr* A, memory::MemorySpace memspace)
   {
     assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
            "Matrix has to be in CSR format for left diagonal scaling.\n");
@@ -277,10 +278,10 @@ namespace ReSolve {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->leftDiagonalScale(diag, A);
+        return cpuImpl_->leftScale(diag, A);
         break;
       case DEVICE:
-        return devImpl_->leftDiagonalScale(diag, A);
+        return devImpl_->leftScale(diag, A);
         break;
     }
     return 1;
@@ -300,7 +301,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandler::rightDiagonalScale(matrix::Csr* A, vector_type* diag, memory::MemorySpace memspace)
+  int MatrixHandler::rightScale(matrix::Csr* A, vector_type* diag, memory::MemorySpace memspace)
   {
     assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW &&
            "Matrix has to be in CSR format for right diagonal scaling.\n");
@@ -310,10 +311,10 @@ namespace ReSolve {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->rightDiagonalScale(A, diag);
+        return cpuImpl_->rightScale(A, diag);
         break;
       case DEVICE:
-        return devImpl_->rightDiagonalScale(A, diag);
+        return devImpl_->rightScale(A, diag);
         break;
     }
     return 1;
@@ -331,7 +332,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandler::vectorDiagonalScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace)
+  int MatrixHandler::vectorScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace)
   {
     assert(diag->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
     assert(diag->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
@@ -339,10 +340,10 @@ namespace ReSolve {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->vectorDiagonalScale(diag, vec);
+        return cpuImpl_->vectorScale(diag, vec);
         break;
       case DEVICE:
-        return devImpl_->vectorDiagonalScale(diag, vec);
+        return devImpl_->vectorScale(diag, vec);
         break;
     }
     return 1;

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -321,35 +321,6 @@ namespace ReSolve {
   }
 
   /**
-   * @brief Scale a vector by a diagonal matrix
-   *
-   * @param[in] diag - vector representing the diagonal matrix
-   * @param[in,out] vec - vector to be scaled
-   * @param[in] memspace - Device where the operation is computed
-   *
-   * @pre The diagonal vector must be of the same size as the vector.
-   * @invariant diag
-   *
-   * @return 0 if successful, 1 otherwise
-   */
-  int MatrixHandler::vectorScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace)
-  {
-    assert(diag->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
-    assert(diag->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
-    assert(vec->getData(memspace) != nullptr && "Vector data is null!\n");
-    using namespace ReSolve::memory;
-    switch (memspace) {
-      case HOST:
-        return cpuImpl_->vectorScale(diag, vec);
-        break;
-      case DEVICE:
-        return devImpl_->vectorScale(diag, vec);
-        break;
-    }
-    return 1;
-  }
-
-  /**
    * @brief Add a constant to the nonzero values of a csr matrix.
    * @param[in,out] A - Sparse matrix
    * @param[in] alpha - scalar parameter

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -56,11 +56,11 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At, memory::MemorySpace memspace);
 
-      int leftDiagonalScale(vector_type* diag, matrix::Csr* A, memory::MemorySpace memspace);
+      int leftScale(vector_type* diag, matrix::Csr* A, memory::MemorySpace memspace);
 
-      int rightDiagonalScale(matrix::Csr* A, vector_type* diag, memory::MemorySpace memspace);
+      int rightScale(matrix::Csr* A, vector_type* diag, memory::MemorySpace memspace);
 
-      int vectorDiagonalScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace);
+      int vectorScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace);
 
       void addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
 

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -60,8 +60,6 @@ namespace ReSolve {
 
       int rightScale(matrix::Csr* A, vector_type* diag, memory::MemorySpace memspace);
 
-      int vectorScale(vector_type* diag, vector_type* vec, memory::MemorySpace memspace);
-
       void addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
 
       /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -347,30 +347,6 @@ namespace ReSolve
   }
 
   /**
-   * @brief Scale a vector by a diagonal matrix
-   *
-   * @param[in] diag - vector representing the diagonal matrix
-   * @param[in, out] vec - vector to be scaled
-   *
-   * @pre The diagonal vector must be of the same size as the vector.
-   * @invariant diag
-   *
-   * @return 0 if successful, 1 otherwise
-   */
-  int MatrixHandlerCpu::vectorScale(vector_type* diag, vector_type* vec)
-  {
-    real_type* diag_data = diag->getData(memory::HOST);
-    real_type* vec_data = vec->getData(memory::HOST);
-    index_type n = vec->getSize();
-
-    for (index_type i = 0; i < n; ++i) {
-      vec_data[i] *= diag_data[i];
-    }
-    vec->setDataUpdated(memory::HOST);
-    return 0;
-  }
-
-  /**
    * @brief Add a constant to all nonzero values in the matrix
    *
    * @param[in, out] A - matrix

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -304,7 +304,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCpu::leftDiagonalScale(vector_type* diag, matrix::Csr* A)
+  int MatrixHandlerCpu::leftScale(vector_type* diag, matrix::Csr* A)
   {
     real_type* diag_data = diag->getData(memory::HOST);
     index_type* rowPtrA = A->getRowData(memory::HOST);
@@ -331,7 +331,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCpu::rightDiagonalScale(matrix::Csr* A, vector_type* diag)
+  int MatrixHandlerCpu::rightScale(matrix::Csr* A, vector_type* diag)
   {
     real_type* diag_data = diag->getData(memory::HOST);
     index_type* rowPtrA = A->getRowData(memory::HOST);
@@ -357,7 +357,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCpu::vectorDiagonalScale(vector_type* diag, vector_type* vec)
+  int MatrixHandlerCpu::vectorScale(vector_type* diag, vector_type* vec)
   {
     real_type* diag_data = diag->getData(memory::HOST);
     real_type* vec_data = vec->getData(memory::HOST);

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -43,8 +43,6 @@ namespace ReSolve {
 
       int rightScale(matrix::Csr* A, vector_type* diag) override;
 
-      int vectorScale(vector_type* diag, vector_type* vec) override;
-
       int addConst(matrix::Sparse* A, real_type alpha) override;
 
       virtual int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -39,11 +39,11 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
-      int leftDiagonalScale(vector_type* diag, matrix::Csr* A) override;
+      int leftScale(vector_type* diag, matrix::Csr* A) override;
 
-      int rightDiagonalScale(matrix::Csr* A, vector_type* diag) override;
+      int rightScale(matrix::Csr* A, vector_type* diag) override;
 
-      int vectorDiagonalScale(vector_type* diag, vector_type* vec) override;
+      int vectorScale(vector_type* diag, vector_type* vec) override;
 
       int addConst(matrix::Sparse* A, real_type alpha) override;
 

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -181,10 +181,10 @@ namespace ReSolve {
     }
 
     cuda::matrix_row_sums(A->getNumRows(),
-                    A->getNnz(),
-                    A->getRowData(memory::DEVICE),
-                    A->getValues(memory::DEVICE),
-                    d_r);
+                          A->getNnz(),
+                          A->getRowData(memory::DEVICE),
+                          A->getValues(memory::DEVICE),
+                          d_r);
 
     int status = cusolverSpDnrminf(workspace_->getCusolverSpHandle(),
                                    A->getNumRows(),

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -345,7 +345,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    leftScale(n, a_row_ptr, a_vals, diag_data);
+    leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -370,7 +370,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -338,7 +338,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCuda::leftDiagonalScale(vector_type* diag, matrix::Csr* A)
+  int MatrixHandlerCuda::leftScale(vector_type* diag, matrix::Csr* A)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     index_type* a_row_ptr = A->getRowData(memory::DEVICE);
@@ -363,7 +363,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCuda::rightDiagonalScale(matrix::Csr* A, vector_type* diag)
+  int MatrixHandlerCuda::rightScale(matrix::Csr* A, vector_type* diag)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     index_type* a_row_ptr = A->getRowData(memory::DEVICE);
@@ -386,7 +386,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerCuda::vectorDiagonalScale(vector_type* diag, vector_type* vec)
+  int MatrixHandlerCuda::vectorScale(vector_type* diag, vector_type* vec)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -8,6 +8,7 @@
 #include <resolve/workspace/LinAlgWorkspaceCUDA.hpp>
 #include "MatrixHandlerCuda.hpp"
 #include <resolve/cuda/cudaKernels.h>
+#include <resolve/cuda/cudaVectorKernels.h>
 #include <resolve/cusolver_defs.hpp> // needed for inf nrm
 
 namespace ReSolve {
@@ -179,7 +180,7 @@ namespace ReSolve {
       workspace_->setDr(d_r);
     }
 
-    matrix_row_sums(A->getNumRows(),
+    cuda::matrix_row_sums(A->getNumRows(),
                     A->getNnz(),
                     A->getRowData(memory::DEVICE),
                     A->getValues(memory::DEVICE),
@@ -345,7 +346,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
+    cuda::leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -370,7 +371,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    cuda::rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -387,7 +388,7 @@ namespace ReSolve {
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();
-    cudaAddConst(nnz, alpha, values);
+    cuda::cudaAddConst(nnz, alpha, values);
     return 0;
   }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -376,28 +376,6 @@ namespace ReSolve {
   }
 
   /**
-   * @brief Scale a vector by a diagonal matrix
-   *
-   * @param[in] diag - vector representing the diagonal matrix
-   * @param[in, out] vec - vector to be scaled
-   *
-   * @pre The diagonal vector must be of the same size as the vector.
-   * @invariant diag
-   *
-   * @return 0 if successful, 1 otherwise
-   */
-  int MatrixHandlerCuda::vectorScale(vector_type* diag, vector_type* vec)
-  {
-    real_type* diag_data = diag->getData(memory::DEVICE);
-    real_type* vec_data = vec->getData(memory::DEVICE);
-    index_type n = vec->getSize();
-    vectorDiagScale(n, diag_data, vec_data);
-    vec->setDataUpdated(memory::DEVICE);
-    return 0;
-  }
-
-
-  /**
    * @brief Add a constant to all nonzero values in the matrix
    *
    * @param[in, out] A - matrix

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -345,7 +345,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    leftDiagScale(n, a_row_ptr, a_vals, diag_data);
+    leftScale(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -370,7 +370,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    rightDiagScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -346,7 +346,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    cuda::leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
+    cuda::leftScale(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -371,7 +371,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    cuda::rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    cuda::rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -388,7 +388,7 @@ namespace ReSolve {
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();
-    cuda::cudaAddConst(nnz, alpha, values);
+    cuda::addConst(nnz, alpha, values);
     return 0;
   }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -45,10 +45,10 @@ namespace ReSolve {
       int rightScale(matrix::Csr* A, vector_type* diag) override;
 
       virtual int matvec(matrix::Sparse* A,
-                 vector_type* vec_x,
-                 vector_type* vec_result,
-                 const real_type* alpha,
-                 const real_type* beta) override;
+                         vector_type* vec_x,
+                         vector_type* vec_result,
+                         const real_type* alpha,
+                         const real_type* beta) override;
       virtual int matrixInfNorm(matrix::Sparse* A, real_type* norm) override;
 
       void setValuesChanged(bool isValuesChanged) override;

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -44,8 +44,6 @@ namespace ReSolve {
 
       int rightScale(matrix::Csr* A, vector_type* diag) override;
 
-      int vectorScale(vector_type* diag, vector_type* vec) override;
-
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,
                  vector_type* vec_result,

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -40,11 +40,11 @@ namespace ReSolve {
 
       int addConst(matrix::Sparse* A, real_type alpha) override;
 
-      int leftDiagonalScale(vector_type* diag, matrix::Csr* A) override;
+      int leftScale(vector_type* diag, matrix::Csr* A) override;
 
-      int rightDiagonalScale(matrix::Csr* A, vector_type* diag) override;
+      int rightScale(matrix::Csr* A, vector_type* diag) override;
 
-      int vectorDiagonalScale(vector_type* diag, vector_type* vec) override;
+      int vectorScale(vector_type* diag, vector_type* vec) override;
 
       virtual int matvec(matrix::Sparse* A,
                  vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -320,7 +320,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerHip::leftDiagonalScale(vector_type* diag, matrix::Csr* A)
+  int MatrixHandlerHip::leftScale(vector_type* diag, matrix::Csr* A)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     index_type* a_row_ptr = A->getRowData(memory::DEVICE);
@@ -345,7 +345,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerHip::rightDiagonalScale(matrix::Csr* A, vector_type* diag)
+  int MatrixHandlerHip::rightScale(matrix::Csr* A, vector_type* diag)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     index_type* a_row_ptr = A->getRowData(memory::DEVICE);
@@ -370,7 +370,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int MatrixHandlerHip::vectorDiagonalScale(vector_type* diag, vector_type* vec)
+  int MatrixHandlerHip::vectorScale(vector_type* diag, vector_type* vec)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -303,7 +303,7 @@ namespace ReSolve {
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();
-    hip::hipAddConst(nnz, alpha, values);
+    hip::addConst(nnz, alpha, values);
     return 0;
   }
 
@@ -327,7 +327,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    hip::leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
+    hip::leftScale(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -352,7 +352,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    hip::rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    hip::rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -169,14 +169,14 @@ namespace ReSolve {
     }
 
     mem_.deviceSynchronize();
-    matrix_row_sums(A->getNumRows(),
+    hip::matrix_row_sums(A->getNumRows(),
                     A->getNnz(),
                     A->getRowData(memory::DEVICE),
                     A->getValues(memory::DEVICE),
                     d_r);
     mem_.deviceSynchronize();
 
-    vector_inf_norm(A->getNumRows(),
+    hip::vector_inf_norm(A->getNumRows(),
                     d_r,
                     workspace_->getNormBuffer(),
                     norm);
@@ -303,7 +303,7 @@ namespace ReSolve {
   {
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz = A->getNnz();
-    hipAddConst(nnz, alpha, values);
+    hip::hipAddConst(nnz, alpha, values);
     return 0;
   }
 
@@ -327,7 +327,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
+    hip::leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -352,7 +352,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    hip::rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -88,15 +88,15 @@ namespace ReSolve {
       rocsparse_create_mat_info(&infoA);
 
       status = rocsparse_dcsrmv_analysis(handle_rocsparse,
-                                          rocsparse_operation_none,
-                                          A->getNumRows(),
-                                          A->getNumColumns(),
-                                          A->getNnz(),
-                                          descrA,
-                                          A->getValues( memory::DEVICE),
-                                          A->getRowData(memory::DEVICE),
-                                          A->getColData(memory::DEVICE),
-                                          infoA);
+                                         rocsparse_operation_none,
+                                         A->getNumRows(),
+                                         A->getNumColumns(),
+                                         A->getNnz(),
+                                         descrA,
+                                         A->getValues( memory::DEVICE),
+                                         A->getRowData(memory::DEVICE),
+                                         A->getColData(memory::DEVICE),
+                                         infoA);
       error_sum += status;
       mem_.deviceSynchronize();
 
@@ -171,16 +171,16 @@ namespace ReSolve {
 
     mem_.deviceSynchronize();
     hip::matrix_row_sums(A->getNumRows(),
-                    A->getNnz(),
-                    A->getRowData(memory::DEVICE),
-                    A->getValues(memory::DEVICE),
-                    d_r);
+                         A->getNnz(),
+                         A->getRowData(memory::DEVICE),
+                         A->getValues(memory::DEVICE),
+                         d_r);
     mem_.deviceSynchronize();
 
     hip::vector_inf_norm(A->getNumRows(),
-                    d_r,
-                    workspace_->getNormBuffer(),
-                    norm);
+                         d_r,
+                         workspace_->getNormBuffer(),
+                         norm);
     return 0;
   }
 
@@ -262,13 +262,13 @@ namespace ReSolve {
       // allocate transpose buffer
       size_t bufferSize;
       status = rocsparse_csr2csc_buffer_size(workspace_->getRocsparseHandle(),
-                                           m,
-                                           n,
-                                           nnz,
-                                           A->getRowData(memory::DEVICE),
-                                           A->getColData(memory::DEVICE),
-                                           rocsparse_action_numeric,
-                                           &bufferSize);
+                                             m,
+                                             n,
+                                             nnz,
+                                             A->getRowData(memory::DEVICE),
+                                             A->getColData(memory::DEVICE),
+                                             rocsparse_action_numeric,
+                                             &bufferSize);
       error_sum += status;
       workspace_->setTransposeBufferWorkspace(bufferSize);
     }

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -357,27 +357,4 @@ namespace ReSolve {
     return 0;
   }
 
-  /**
-   * @brief Scale a vector by a diagonal matrix in HIP
-   *
-   * @param[in]  diag - vector representing the diagonal matrix
-   * @param[in, out]  vec - vector to be scaled
-   *
-   * @pre The diagonal vector must be of the same size as the vector.
-   * @pre vec is unscaled
-   * @post vec is scaled
-   * @invariant diag
-   *
-   * @return 0 if successful, 1 otherwise
-   */
-  int MatrixHandlerHip::vectorScale(vector_type* diag, vector_type* vec)
-  {
-    real_type* diag_data = diag->getData(memory::DEVICE);
-    real_type* vec_data = vec->getData(memory::DEVICE);
-    index_type n = vec->getSize();
-    vectorDiagScale(n, diag_data, vec_data);
-    vec->setDataUpdated(memory::DEVICE);
-    return 0;
-  }
-
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -327,7 +327,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    leftScale(n, a_row_ptr, a_vals, diag_data);
+    leftScaleWrapper(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -352,7 +352,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    rightScaleWrapper(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -7,6 +7,7 @@
 #include <resolve/matrix/Csr.hpp>
 #include <resolve/workspace/LinAlgWorkspaceHIP.hpp>
 #include <resolve/hip/hipKernels.h>
+#include <resolve/hip/hipVectorKernels.h>
 #include "MatrixHandlerHip.hpp"
 
 namespace ReSolve {

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -327,7 +327,7 @@ namespace ReSolve {
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
     // check values in A and diag
-    leftDiagScale(n, a_row_ptr, a_vals, diag_data);
+    leftScale(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }
@@ -352,7 +352,7 @@ namespace ReSolve {
     index_type* a_col_idx = A->getColData(memory::DEVICE);
     real_type*  a_vals = A->getValues( memory::DEVICE);
     index_type n = A->getNumRows();
-    rightDiagScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
+    rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -39,11 +39,11 @@ namespace ReSolve {
 
       int transpose(matrix::Csr* A, matrix::Csr* At) override;
 
-      int leftDiagonalScale(vector_type* diag, matrix::Csr* A) override;
+      int leftScale(vector_type* diag, matrix::Csr* A) override;
 
-      int rightDiagonalScale(matrix::Csr* A, vector_type* diag) override;
+      int rightScale(matrix::Csr* A, vector_type* diag) override;
 
-      int vectorDiagonalScale(vector_type* diag, vector_type* vec) override;
+      int vectorScale(vector_type* diag, vector_type* vec) override;
 
       int addConst(matrix::Sparse* A, real_type alpha) override;
       virtual int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -43,8 +43,6 @@ namespace ReSolve {
 
       int rightScale(matrix::Csr* A, vector_type* diag) override;
 
-      int vectorScale(vector_type* diag, vector_type* vec) override;
-
       int addConst(matrix::Sparse* A, real_type alpha) override;
       virtual int matvec(matrix::Sparse* A,
                          vector_type* vec_x,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -40,8 +40,6 @@ namespace ReSolve {
 
       virtual int rightScale(matrix::Csr* A, vector_type* diag) = 0;
 
-      virtual int vectorScale(vector_type* diag, vector_type* vec) = 0;
-
       virtual int addConst(matrix::Sparse* A, real_type alpha) = 0;
 
       virtual int matvec(matrix::Sparse* A,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -36,11 +36,11 @@ namespace ReSolve {
 
       virtual int transpose(matrix::Csr* A, matrix::Csr* At) = 0;
 
-      virtual int leftDiagonalScale(vector_type* diag, matrix::Csr* A) = 0;
+      virtual int leftScale(vector_type* diag, matrix::Csr* A) = 0;
 
-      virtual int rightDiagonalScale(matrix::Csr* A, vector_type* diag) = 0;
+      virtual int rightScale(matrix::Csr* A, vector_type* diag) = 0;
 
-      virtual int vectorDiagonalScale(vector_type* diag, vector_type* vec) = 0;
+      virtual int vectorScale(vector_type* diag, vector_type* vec) = 0;
 
       virtual int addConst(matrix::Sparse* A, real_type alpha) = 0;
 

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cmath>
+#include <cassert>
 
 #include <resolve/utilities/logger/Logger.hpp>
 #include <resolve/vector/Vector.hpp>
@@ -264,6 +265,35 @@ namespace ReSolve {
         break;
     }
     res->setDataUpdated(memspace);
+  }
+
+  /**
+   * @brief Scale a vector by a diagonal matrix
+   *
+   * @param[in] diag - vector representing the diagonal matrix
+   * @param[in,out] vec - vector to be scaled
+   * @param[in] memspace - Device where the operation is computed
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @invariant diag
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandler::vectorScale(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace)
+  {
+    assert(diag->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
+    assert(diag->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
+    assert(vec->getData(memspace) != nullptr && "Vector data is null!\n");
+    using namespace ReSolve::memory;
+    switch (memspace) {
+      case HOST:
+        return cpuImpl_->vectorScale(diag, vec);
+        break;
+      case DEVICE:
+        return devImpl_->vectorScale(diag, vec);
+        break;
+    }
+    return 1;
   }
 
   /**

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -279,7 +279,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::vectorScale(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace)
+  int VectorHandler::scale(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace)
   {
     assert(diag->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
     assert(diag->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
@@ -287,10 +287,10 @@ namespace ReSolve {
     using namespace ReSolve::memory;
     switch (memspace) {
       case HOST:
-        return cpuImpl_->vectorScale(diag, vec);
+        return cpuImpl_->scale(diag, vec);
         break;
       case DEVICE:
-        return devImpl_->vectorScale(diag, vec);
+        return devImpl_->scale(diag, vec);
         break;
     }
     return 1;

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -55,6 +55,8 @@ namespace ReSolve { //namespace vector {
                 vector::Vector* x,
                 memory::MemorySpace memspace);
 
+      int vectorScale(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace);
+
       /** infNorm:
        * Returns infinity norm of a vector (i.e., entry with max abs value)
        */ 

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -55,7 +55,7 @@ namespace ReSolve { //namespace vector {
                 vector::Vector* x,
                 memory::MemorySpace memspace);
 
-      int vectorScale(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace);
+      int scale(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace);
 
       /** infNorm:
        * Returns infinity norm of a vector (i.e., entry with max abs value)

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -267,7 +267,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::vectorScale(vector::Vector* diag, vector::Vector* vec)
+  int VectorHandlerCpu::scale(vector::Vector* diag, vector::Vector* vec)
   {
     real_type* diag_data = diag->getData(memory::HOST);
     real_type* vec_data = vec->getData(memory::HOST);

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -259,4 +259,25 @@ namespace ReSolve {
     }
   }
 
+  /** 
+   * @brief Scale a vector by a diagonal matrix
+   * 
+   * @param[in] diag Diagonal vector
+   * @param[in] vec Vector to be scaled
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCpu::vectorScale(vector::Vector* diag, vector::Vector* vec)
+  {
+    real_type* diag_data = diag->getData(memory::HOST);
+    real_type* vec_data = vec->getData(memory::HOST);
+    index_type n = vec->getSize();
+
+    for (index_type i = 0; i < n; ++i) {
+      vec_data[i] *= diag_data[i];
+    }
+    vec->setDataUpdated(memory::HOST);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -52,6 +52,9 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* V,
                         vector::Vector* y,
                         vector::Vector* x);
+
+      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec);
+
     private:
       LinAlgWorkspaceCpu* workspace_;
   };

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -53,7 +53,7 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* y,
                         vector::Vector* x);
 
-      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec);
+      virtual int scale(vector::Vector* diag, vector::Vector* vec);
 
     private:
       LinAlgWorkspaceCpu* workspace_;

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -275,7 +275,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    vectorScale(n, diag_data, vec_data);
+    vectorScaleWrapper(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -275,7 +275,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    vectorDiagScale(n, diag_data, vec_data);
+    vectorScale(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -257,4 +257,27 @@ namespace ReSolve {
     }
   }
 
+  /**
+   * @brief Scale a vector by a diagonal matrix in HIP
+   *
+   * @param[in]  diag - vector representing the diagonal matrix
+   * @param[in, out]  vec - vector to be scaled
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @pre vec is unscaled
+   * @post vec is scaled
+   * @invariant diag
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCuda::vectorScale(vector::Vector* diag, vector::Vector* vec)
+  {
+    real_type* diag_data = diag->getData(memory::DEVICE);
+    real_type* vec_data = vec->getData(memory::DEVICE);
+    index_type n = vec->getSize();
+    vectorDiagScale(n, diag_data, vec_data);
+    vec->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -198,7 +198,7 @@ namespace ReSolve {
   {
     using namespace constants;
     if (k < 200) {
-      mass_axpy(size, k, x->getData(memory::DEVICE), y->getData(memory::DEVICE),alpha->getData(memory::DEVICE));
+      cuda::mass_axpy(size, k, x->getData(memory::DEVICE), y->getData(memory::DEVICE),alpha->getData(memory::DEVICE));
     } else {
       cublasHandle_t handle_cublas =  workspace_->getCublasHandle();
       cublasDgemm(handle_cublas,
@@ -237,7 +237,7 @@ namespace ReSolve {
     using namespace constants;
 
     if (k < 200) {
-      mass_inner_product_two_vectors(size, k, x->getData(memory::DEVICE) , x->getData(1, memory::DEVICE), V->getData(memory::DEVICE), res->getData(memory::DEVICE));
+      cuda::mass_inner_product_two_vectors(size, k, x->getData(memory::DEVICE) , x->getData(1, memory::DEVICE), V->getData(memory::DEVICE), res->getData(memory::DEVICE));
     } else {
       cublasHandle_t handle_cublas =  workspace_->getCublasHandle();
       cublasDgemm(handle_cublas,
@@ -275,7 +275,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    scaleWrapper(n, diag_data, vec_data);
+    cuda::scaleWrapper(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -270,12 +270,12 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::vectorScale(vector::Vector* diag, vector::Vector* vec)
+  int VectorHandlerCuda::scale(vector::Vector* diag, vector::Vector* vec)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    vectorScaleWrapper(n, diag_data, vec_data);
+    scaleWrapper(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -275,7 +275,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    cuda::scaleWrapper(n, diag_data, vec_data);
+    cuda::scale(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -53,6 +53,17 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* V,
                         vector::Vector* y,
                         vector::Vector* x);
+
+      /**
+       * @brief vectorScale: scales a vector by a diagonal matrix
+       * 
+       * @param[in] diag diagonal vector of size n x 1
+       * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
+       * 
+       * @return 0 if successful, 1 otherwise
+       */
+      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec);
+      
     private:
       MemoryHandler mem_; ///< Device memory manager object
       LinAlgWorkspaceCUDA* workspace_;

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -55,14 +55,14 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* x);
 
       /**
-       * @brief vectorScale: scales a vector by a diagonal matrix
+       * @brief scale: scales a vector by a diagonal matrix
        * 
        * @param[in] diag diagonal vector of size n x 1
        * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
        * 
        * @return 0 if successful, 1 otherwise
        */
-      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec);
+      virtual int scale(vector::Vector* diag, vector::Vector* vec);
       
     private:
       MemoryHandler mem_; ///< Device memory manager object

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -255,4 +255,27 @@ namespace ReSolve {
     }
   }
 
+  /**
+   * @brief Scale a vector by a diagonal matrix in HIP
+   *
+   * @param[in]  diag - vector representing the diagonal matrix
+   * @param[in, out]  vec - vector to be scaled
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @pre vec is unscaled
+   * @post vec is scaled
+   * @invariant diag
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int vectorScale(vector::Vector* diag, vector::Vector* vec)
+  {
+    real_type* diag_data = diag->getData(memory::DEVICE);
+    real_type* vec_data = vec->getData(memory::DEVICE);
+    index_type n = vec->getSize();
+    vectorDiagScale(n, diag_data, vec_data);
+    vec->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -273,7 +273,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    vectorScale(n, diag_data, vec_data);
+    vectorScaleWrapper(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -273,7 +273,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    vectorDiagScale(n, diag_data, vec_data);
+    vectorScale(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -268,7 +268,7 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int vectorScale(vector::Vector* diag, vector::Vector* vec)
+  int VectorHandlerHip::vectorScale(vector::Vector* diag, vector::Vector* vec)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -268,12 +268,12 @@ namespace ReSolve {
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::vectorScale(vector::Vector* diag, vector::Vector* vec)
+  int VectorHandlerHip::scale(vector::Vector* diag, vector::Vector* vec)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    vectorScaleWrapper(n, diag_data, vec_data);
+    scaleWrapper(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -89,7 +89,7 @@ namespace ReSolve {
       workspace_->setNormBufferState(true);
     }
     real_type norm;
-    vector_inf_norm(x->getSize(),
+    hip::vector_inf_norm(x->getSize(),
                     x->getData(memory::DEVICE),
                     workspace_->getNormBuffer(),
                     &norm);
@@ -193,7 +193,7 @@ namespace ReSolve {
   {
     using namespace constants;
     if (k < 200) {
-      mass_axpy(size, k, x->getData(memory::DEVICE), y->getData(memory::DEVICE),alpha->getData(memory::DEVICE));
+      hip::mass_axpy(size, k, x->getData(memory::DEVICE), y->getData(memory::DEVICE),alpha->getData(memory::DEVICE));
 
     } else {
       rocblas_handle handle_rocblas =  workspace_->getRocblasHandle();
@@ -234,7 +234,7 @@ namespace ReSolve {
     using namespace constants;
 
     if (k < 200) {
-      mass_inner_product_two_vectors(size, k, x->getData(memory::DEVICE) , x->getData(1, memory::DEVICE), V->getData(memory::DEVICE), res->getData(memory::DEVICE));
+      hip::mass_inner_product_two_vectors(size, k, x->getData(memory::DEVICE) , x->getData(1, memory::DEVICE), V->getData(memory::DEVICE), res->getData(memory::DEVICE));
     } else {
       rocblas_handle handle_rocblas =  workspace_->getRocblasHandle();
       rocblas_dgemm(handle_rocblas,
@@ -273,7 +273,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    scaleWrapper(n, diag_data, vec_data);
+    hip::scaleWrapper(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -273,7 +273,7 @@ namespace ReSolve {
     real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data = vec->getData(memory::DEVICE);
     index_type n = vec->getSize();
-    hip::scaleWrapper(n, diag_data, vec_data);
+    hip::scale(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -52,6 +52,17 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* V,
                         vector::Vector* y,
                         vector::Vector* x);
+
+      /**
+       * @brief vectorScale: scales a vector by a diagonal matrix
+       * 
+       * @param[in] diag diagonal vector of size n x 1
+       * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
+       * 
+       * @return 0 if successful, 1 otherwise
+       */
+      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec);
+
     private:
       LinAlgWorkspaceHIP* workspace_;
       MemoryHandler mem_; ///< Device memory manager object

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -54,14 +54,14 @@ namespace ReSolve { //namespace vector {
                         vector::Vector* x);
 
       /**
-       * @brief vectorScale: scales a vector by a diagonal matrix
+       * @brief scale: scales a vector by a diagonal matrix
        * 
        * @param[in] diag diagonal vector of size n x 1
        * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
        * 
        * @return 0 if successful, 1 otherwise
        */
-      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec);
+      virtual int scale(vector::Vector* diag, vector::Vector* vec);
 
     private:
       LinAlgWorkspaceHIP* workspace_;

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -41,7 +41,7 @@ namespace ReSolve
       virtual void massDot2Vec(index_type size, vector::Vector* V, index_type k, vector::Vector* x, vector::Vector* res) = 0;
 
       // Scale a vector by a diagonal matrix
-      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec) = 0;
+      virtual int scale(vector::Vector* diag, vector::Vector* vec) = 0;
 
       /** gemv:
        * if `transpose = N` (no), `x = beta*x +  alpha*V*y`,

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -40,6 +40,9 @@ namespace ReSolve
       //Size = n
       virtual void massDot2Vec(index_type size, vector::Vector* V, index_type k, vector::Vector* x, vector::Vector* res) = 0;
 
+      // Scale a vector by a diagonal matrix
+      virtual int vectorScale(vector::Vector* diag, vector::Vector* vec) = 0;
+
       /** gemv:
        * if `transpose = N` (no), `x = beta*x +  alpha*V*y`,
        * where `x` is `[n x 1]`, `V` is `[n x k]` and `y` is `[k x 1]`.

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -150,47 +150,53 @@ public:
       return status.report(testname.c_str());
   }
 
-  TestOutcome leftDiagScale(index_type n, index_type m)
+  TestOutcome leftScale(index_type n, index_type m)
   {
     TestStatus status;
     std::string testname(__func__);
     matrix::Csr* A = createRectangularCsrMatrix(n, m);
     vector::Vector diag = createIncrementingVector(n);
-    handler_.leftDiagonalScale(&diag, A, memspace_);
+
+    handler_.leftScale(&diag, A, memspace_);
     if (memspace_ == memory::DEVICE) {
       A->syncData(memory::HOST);
     }
     status *= verifyLeftScaledCsrMatrix(A);
+
     delete A;
     return status.report(testname.c_str());
   }
 
-  TestOutcome rightDiagScale(index_type n, index_type m)
+  TestOutcome rightScale(index_type n, index_type m)
   {
     TestStatus status;
     std::string testname(__func__);
     matrix::Csr* A = createRectangularCsrMatrix(n, m);
     vector::Vector diag = createIncrementingVector(m);
-    handler_.rightDiagonalScale(A, &diag, memspace_);
+
+    handler_.rightScale(A, &diag, memspace_);
     if (memspace_ == memory::DEVICE) {
       A->syncData(memory::HOST);
     }
     status *= verifyRightScaledCsrMatrix(A);
+    
     delete A;
     return status.report(testname.c_str());
   }
 
-  TestOutcome vectorDiagScale(index_type n)
+  TestOutcome vectorScale(index_type n)
   {
     TestStatus status;
     std::string testname(__func__);
     vector::Vector diag = createIncrementingVector(n);
     vector::Vector vec = createIncrementingVector(n);
-    handler_.vectorDiagonalScale(&diag, &vec, memspace_);
+
+    handler_.vectorScale(&diag, &vec, memspace_);
     if (memspace_ == memory::DEVICE) {
       vec.syncData(memory::HOST);
     }
     status *= verifyVectorScaledDiagMatrix(&vec);
+
     return status.report(testname.c_str());
   }
 

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -184,22 +184,6 @@ public:
     return status.report(testname.c_str());
   }
 
-  TestOutcome vectorScale(index_type n)
-  {
-    TestStatus status;
-    std::string testname(__func__);
-    vector::Vector diag = createIncrementingVector(n);
-    vector::Vector vec = createIncrementingVector(n);
-
-    handler_.vectorScale(&diag, &vec, memspace_);
-    if (memspace_ == memory::DEVICE) {
-      vec.syncData(memory::HOST);
-    }
-    status *= verifyVectorScaledDiagMatrix(&vec);
-
-    return status.report(testname.c_str());
-  }
-
 private:
   ReSolve::MatrixHandler& handler_;
   memory::MemorySpace memspace_{memory::HOST};

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -45,13 +45,13 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.transpose(2048, 1024);
   result += test.transpose(1024, 1200);
   result += test.transpose(1200, 1024);
-  result += test.leftDiagScale(1024, 1024);
-  result += test.leftDiagScale(1024, 2048);
-  result += test.leftDiagScale(2048, 1024);
-  result += test.rightDiagScale(1024, 1024);
-  result += test.rightDiagScale(1024, 2048);
-  result += test.rightDiagScale(2048, 1024);
-  result += test.vectorDiagScale(1024);
+  result += test.leftScale(1024, 1024);
+  result += test.leftScale(1024, 2048);
+  result += test.leftScale(2048, 1024);
+  result += test.rightScale(1024, 1024);
+  result += test.rightScale(1024, 2048);
+  result += test.rightScale(2048, 1024);
+  result += test.vectorScale(1024);
   std::cout << "\n";
 }
 

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -51,7 +51,6 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.rightScale(1024, 1024);
   result += test.rightScale(1024, 2048);
   result += test.rightScale(2048, 1024);
-  result += test.vectorScale(1024);
   std::cout << "\n";
 }
 

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -228,15 +228,32 @@ namespace ReSolve {
           vector::Vector diag(N);
           vector::Vector vec(N);
 
+          // diag[i] = i, vec[i] = 3.0
+          // expected result vec[i] = i * 3.0
           diag.allocate(memspace_);
           vec.allocate(memspace_);
 
-          diag.setToConst(2.0, memspace_);
           vec.setToConst(3.0, memspace_);
+
+          real_type* diag_data = new real_type[N];
+          for (index_type i = 1; i <= N; ++i) {
+            diag_data[i] = (real_type)i;
+          }
+          diag.copyDataFrom(diag_data, memory::HOST, memspace_);
+          diag.syncData(memory::DEVICE);
 
           handler_.vectorScale(&diag, &vec, memspace_);
 
-          status *= verifyAnswer(vec, 6.0);
+          vec.syncData(memory::HOST);
+
+          for (index_type i = 1; i <= N; ++i) {
+            if (!isEqual(vec.getData(memory::HOST)[i], (real_type)i * 3.0)) {
+              std::cout << "Solution vector element vec[" << i << "] = " << vec.getData(memory::HOST)[i]
+                << ", expected: " << (real_type)i * 3.0 << "\n";
+              status *= false;
+              break; 
+            }
+          }
 
           return status.report(__func__);
         }

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -221,6 +221,26 @@ namespace ReSolve {
           return status.report(__func__);
         }
 
+        TestOutcome vectorScale(index_type N)
+        {
+          TestStatus status;
+
+          vector::Vector diag(N);
+          vector::Vector vec(N);
+
+          diag.allocate(memspace_);
+          vec.allocate(memspace_);
+
+          diag.setToConst(2.0, memspace_);
+          vec.setToConst(3.0, memspace_);
+
+          handler_.vectorScale(&diag, &vec, memspace_);
+
+          status *= verifyAnswer(vec, 6.0);
+
+          return status.report(__func__);
+        }
+
       private:
         ReSolve::VectorHandler& handler_;
         ReSolve::memory::MemorySpace memspace_{memory::HOST};

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -236,19 +236,21 @@ namespace ReSolve {
           vec.setToConst(3.0, memspace_);
 
           real_type* diag_data = new real_type[N];
-          for (index_type i = 1; i <= N; ++i) {
-            diag_data[i] = (real_type)i;
+          for (index_type i = 0; i < N; ++i) {
+            diag_data[i] = (real_type)(i+1);
           }
-          diag.copyDataFrom(diag_data, memory::HOST, memspace_)
+          diag.copyDataFrom(diag_data, memory::HOST, memspace_);
           
           handler_.vectorScale(&diag, &vec, memspace_);
 
-          vec.syncData(memory::HOST);
+          if (memspace_ == memory::DEVICE) {
+            vec.syncData(memory::HOST);
+          }
 
-          for (index_type i = 1; i <= N; ++i) {
-            if (!isEqual(vec.getData(memory::HOST)[i], (real_type)i * 3.0)) {
+          for (index_type i = 0; i < N; ++i) {
+            if (!isEqual(vec.getData(memory::HOST)[i], (real_type)(i+1) * 3.0)) {
               std::cout << "Solution vector element vec[" << i << "] = " << vec.getData(memory::HOST)[i]
-                << ", expected: " << (real_type)i * 3.0 << "\n";
+                << ", expected: " << (real_type)(i+1) * 3.0 << "\n";
               status *= false;
               break; 
             }

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -239,9 +239,8 @@ namespace ReSolve {
           for (index_type i = 1; i <= N; ++i) {
             diag_data[i] = (real_type)i;
           }
-          diag.copyDataFrom(diag_data, memory::HOST, memspace_);
-          diag.syncData(memory::DEVICE);
-
+          diag.copyDataFrom(diag_data, memory::HOST, memspace_)
+          
           handler_.vectorScale(&diag, &vec, memspace_);
 
           vec.syncData(memory::HOST);

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -221,7 +221,7 @@ namespace ReSolve {
           return status.report(__func__);
         }
 
-        TestOutcome vectorScale(index_type N)
+        TestOutcome scale(index_type N)
         {
           TestStatus status;
 
@@ -241,7 +241,7 @@ namespace ReSolve {
           }
           diag.copyDataFrom(diag_data, memory::HOST, memspace_);
           
-          handler_.vectorScale(&diag, &vec, memspace_);
+          handler_.scale(&diag, &vec, memspace_);
 
           if (memspace_ == memory::DEVICE) {
             vec.syncData(memory::HOST);

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -23,7 +23,7 @@ int main(int, char**)
     result += test.gemv(5000, 10);
     result += test.massAxpy(100, 10);
     result += test.massDot(100, 10);
-    result += test.vectorScale(100);
+    result += test.scale(100);
 
     std::cout << "\n";
   }
@@ -46,7 +46,7 @@ int main(int, char**)
     result += test.massDot(100, 10);
     result += test.massDot(1000, 30);
     result += test.infNorm(1000);
-    result += test.vectorScale(1000);
+    result += test.scale(1000);
 
     std::cout << "\n";
   }
@@ -70,7 +70,7 @@ int main(int, char**)
     result += test.massDot(100, 10);
     result += test.massDot(1000, 30);
     result += test.infNorm(1000);
-    result += test.vectorScale(1000);
+    result += test.scale(1000);
 
     std::cout << "\n";
   }

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -23,6 +23,7 @@ int main(int, char**)
     result += test.gemv(5000, 10);
     result += test.massAxpy(100, 10);
     result += test.massDot(100, 10);
+    result += test.vectorScale(100);
 
     std::cout << "\n";
   }

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -46,6 +46,7 @@ int main(int, char**)
     result += test.massDot(100, 10);
     result += test.massDot(1000, 30);
     result += test.infNorm(1000);
+    result += test.vectorScale(1000);
 
     std::cout << "\n";
   }
@@ -69,6 +70,7 @@ int main(int, char**)
     result += test.massDot(100, 10);
     result += test.massDot(1000, 30);
     result += test.infNorm(1000);
+    result += test.vectorScale(1000);
 
     std::cout << "\n";
   }


### PR DESCRIPTION
## Description
 
Renames the functions to scale a vector by a diagonal matrix, and moves this functionality to `VectorHandler.cpp` rather than `MatrixHandler.cpp`.

Closes #301
 

 ## Proposed changes
 
- Renames `leftDiagonalScale` to `leftScale` and similarly for `rightDiagonalScale` and `vectorScale` in all declarations.
- Moves the `vectorScale` function from `MatrixHandler.hpp` and all derived classes to `VectorHandler.hpp` and its derived classes, as well as moving the test for it.

 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
