### PR TITLE
fix the means by which cmake finds the suitesparse include dir

### DIFF
--- a/cmake/FindSuiteSparse.cmake
+++ b/cmake/FindSuiteSparse.cmake
@@ -29,7 +29,7 @@ if(SUITESPARSE_LIBRARY)
   get_filename_component(SUITESPARSE_LIBRARY_DIR ${SUITESPARSE_LIBRARY} DIRECTORY CACHE "Suitesparse library directory")
   message(STATUS "Found Suitesparse libraries in: " ${SUITESPARSE_LIBRARY_DIR})
   mark_as_advanced(SUITESPARSE_LIBRARY SUITESPARSE_LIBRARY_DIR)
-  if(NOT SUITESPARSE_DIR) 
+  if(NOT SUITESPARSE_DIR)
     get_filename_component(SUITESPARSE_DIR ${SUITESPARSE_LIBRARY_DIR} DIRECTORY CACHE)
   endif()
 endif()
@@ -44,7 +44,8 @@ find_path(SUITESPARSE_INCLUDE_DIR
   PATHS
   ${SUITESPARSE_DIR} $ENV{SUITESPARSE_DIR} ${SUITESPARSE_ROOT_DIR} ${SUITESPARSE_LIBRARY_DIR}/..
   PATH_SUFFIXES
-  include)
+  include
+  include/suitesparse)
 
 if(SUITESPARSE_LIBRARY)
   message(STATUS "Found Suitesparse include: ${SUITESPARSE_INCLUDE_DIR}")
@@ -53,7 +54,7 @@ if(SUITESPARSE_LIBRARY)
   add_library(SUITESPARSE INTERFACE IMPORTED)
   target_include_directories(SUITESPARSE INTERFACE ${SUITESPARSE_INCLUDE_DIR})
   foreach(mod ${SUITESPARSE_MODULES})
-    find_library(suitesparse_${mod} 
+    find_library(suitesparse_${mod}
       NAMES ${mod}
       HINTS ${SUITESPARSE_LIBRARY_DIR})
     if(suitesparse_${mod})


### PR DESCRIPTION
this is a really simple fix to the `FindSuitesparse.cmake` file so that it finds the suitesparse include dir properly

 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
