### PR TITLE
Add warnings flags 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,12 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "In-source build prohibited.")
 endif()
 
+if (MSVC)
+  set(CMAKE_CXX_FLAGS "/Wall")
+else()
+  set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wpedantic")
+endif()
+
 option(RESOLVE_TEST_WITH_BSUB "Use `jsrun` instead of `mpirun` commands when running tests" OFF)
 option(RESOLVE_USE_KLU  "Use KLU, AMD and COLAMD libraries from SuiteSparse" OFF)
 option(RESOLVE_USE_LUSOL "Build the LUSOL library" OFF)

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -253,7 +253,7 @@ namespace ReSolve
         vec.setToConst(3.0, memspace_);
 
         auto diag_data = std::unique_ptr<real_type[]>(new real_type[N]);
-        for (index_type i = 0; i < N; ++i)
+        for (size_t i = 0; i < static_cast<size_t>(N); ++i)
         {
           diag_data[i] = (real_type) (i + 1);
         }


### PR DESCRIPTION
## Description
 
Pedantic compiler warnings on by default. 

 ## Proposed changes
 
Ensure pedantic warnings are used at all times in addition to optional address sanitizers.
 
 ## Checklist
 

- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
