### PR TITLE
fix some more memory leaks and add ubsan support to `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ option(RESOLVE_USE_PROFILING "Set profiling tracers in the code" OFF)
 option(RESOLVE_USE_GPU  "Use GPU device for computations" OFF)
 mark_as_advanced(FORCE RESOLVE_USE_GPU)
 
-option(RESOLVE_USE_ASAN "Use LLVM address sanitizer" OFF)
+option(RESOLVE_USE_ASAN "Enable the address sanitizer" OFF)
+option(RESOLVE_USE_UBSAN "Enable the undefined behavior sanitizer" OFF)
 option(RESOLVE_USE_DOXYGEN "Use Doxygen to generate Re::Solve documentation" OFF)
 set(RESOLVE_CTEST_OUTPUT_DIR ${PROJECT_BINARY_DIR} CACHE PATH "Directory where CTest outputs are saved")
 
@@ -113,9 +114,18 @@ else()
   message(STATUS "Not using HIP")
 endif(RESOLVE_USE_HIP)
 
-if (RESOLVE_USE_ASAN)
+if(RESOLVE_USE_ASAN)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+endif()
+
+if(RESOLVE_USE_UBSAN)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined")
 endif()
 
 # The binary dir is already a global include directory

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -449,6 +449,8 @@ namespace ReSolve
     vec_w_ = nullptr;
     delete vec_v_;
     vec_v_ = nullptr;
+    delete vec_x_;
+    vec_x_ = nullptr;
 
     setup_complete_ = false;
     return 0;

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -1,7 +1,9 @@
 #pragma once
+
 #include <algorithm>
 #include <iomanip>
 #include <iterator>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -250,12 +252,12 @@ namespace ReSolve
 
         vec.setToConst(3.0, memspace_);
 
-        real_type* diag_data = new real_type[N];
+        auto diag_data = std::unique_ptr<real_type[]>(new real_type[N]);
         for (index_type i = 0; i < N; ++i)
         {
           diag_data[i] = (real_type) (i + 1);
         }
-        diag.copyDataFrom(diag_data, memory::HOST, memspace_);
+        diag.copyDataFrom(diag_data.get(), memory::HOST, memspace_);
 
         handler_.scale(&diag, &vec, memspace_);
 


### PR DESCRIPTION
## description

fixes a memory leak introduced in `4a7c9847e32d6dade0d07e61db62e8f93dcbf58e` and another in `afdd00f4f2e9bc851daca48191d543e3a0ee5d1b`. adds ubsan support and sets the asan flags in cflags and fortran flags just in case (i didn't find anything by doing this but it may in future code iterations).

 ## checklist

- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 