### PR TITLE
shaked/assymetric_klu_fix

### DIFF
--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -218,8 +218,19 @@ namespace ReSolve
     // copy the vector
     x->copyDataFrom(rhs->getData(memory::HOST), memory::HOST, memory::HOST);
     x->setDataUpdated(memory::HOST);
-
-    int kluStatus = klu_solve(Symbolic_, Numeric_, A_->getNumRows(), 1, x->getData(memory::HOST), &Common_);
+    int kluStatus = 1;
+    // check sparsity format of A
+    if (A_->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_COLUMN)
+    {
+      kluStatus = klu_solve(Symbolic_, Numeric_, A_->getNumRows(), 1, x->getData(memory::HOST), &Common_);
+    } else if (A_->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW)
+    {
+      kluStatus = klu_tsolve(Symbolic_, Numeric_, A_->getNumRows(), 1, x->getData(memory::HOST), &Common_);
+    } else
+    {
+      out::error() << "Unsupported sparse format for matrix A in LinSolverDirectKLU! Only CSC and CSR are supported.\n";
+      return 1;
+    }
 
     if (!kluStatus)
     {

--- a/tests/functionality/testKlu.cpp
+++ b/tests/functionality/testKlu.cpp
@@ -150,7 +150,7 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
+  error_sum += helper.checkResult(ReSolve::constants::MACHINE_EPSILON);
 
   // Load the second matrix
   std::ifstream mat2(matrix_file_name_2);
@@ -200,7 +200,7 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   {
     helper.printIrSummary(&FGMRES);
   }
-  error_sum += helper.checkResult(1e-16);
+  error_sum += helper.checkResult(ReSolve::constants::MACHINE_EPSILON);
 
   isTestPass(error_sum, test_name);
 


### PR DESCRIPTION
## Description
 
 _Many of our solvers use KLU in the first iteration, which assumes CSC storage. However, our data is coming in in CSR, and the solvers themselves also use CSR. This means that unless the matrices are symmetric, we should not expect the solvers to work as is.
gpuRefactor and kluRefactor produce large residuals._
 
 _Partially addresses #321 Solves `kluRefactor` and `gpuRefactor` but not `gluRefactor`_
 
 ## Proposed changes
 
 _I fixed the code to use `klu_solve` or `klu_tsolve` based on the sparsity structure of the matrix. I also changed the tolerance, from the arbitrary `1e-16` to machine epsilon (required for tests to pass)._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [ ] All tests pass. Code tested on
     - [ ] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 