### PR TITLE
Update Spack and setup CI with asan and ubsan variants

### DIFF
--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -152,10 +152,10 @@ jobs:
         run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh
 
       - name: Test Build
-        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve ctest -VV
+        run: cd $(spack -e . location --build-dir resolve@develop) && spack -e ${OLDPWD} build-env resolve ctest -VV
 
       - name: Test Installation
-        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve make test_install
+        run: cd $(spack -e . location --build-dir resolve@develop) && spack -e ${OLDPWD} build-env resolve make test_install
 
       # Push with force to override existing binaries...
       - name: Push to binaries to buildcache

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -130,38 +130,35 @@ jobs:
               spack: https://binaries.spack.io/develop
           EOF
 
-      - name: Create and activate Spack environment
-        run: spack env create . resolve-spack-env
-
       - name: Configure GHCR mirror
-        run: spack -e resolve-spack-env --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
+        run: spack -e . mirror set --oci-username ${{ env.USERNAME }} --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
 
       - name: Trust keys
-        run: spack -e resolve-spack-env buildcache keys --install --trust
+        run: spack -e . buildcache keys --install --trust
 
       - name: Find external packages
-        run: spack -e resolve-spack-env external find --all
+        run: spack -e . external find --all
 
       - name: Spack develop ReSolve
-        run: spack -e resolve-spack-env develop --path=$(pwd) resolve@develop
+        run: spack -e . develop --path=$(pwd) resolve@develop
 
       - name: Concretize
-        run: spack -e resolve-spack-env concretize
+        run: spack -e . concretize
 
       - name: Install dependencies
-        run: spack -e resolve-spack-env install --no-check-signature --only dependencies
+        run: spack -e . install --no-check-signature --only dependencies
 
       - name: Install package
-        run: spack -e resolve-spack-env install --keep-stage --no-check-signature --no-cache --fresh
+        run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh
 
       - name: Test Build
-        run: cd $(spack -e resolve-spack-env location --build-dir resolve@develop) && spack -e resolve-spack-env build-env resolve ctest -VV"
+        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve ctest -VV
 
       - name: Test Installation
-        run: cd $(spack -e resolve-spack-env location --build-dir resolve@develop) && spack -e resolve-spack-env build-env resolve make test_install
+        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve make test_install
 
       # Push with force to override existing binaries...
       - name: Push to binaries to buildcache
         run: |
-          spack -e resolve-spack-env buildcache push --force --base-image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BASE_VERSION }} --unsigned --update-index local-buildcache
+          spack -e . buildcache push --force --base-image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BASE_VERSION }} --unsigned --update-index local-buildcache
         if: ${{ !cancelled() }}

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -7,7 +7,7 @@ env:
   # Our repo name contains upper case characters, so we can't use ${{ github.repository }}
   IMAGE_NAME: resolve
   USERNAME: resolve-bot
-  BASE_VERSION: ubuntu-22.04-fortran-v0.1.0
+  BASE_VERSION: ubuntu-22.04-fortran-v0.2.0
 
 # Until we remove the need to clone submodules to build, this should on be in PRs
 on: [pull_request]
@@ -99,6 +99,7 @@ jobs:
           - resolve@develop~klu~lusol
           - resolve@develop+klu~lusol
           - resolve@develop+klu+lusol
+          - resolve@develop+asan+klu+lusol+ubsan
 
     name: Build ReSolve with Spack
     steps:

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -130,35 +130,38 @@ jobs:
               spack: https://binaries.spack.io/develop
           EOF
 
+      - name: Create and activate Spack environment
+        run: spack env create . resolve-spack-env
+
       - name: Configure GHCR mirror
-        run: spack -e . mirror set --oci-username ${{ env.USERNAME }} --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
+        run: spack -e resolve-spack-env --oci-password "${{ secrets.GITHUB_TOKEN }}" local-buildcache
 
       - name: Trust keys
-        run: spack -e . buildcache keys --install --trust
+        run: spack -e resolve-spack-env buildcache keys --install --trust
 
       - name: Find external packages
-        run: spack -e . external find --all
+        run: spack -e resolve-spack-env external find --all
 
       - name: Spack develop ReSolve
-        run: spack -e . develop --path=$(pwd) resolve@develop
+        run: spack -e resolve-spack-env develop --path=$(pwd) resolve@develop
 
       - name: Concretize
-        run: spack -e . concretize
+        run: spack -e resolve-spack-env concretize
 
       - name: Install dependencies
-        run: spack -e . install --no-check-signature --only dependencies
+        run: spack -e resolve-spack-env install --no-check-signature --only dependencies
 
       - name: Install package
-        run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh
+        run: spack -e resolve-spack-env install --keep-stage --no-check-signature --no-cache --fresh
 
       - name: Test Build
-        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve ctest -VV
+        run: cd $(spack -e resolve-spack-env location --build-dir resolve@develop) && spack -e resolve-spack-env build-env resolve ctest -VV"
 
       - name: Test Installation
-        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve make test_install
+        run: cd $(spack -e resolve-spack-env location --build-dir resolve@develop) && spack -e resolve-spack-env build-env resolve make test_install
 
       # Push with force to override existing binaries...
       - name: Push to binaries to buildcache
         run: |
-          spack -e . buildcache push --force --base-image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BASE_VERSION }} --unsigned --update-index local-buildcache
+          spack -e resolve-spack-env buildcache push --force --base-image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BASE_VERSION }} --unsigned --update-index local-buildcache
         if: ${{ !cancelled() }}

--- a/.github/workflows/spack_cpu_build.yaml
+++ b/.github/workflows/spack_cpu_build.yaml
@@ -152,10 +152,10 @@ jobs:
         run: spack -e . install --keep-stage --no-check-signature --no-cache --fresh
 
       - name: Test Build
-        run: cd $(spack -e . location --build-dir resolve@develop) && ctest -VV
+        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve ctest -VV
 
       - name: Test Installation
-        run: cd $(spack -e . location --build-dir resolve@develop) && make test_install
+        run: cd $(spack -e . location --build-dir resolve@develop) && spack build-env resolve make test_install
 
       # Push with force to override existing binaries...
       - name: Push to binaries to buildcache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "buildsystem/spack/spack"]
 	path = buildsystem/spack/spack
-	url = https://github.com/cameronrutherford/spack.git
+	url = https://github.com/spack/spack.git
 [submodule "doxygen-awesome-css"]
 	path = docs/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,20 +114,6 @@ else()
   message(STATUS "Not using HIP")
 endif(RESOLVE_USE_HIP)
 
-if(RESOLVE_USE_ASAN)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
-endif()
-
-if(RESOLVE_USE_UBSAN)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined")
-endif()
-
 # The binary dir is already a global include directory
 configure_file(
   ${CMAKE_SOURCE_DIR}/resolve/resolve_defs.hpp.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,12 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "In-source build prohibited.")
 endif()
 
+if (MSVC)
+  set(CMAKE_CXX_FLAGS "/Wall")
+else()
+  set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wpedantic")
+endif()
+
 option(RESOLVE_TEST_WITH_BSUB "Use `jsrun` instead of `mpirun` commands when running tests" OFF)
 option(RESOLVE_USE_KLU  "Use KLU, AMD and COLAMD libraries from SuiteSparse" OFF)
 option(RESOLVE_USE_LUSOL "Build the LUSOL library" OFF)

--- a/buildsystem/spack/frontier/modules/dependencies.sh
+++ b/buildsystem/spack/frontier/modules/dependencies.sh
@@ -75,5 +75,5 @@ module load mpfr/4.2.1-rocmcc-6.3.1-h5arply
 module load openblas/0.3.28-rocmcc-6.3.1-yx5h226
 # suite-sparse@=7.7.0%rocmcc@=6.3.1~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-zen3
 module load suite-sparse/7.7.0-rocmcc-6.3.1-k5bpn4t
-# resolve@=develop%rocmcc@=6.3.1~cuda~ipo+klu+lusol+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ReSolve generator=make arch=linux-sles15-zen3
-## module load resolve/develop-rocmcc-6.3.1-6pmzbco
+# resolve@=develop%rocmcc@=6.3.1+asan~cuda~ipo+klu+lusol+rocm+ubsan amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ReSolve generator=make arch=linux-sles15-zen3
+## module load resolve/develop-rocmcc-6.3.1-uzusuxq

--- a/buildsystem/spack/frontier/modules/dependencies.sh
+++ b/buildsystem/spack/frontier/modules/dependencies.sh
@@ -1,79 +1,79 @@
 module use -a /lustre/orion/stf006/world-shared/nkouk/resolve/spack-install/modules/linux-sles15-zen3
-# cmake@=3.30.5%rocmcc@=6.3.1~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-zen3
-module load cmake/3.30.5-rocmcc-6.3.1-4jn2bjq
+# cmake@=3.30.5%rocmcc@=6.3.1~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release patches=dbc3892 arch=linux-sles15-zen3
+module load cmake/3.30.5-rocmcc-6.3.1-hv4mzvr
 # glibc@=2.38%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load glibc/2.38-rocmcc-6.3.1-hn22erg
+module load glibc/2.38-rocmcc-6.3.1-3hkbcwm
 # gmake@=4.4.1%rocmcc@=6.3.1~guile build_system=generic arch=linux-sles15-zen3
-module load gmake/4.4.1-rocmcc-6.3.1-dtf7cnx
-# hip@=6.3.1%rocmcc@=6.3.1~cuda+rocm build_system=cmake build_type=Release generator=make patches=1f65dfe arch=linux-sles15-zen3
-module load hip/6.3.1-rocmcc-6.3.1-ykh7piu
+module load gmake/4.4.1-rocmcc-6.3.1-pca4j24
+# hip@=6.3.1%rocmcc@=6.3.1~asan~cuda+rocm build_system=cmake build_type=Release generator=make patches=1f65dfe arch=linux-sles15-zen3
+module load hip/6.3.1-rocmcc-6.3.1-ar4rzg2
 # hsa-rocr-dev@=6.3.1%rocmcc@=6.3.1~asan+image+shared build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hsa-rocr-dev/6.3.1-rocmcc-6.3.1-xxxdnpr
+module load hsa-rocr-dev/6.3.1-rocmcc-6.3.1-wwlghld
 # llvm-amdgpu@=6.3.1%rocmcc@=6.3.1~link_llvm_dylib~llvm_dylib+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=b4774ca arch=linux-sles15-zen3
-module load llvm-amdgpu/6.3.1-rocmcc-6.3.1-vtiuud6
-# rocblas@=6.3.1%rocmcc@=6.3.1+tensile amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocblas/6.3.1-rocmcc-6.3.1-3v25znh
-# rocsolver@=6.3.1%rocmcc@=6.3.1+optimal amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocsolver/6.3.1-rocmcc-6.3.1-zt6tvxo
-# rocsparse@=6.3.1%rocmcc@=6.3.1~test amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocsparse/6.3.1-rocmcc-6.3.1-f6dcxbw
+module load llvm-amdgpu/6.3.1-rocmcc-6.3.1-fuu6pxm
+# rocblas@=6.3.1%rocmcc@=6.3.1~asan+tensile amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load rocblas/6.3.1-rocmcc-6.3.1-m3viuwr
+# rocsolver@=6.3.1%rocmcc@=6.3.1~asan+optimal amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load rocsolver/6.3.1-rocmcc-6.3.1-qfyv2cr
+# rocsparse@=6.3.1%rocmcc@=6.3.1~asan~test amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load rocsparse/6.3.1-rocmcc-6.3.1-y3afx76
 # autoconf@=2.72%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load autoconf/2.72-rocmcc-6.3.1-oy4453o
+module load autoconf/2.72-rocmcc-6.3.1-aq7yj4t
 # berkeley-db@=18.1.40%rocmcc@=6.3.1+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-sles15-zen3
-module load berkeley-db/18.1.40-rocmcc-6.3.1-mz4xs4a
+module load berkeley-db/18.1.40-rocmcc-6.3.1-6epjpim
 # libiconv@=1.17%rocmcc@=6.3.1 build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load libiconv/1.17-rocmcc-6.3.1-hvakkfo
+module load libiconv/1.17-rocmcc-6.3.1-pyw3ira
 # diffutils@=3.10%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load diffutils/3.10-rocmcc-6.3.1-n6jzu3b
+module load diffutils/3.10-rocmcc-6.3.1-ltpkf77
 # bzip2@=1.0.8%rocmcc@=6.3.1~debug~pic+shared build_system=generic arch=linux-sles15-zen3
-module load bzip2/1.0.8-rocmcc-6.3.1-gk6oqef
+module load bzip2/1.0.8-rocmcc-6.3.1-u4w6woy
 # pkgconf@=2.2.0%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load pkgconf/2.2.0-rocmcc-6.3.1-wsjynjg
+module load pkgconf/2.2.0-rocmcc-6.3.1-zuhzde2
 # ncurses@=6.5%rocmcc@=6.3.1~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-sles15-zen3
-module load ncurses/6.5-rocmcc-6.3.1-j5podue
+module load ncurses/6.5-rocmcc-6.3.1-4dt7xfj
 # readline@=8.2%rocmcc@=6.3.1 build_system=autotools patches=bbf97f1 arch=linux-sles15-zen3
-module load readline/8.2-rocmcc-6.3.1-zmzjziy
+module load readline/8.2-rocmcc-6.3.1-hsjqzow
 # gdbm@=1.23%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load gdbm/1.23-rocmcc-6.3.1-tiixxjd
-# zlib-ng@=2.1.6%rocmcc@=6.3.1+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-sles15-zen3
-module load zlib-ng/2.1.6-rocmcc-6.3.1-s5htcyp
-# perl@=5.38.2%rocmcc@=6.3.1+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-sles15-zen3
-module load perl/5.38.2-rocmcc-6.3.1-nyloggh
+module load gdbm/1.23-rocmcc-6.3.1-s5d7ejr
+# zlib-ng@=2.2.1%rocmcc@=6.3.1+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-sles15-zen3
+module load zlib-ng/2.2.1-rocmcc-6.3.1-d2zifpp
+# perl@=5.40.0%rocmcc@=6.3.1+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-zen3
+module load perl/5.40.0-rocmcc-6.3.1-2zihsrz
 # automake@=1.16.5%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load automake/1.16.5-rocmcc-6.3.1-hoteu52
+module load automake/1.16.5-rocmcc-6.3.1-ienwcxn
 # findutils@=4.9.0%rocmcc@=6.3.1 build_system=autotools patches=440b954 arch=linux-sles15-zen3
-module load findutils/4.9.0-rocmcc-6.3.1-qssfjtq
+module load findutils/4.9.0-rocmcc-6.3.1-doylhaz
 # libsigsegv@=2.14%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load libsigsegv/2.14-rocmcc-6.3.1-wtj6uyw
+module load libsigsegv/2.14-rocmcc-6.3.1-ilsqgla
 # m4@=1.4.19%rocmcc@=6.3.1+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-zen3
-module load m4/1.4.19-rocmcc-6.3.1-jvy4rfl
+module load m4/1.4.19-rocmcc-6.3.1-mcpzhki
 # libtool@=2.4.7%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load libtool/2.4.7-rocmcc-6.3.1-ouy6mmk
+module load libtool/2.4.7-rocmcc-6.3.1-tvjldov
 # gmp@=6.3.0%rocmcc@=6.3.1+cxx build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load gmp/6.3.0-rocmcc-6.3.1-tvanywa
+module load gmp/6.3.0-rocmcc-6.3.1-qwd3slg
 # metis@=5.1.0%rocmcc@=6.3.1~gdb~int64~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-zen3
-module load metis/5.1.0-rocmcc-6.3.1-7gkwxyy
+module load metis/5.1.0-rocmcc-6.3.1-iqwjyj4
 # autoconf-archive@=2023.02.20%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load autoconf-archive/2023.02.20-rocmcc-6.3.1-53iazlo
+module load autoconf-archive/2023.02.20-rocmcc-6.3.1-t7qwzg2
 # xz@=5.4.6%rocmcc@=6.3.1~pic build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load xz/5.4.6-rocmcc-6.3.1-ytt6q22
-# libxml2@=2.10.3%rocmcc@=6.3.1+pic~python+shared build_system=autotools arch=linux-sles15-zen3
-module load libxml2/2.10.3-rocmcc-6.3.1-6muewa3
+module load xz/5.4.6-rocmcc-6.3.1-mth7psn
+# libxml2@=2.13.4%rocmcc@=6.3.1+pic~python+shared build_system=autotools arch=linux-sles15-zen3
+module load libxml2/2.13.4-rocmcc-6.3.1-hwoe2qh
 # pigz@=2.8%rocmcc@=6.3.1 build_system=makefile arch=linux-sles15-zen3
-module load pigz/2.8-rocmcc-6.3.1-5qpxnu3
+module load pigz/2.8-rocmcc-6.3.1-cy5cnw7
 # zstd@=1.5.6%rocmcc@=6.3.1+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-zen3
-module load zstd/1.5.6-rocmcc-6.3.1-u7riryn
+module load zstd/1.5.6-rocmcc-6.3.1-cftojny
 # tar@=1.34%rocmcc@=6.3.1 build_system=autotools zip=pigz arch=linux-sles15-zen3
-module load tar/1.34-rocmcc-6.3.1-und3txi
+module load tar/1.34-rocmcc-6.3.1-kfi7nsj
 # gettext@=0.22.5%rocmcc@=6.3.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-zen3
-module load gettext/0.22.5-rocmcc-6.3.1-wvyrm4d
+module load gettext/0.22.5-rocmcc-6.3.1-3ck747y
 # texinfo@=7.1%rocmcc@=6.3.1 build_system=autotools arch=linux-sles15-zen3
-module load texinfo/7.1-rocmcc-6.3.1-yvjdn4b
+module load texinfo/7.1-rocmcc-6.3.1-327afxj
 # mpfr@=4.2.1%rocmcc@=6.3.1 build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load mpfr/4.2.1-rocmcc-6.3.1-f7dufge
-# openblas@=0.3.28%rocmcc@=6.3.1~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared build_system=makefile symbol_suffix=none threads=none arch=linux-sles15-zen3
-module load openblas/0.3.28-rocmcc-6.3.1-x7oqcfj
+module load mpfr/4.2.1-rocmcc-6.3.1-h5arply
+# openblas@=0.3.28%rocmcc@=6.3.1~bignuma~consistent_fpcsr+dynamic_dispatch+fortran~ilp64+locking+pic+shared build_system=makefile patches=d0b9276 symbol_suffix=none threads=none arch=linux-sles15-zen3
+module load openblas/0.3.28-rocmcc-6.3.1-yx5h226
 # suite-sparse@=7.7.0%rocmcc@=6.3.1~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-zen3
-module load suite-sparse/7.7.0-rocmcc-6.3.1-gqj34rs
+module load suite-sparse/7.7.0-rocmcc-6.3.1-k5bpn4t
 # resolve@=develop%rocmcc@=6.3.1~cuda~ipo+klu+lusol+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ReSolve generator=make arch=linux-sles15-zen3
-## module load resolve/develop-rocmcc-6.3.1-h2ge4c6
+## module load resolve/develop-rocmcc-6.3.1-6pmzbco

--- a/buildsystem/spack/frontier/spack.yaml
+++ b/buildsystem/spack/frontier/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-  - resolve@develop%rocmcc@6.3.1~cuda+rocm amdgpu_target=gfx90a
+  - resolve@develop%rocmcc@6.3.1+asan~cuda+rocm+ubsan amdgpu_target=gfx90a
   view: false
   concretizer:
     unify: when_possible

--- a/buildsystem/spack/frontier/spack.yaml
+++ b/buildsystem/spack/frontier/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-  - resolve@develop%rocmcc@6.3.1+asan~cuda+rocm+ubsan amdgpu_target=gfx90a
+  - resolve@develop%rocmcc@6.3.1~asan~cuda+rocm~ubsan amdgpu_target=gfx90a
   view: false
   concretizer:
     unify: when_possible

--- a/resolve/CMakeLists.txt
+++ b/resolve/CMakeLists.txt
@@ -138,6 +138,24 @@ if(RESOLVE_USE_HIP)
   list(APPEND ReSolve_HEADER_INSTALL ${ReSolve_ROCM_HEADER_INSTALL})
 endif()
 
+# Address sanitizer target
+if(RESOLVE_USE_ASAN)
+  add_library(resolve_asan INTERFACE)
+  target_compile_options(resolve_asan INTERFACE "-fsanitize=address")
+  target_link_libraries(resolve_asan INTERFACE "-fsanitize=address -fno-omit-frame-pointer")
+  target_link_libraries(resolve_tpl INTERFACE resolve_asan)
+  list(APPEND ReSolve_Targets_List resolve_asan)
+endif()
+
+# Undefined behavior sanitizer target
+if(RESOLVE_USE_UBSAN)
+  add_library(resolve_ubsan INTERFACE)
+  target_compile_options(resolve_ubsan INTERFACE "-fsanitize=undefined")
+  target_link_libraries(resolve_ubsan INTERFACE "-fsanitize=undefined -fno-omit-frame-pointer")
+  target_link_libraries(resolve_tpl INTERFACE resolve_ubsan)
+  list(APPEND ReSolve_Targets_List resolve_ubsan)
+endif()
+
 # Set installable targets
 install(TARGETS ${ReSolve_Targets_List} EXPORT ReSolveTargets)
 

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -253,7 +253,7 @@ namespace ReSolve
         vec.setToConst(3.0, memspace_);
 
         auto diag_data = std::unique_ptr<real_type[]>(new real_type[N]);
-        for (index_type i = 0; i < N; ++i)
+        for (size_t i = 0; i < static_cast<size_t>(N); ++i)
         {
           diag_data[i] = (real_type) (i + 1);
         }


### PR DESCRIPTION
## Description
 
CI support for sanitizers 

 ## Proposed changes
 
- Updated Spack package with `asan` and `ubsan` variants. [PR to upstream Spack](https://github.com/spack/spack-packages/pull/392)
- Updated Frontier dependencies accordingly
- Updated Github Actions pipeline to build and test with the sanitizers
- Created targets `resolve_asan` and `resolve_ubsan` that can be exported. This was needed to make the consumer test work, in addition to ensuring that the compilers match.
 
 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 ## Further comments