### PR TITLE
Fixed GLU to work on non-symmetric matrices.

### DIFF
--- a/examples/gluRefactor.cpp
+++ b/examples/gluRefactor.cpp
@@ -164,7 +164,7 @@ int gluRefactor(int argc, char* argv[])
   vector_type* vec_x   = nullptr;
 
   RESOLVE_RANGE_PUSH(__FUNCTION__);
-  for (int i = 0; i < num_systems; ++i)
+  for (int i = 1; i < num_systems; ++i)
   {
     std::cout << "System " << i << ":\n";
 
@@ -190,7 +190,7 @@ int gluRefactor(int argc, char* argv[])
       return -1;
     }
     bool is_expand_symmetric = true;
-    if (i == 0)
+    if (i == 1)
     {
       A       = io::createCsrFromFile(mat_file, is_expand_symmetric);
       vec_rhs = io::createVectorFromFile(rhs_file);
@@ -217,7 +217,7 @@ int gluRefactor(int argc, char* argv[])
 
     int status = 0;
 
-    if (i < 1)
+    if (i < 2)
     {
       RESOLVE_RANGE_PUSH("KLU");
       // Setup factorization solver
@@ -235,10 +235,6 @@ int gluRefactor(int argc, char* argv[])
       status = KLU.solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
 
-      // // Extract factors and configure refactorization solver
-      // matrix::Csc* L = (matrix::Csc*) KLU.getLFactor();
-      // matrix::Csc* U = (matrix::Csc*) KLU.getUFactor();
-
       // Extract factors and configure refactorization solver
       matrix::Csr* L = (matrix::Csr*) KLU.getLFactorCsr();
       matrix::Csr* U = (matrix::Csr*) KLU.getUFactorCsr();
@@ -248,7 +244,6 @@ int gluRefactor(int argc, char* argv[])
       }
       index_type* P = KLU.getPOrdering();
       index_type* Q = KLU.getQOrdering();
-      //status = Rf.setup(A, L, U, P, Q); // code works till here
       status = Rf.setupCsr(A, L, U, P, Q);
       std::cout << "Refactorization setup status: " << status << std::endl;
 

--- a/examples/gluRefactor.cpp
+++ b/examples/gluRefactor.cpp
@@ -248,8 +248,9 @@ int gluRefactor(int argc, char* argv[])
       }
       index_type* P = KLU.getPOrdering();
       index_type* Q = KLU.getQOrdering();
-
-      status = Rf.setup(A, L, U, P, Q);
+      //status = Rf.setup(A, L, U, P, Q); // code works till here
+      status = Rf.setupCsr(A, L, U, P, Q);
+      std::cout << "Refactorization setup status: " << status << std::endl;
 
       RESOLVE_RANGE_POP("KLU");
     }

--- a/examples/gluRefactor.cpp
+++ b/examples/gluRefactor.cpp
@@ -240,8 +240,8 @@ int gluRefactor(int argc, char* argv[])
       // matrix::Csc* U = (matrix::Csc*) KLU.getUFactor();
 
       // Extract factors and configure refactorization solver
-      matrix::Csr* L = KLU.getLFactorCsr();
-      matrix::Csr* U = KLU.getUFactorCsr();
+      matrix::Csr* L = (matrix::Csr*) KLU.getLFactorCsr();
+      matrix::Csr* U = (matrix::Csr*) KLU.getUFactorCsr();
       if (L == nullptr || U == nullptr)
       {
         std::cout << "Factor extraction from KLU failed!\n";

--- a/examples/gluRefactor.cpp
+++ b/examples/gluRefactor.cpp
@@ -235,9 +235,13 @@ int gluRefactor(int argc, char* argv[])
       status = KLU.solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
 
+      // // Extract factors and configure refactorization solver
+      // matrix::Csc* L = (matrix::Csc*) KLU.getLFactor();
+      // matrix::Csc* U = (matrix::Csc*) KLU.getUFactor();
+
       // Extract factors and configure refactorization solver
-      matrix::Csc* L = (matrix::Csc*) KLU.getLFactor();
-      matrix::Csc* U = (matrix::Csc*) KLU.getUFactor();
+      matrix::Csr* L = KLU.getLFactorCsr();
+      matrix::Csr* U = KLU.getUFactorCsr();
       if (L == nullptr || U == nullptr)
       {
         std::cout << "Factor extraction from KLU failed!\n";

--- a/resolve/LinSolverDirect.cpp
+++ b/resolve/LinSolverDirect.cpp
@@ -62,6 +62,33 @@ namespace ReSolve
   }
 
   /**
+   * @brief Setup function for LinSolverDirect class with CSR data
+   *
+   * @param[in] A - matrix to be solved
+   * @param[in] L - optional lower triangular factor
+   * @param[in] U - optional upper triangular factor
+   * @param[in] P - optional row permutation vector
+   * @param[in] Q - optional column permutation vector
+   * @param[in] rhs - optional right-hand side vector
+   *
+   * @return int - error code, 0 if successful
+   */
+  int LinSolverDirect::setupCsr(matrix::Sparse* A,
+                             matrix::Sparse* /* L */,
+                             matrix::Sparse* /* U */,
+                             index_type* /* P */,
+                             index_type* /* Q */,
+                             vector_type* /* rhs */)
+  {
+    if (A == nullptr)
+    {
+      return 1;
+    }
+    A_ = A;
+    return 0;
+  } 
+
+  /**
    * @brief Placeholder function for symbolic factorization.
    */
   int LinSolverDirect::analyze()
@@ -83,6 +110,22 @@ namespace ReSolve
   int LinSolverDirect::refactorize()
   {
     return 1;
+  }
+
+  /**
+   * @brief Placeholder function for lower triangular factor in Csr.
+   */
+  matrix::Sparse* LinSolverDirect::getLFactorCsr()
+  {
+    return nullptr;
+  }
+
+  /**
+   * @brief Placeholder function for upper triangular factor in Csr.
+   */
+  matrix::Sparse* LinSolverDirect::getUFactorCsr()
+  {
+    return nullptr;
   }
 
   /**

--- a/resolve/LinSolverDirect.hpp
+++ b/resolve/LinSolverDirect.hpp
@@ -24,6 +24,13 @@ namespace ReSolve
                       index_type*     P   = nullptr,
                       index_type*     Q   = nullptr,
                       vector_type*    rhs = nullptr);
+    
+    virtual int  setupCsr(matrix::Sparse* A,
+                          matrix::Sparse* L   = nullptr,
+                          matrix::Sparse* U   = nullptr,
+                          index_type*     P   = nullptr,
+                          index_type*     Q   = nullptr,
+                          vector_type*    rhs = nullptr);
 
     virtual int analyze(); // the same as symbolic factorization
     virtual int factorize();
@@ -31,6 +38,8 @@ namespace ReSolve
     virtual int solve(vector_type* rhs, vector_type* x) = 0;
     virtual int solve(vector_type* x)                   = 0;
 
+    virtual matrix::Sparse* getLFactorCsr();
+    virtual matrix::Sparse* getUFactorCsr();
     virtual matrix::Sparse* getLFactor();
     virtual matrix::Sparse* getUFactor();
     virtual index_type*     getPOrdering();

--- a/resolve/LinSolverDirectCuSolverGLU.cpp
+++ b/resolve/LinSolverDirectCuSolverGLU.cpp
@@ -228,13 +228,11 @@ namespace ReSolve
       {
         M_col[count++] = L_col[j];
       }
-      for (index_type j = U_row[i] + 1; j < U_row[i + 1]; ++j)
+      for (index_type j = U_row[i] + 1; j < U_row[i + 1]; ++j) // skip the diagonal element of U, which is at U_row[i] 
       {
-        // skip the diagonal element of U, which is at U_row[i] 
         M_col[count++] = U_col[j];
       }
-    }
-    
+    } 
   }
 
   void LinSolverDirectCuSolverGLU::combineFactors(matrix::Sparse* L, matrix::Sparse* U)

--- a/resolve/LinSolverDirectCuSolverGLU.cpp
+++ b/resolve/LinSolverDirectCuSolverGLU.cpp
@@ -27,6 +27,92 @@ namespace ReSolve
     cusolverSpDestroyGluInfo(info_M_);
     delete M_;
   }
+  /** 
+   * @brief Sets up the GLU factorization for the CSR matrix A.
+   * 
+   * This function initializes the GLU factorization for a given sparse matrix A.
+   * It combines the L and U factors into a single matrix M, sets up the necessary
+   * descriptors, and performs the GLU setup, analysis, and factorization.
+   * @param[in] A - Pointer to the sparse matrix in CSR format.
+   * @param[in] L - Pointer to the L factor in CSR format. (Note that L has the scaling.)
+   * @param[in] U - Pointer to the U factor in CSR format. (Note that U has unit diagonal.)
+   * @param[in] P - Pointer to the permutation vector for rows (base-0).
+   * @param[in] Q - Pointer to the permutation vector for columns (base-0).
+   * @param[in] rhs - Pointer to the right-hand side vector (not used in this setup).
+  */
+  int LinSolverDirectCuSolverGLU::setupCsr(matrix::Sparse* A,
+                                           matrix::Sparse* L,
+                                           matrix::Sparse* U,
+                                           index_type*     P,
+                                           index_type*     Q,
+                                           vector_type* /** rhs */)
+  {
+    RESOLVE_RANGE_PUSH(__FUNCTION__);
+    int error_sum = 0;
+
+    LinAlgWorkspaceCUDA* workspaceCUDA = workspace_;
+    // get the handle
+    handle_cusolversp_ = workspaceCUDA->getCusolverSpHandle();
+    A_                 = (matrix::Csr*) A;
+    index_type n       = A_->getNumRows();
+    index_type nnz     = A_->getNnz();
+    // create combined factor
+    combineFactorsCsr(L, U);
+
+    // set up descriptors
+    cusparseCreateMatDescr(&descr_M_);
+    cusparseSetMatType(descr_M_, CUSPARSE_MATRIX_TYPE_GENERAL);
+    cusparseSetMatIndexBase(descr_M_, CUSPARSE_INDEX_BASE_ZERO);
+    cusolverSpCreateGluInfo(&info_M_);
+
+    cusparseCreateMatDescr(&descr_A_);
+    cusparseSetMatType(descr_A_, CUSPARSE_MATRIX_TYPE_GENERAL);
+    cusparseSetMatIndexBase(descr_A_, CUSPARSE_INDEX_BASE_ZERO);
+
+    // set up the GLU
+    status_cusolver_ = cusolverSpDgluSetup(handle_cusolversp_,
+                                           n,
+                                           nnz,
+                                           descr_A_,
+                                           A_->getRowData(memory::HOST),
+                                           A_->getColData(memory::HOST),
+                                           P,            /** base-0 */
+                                           Q,            /** base-0 */
+                                           M_->getNnz(), /** nnzM */
+                                           descr_M_,
+                                           M_->getRowData(memory::HOST),
+                                           M_->getColData(memory::HOST),
+                                           info_M_);
+    error_sum += status_cusolver_;
+    // NOW the buffer
+    size_t buffer_size;
+    status_cusolver_ = cusolverSpDgluBufferSize(handle_cusolversp_, info_M_, &buffer_size);
+    error_sum += status_cusolver_;
+
+    mem_.allocateBufferOnDevice(&glu_buffer_, buffer_size);
+
+    status_cusolver_ = cusolverSpDgluAnalysis(handle_cusolversp_, info_M_, glu_buffer_);
+    error_sum += status_cusolver_;
+
+    // reset and refactor so factors are ON THE GPU
+
+    status_cusolver_ = cusolverSpDgluReset(handle_cusolversp_,
+                                           n,
+                                           /** A is original matrix */
+                                           nnz,
+                                           descr_A_,
+                                           A_->getValues(memory::DEVICE),
+                                           A_->getRowData(memory::DEVICE),
+                                           A_->getColData(memory::DEVICE),
+                                           info_M_);
+    error_sum += status_cusolver_;
+
+    status_cusolver_ = cusolverSpDgluFactor(handle_cusolversp_, info_M_, glu_buffer_);
+    error_sum += status_cusolver_;
+
+    RESOLVE_RANGE_POP(__FUNCTION__);
+    return error_sum;
+  }
 
   int LinSolverDirectCuSolverGLU::setup(matrix::Sparse* A,
                                         matrix::Sparse* L,
@@ -100,6 +186,55 @@ namespace ReSolve
 
     RESOLVE_RANGE_POP(__FUNCTION__);
     return error_sum;
+  }
+
+  /**
+   * @brief Combines the CSR L and U factors into a single matrix CSR M.
+   * 
+   * This function takes two sparse matrices L and U in CSR format,
+   * combines them into a single matrix M in CSR format,
+   * where M = L + U. The diagonal of L is taken and that of U is ommitted.
+   * It is implicitly assumed that L has the scaling and U has unit diagonal.
+   * 
+   * @param[in] L - Pointer to the L factor in CSR format.
+   * @param[in] U - Pointer to the U factor in CSR format.
+   */
+  void LinSolverDirectCuSolverGLU::combineFactorsCsr(matrix::Sparse* L, matrix::Sparse* U)
+  {
+    index_type  n    = L->getNumRows();
+    index_type* L_row   = L->getRowData(memory::HOST);
+    index_type* L_col   = L->getColData(memory::HOST);
+    index_type* U_row   = U->getRowData(memory::HOST);
+    index_type* U_col   = U->getColData(memory::HOST);
+    index_type  M_nnz = (L->getNnz() + U->getNnz() - n);
+    M_               = new matrix::Csr(n, n, M_nnz);
+    M_->allocateMatrixData(memory::HOST);
+    index_type* M_row = M_->getRowData(memory::HOST);
+    index_type* M_col = M_->getColData(memory::HOST);
+    // The total number of non-zeros in a row is the sum of non-zeros in L and U, 
+    // minus 1 for the diagonal element, which is not counted twice.
+    // You can verify with this formula that M_row[i+1] - M_row[i] is the number of non-zeros in row i.
+    // M_row[i+1] - M_row[i] = (L_row[i+1] - L_row[i]) + (U_row[i+1] - U_row[i]) - 1
+    // The number of zeros in the i-th row of L + U -1.
+    for (index_type i=0; i<=n; i++)
+    {
+      M_row[i] = L_row[i] + U_row[i] - i;
+    }
+    // Now we need to fill the M_col array with the correct column indices.
+    index_type count = 0;
+    for (index_type i = 0; i < n; ++i)
+    {
+      for (index_type j = L_row[i]; j < L_row[i + 1]; ++j)
+      {
+        M_col[count++] = L_col[j];
+      }
+      for (index_type j = U_row[i] + 1; j < U_row[i + 1]; ++j)
+      {
+        // skip the diagonal element of U, which is at U_row[i] 
+        M_col[count++] = U_col[j];
+      }
+    }
+    
   }
 
   void LinSolverDirectCuSolverGLU::combineFactors(matrix::Sparse* L, matrix::Sparse* U)

--- a/resolve/LinSolverDirectCuSolverGLU.cpp
+++ b/resolve/LinSolverDirectCuSolverGLU.cpp
@@ -57,7 +57,9 @@ namespace ReSolve
     index_type n       = A_->getNumRows();
     index_type nnz     = A_->getNnz();
     // create combined factor
+    std::cout << "Combining L and U factors into M...\n";
     combineFactorsCsr(L, U);
+    std::cout << "Combined factor M has " << M_->getNnz() << " non-zeros.\n";
 
     // set up descriptors
     cusparseCreateMatDescr(&descr_M_);
@@ -83,6 +85,7 @@ namespace ReSolve
                                            M_->getRowData(memory::HOST),
                                            M_->getColData(memory::HOST),
                                            info_M_);
+    std::cout << "GLU setup status: " << status_cusolver_ << std::endl;
     error_sum += status_cusolver_;
     // NOW the buffer
     size_t buffer_size;
@@ -105,6 +108,8 @@ namespace ReSolve
                                            A_->getRowData(memory::DEVICE),
                                            A_->getColData(memory::DEVICE),
                                            info_M_);
+                                           
+    std::cout << "GLU reset status: " << status_cusolver_ << std::endl;
     error_sum += status_cusolver_;
 
     status_cusolver_ = cusolverSpDgluFactor(handle_cusolversp_, info_M_, glu_buffer_);

--- a/resolve/LinSolverDirectCuSolverGLU.hpp
+++ b/resolve/LinSolverDirectCuSolverGLU.hpp
@@ -34,6 +34,13 @@ namespace ReSolve
     int solve(vector_type* rhs, vector_type* x) override;
     int solve(vector_type* x) override;
 
+    int setupCsr(matrix::Sparse* A,
+                 matrix::Sparse* L   = nullptr,
+                 matrix::Sparse* U   = nullptr,
+                 index_type*     P   = nullptr,
+                 index_type*     Q   = nullptr,
+                 vector_type*    rhs = nullptr) override;
+
     int setup(matrix::Sparse* A,
               matrix::Sparse* L,
               matrix::Sparse* U,
@@ -50,6 +57,7 @@ namespace ReSolve
 
   private:
     void            combineFactors(matrix::Sparse* L, matrix::Sparse* U); ///< creates L+U from separate L, U factors
+    void            combineFactorsCsr(matrix::Sparse* L, matrix::Sparse* U); ///< creates L+U from separate L, U factors in CSR format
     matrix::Sparse* M_;                                                   ///< the matrix that contains added factors
     // note: we need cuSolver handle, we can copy it from the workspace to avoid double allocation
     cusparseMatDescr_t   descr_M_;   // this is NOT sparse matrix descriptor

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -3,6 +3,7 @@
 #include <cstring> // includes memcpy
 
 #include <resolve/matrix/Csc.hpp>
+#include <resolve/matrix/Csr.hpp>
 #include <resolve/utilities/logger/Logger.hpp>
 #include <resolve/vector/Vector.hpp>
 

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -272,36 +272,31 @@ namespace ReSolve
   {
     if (!factors_extracted_)
     {
-      //this is not a typo, we switch L and U here
-      // because KLU does not support CSR format directly
-      // this is a workaround to extract L and U factors
-      const int nnzU = Numeric_->lnz;
-      const int nnzL = Numeric_->unz;
+      const int nnzL = Numeric_->lnz;
+      const int nnzU = Numeric_->unz;
 
-      L_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzL);
-      U_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzU);
+      // Create CSR matrices - L gets U's data, U gets L's data
+      L_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzU);
+      U_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzL);
       L_->allocateMatrixData(memory::HOST);
       U_->allocateMatrixData(memory::HOST);
 
-      // Extract L and U factors from the numeric factorization
-      // Note: KLU does not support CSR format directly, so we use CSC format
-      // and switch between L and U and their column and row data.
       int ok = klu_extract(Numeric_,
-                           Symbolic_,
-                           U_->getRowData(memory::HOST),
-                           U_->getColData(memory::HOST),
-                           U_->getValues(memory::HOST),
-                           L_->getRowData(memory::HOST),
-                           L_->getColData(memory::HOST),
-                           L_->getValues(memory::HOST),
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           &Common_);
+                          Symbolic_,
+                          U_->getRowData(memory::HOST),  // L CSC colptr -> U CSR rowptr
+                          U_->getColData(memory::HOST),  // L CSC rowidx -> U CSR colidx
+                          U_->getValues(memory::HOST),   // L CSC values -> U CSR values
+                          L_->getRowData(memory::HOST),  // U CSC colptr -> L CSR rowptr
+                          L_->getColData(memory::HOST),  // U CSC rowidx -> L CSR colidx
+                          L_->getValues(memory::HOST),   // U CSC values -> L CSR values
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          &Common_);
 
       L_->setUpdated(memory::HOST);
       U_->setUpdated(memory::HOST);
@@ -328,40 +323,34 @@ namespace ReSolve
    * @return U factor in compressed sparse row format
    */
   matrix::Sparse* LinSolverDirectKLU::getUFactorCsr()
-  {
+ {
     if (!factors_extracted_)
     {
-      //this is not a typo, we switch L and U here
-      // because KLU does not support CSR format directly
-      // this is a workaround to extract L and U factors
-      const int nnzU = Numeric_->lnz;
-      const int nnzL = Numeric_->unz;
+      const int nnzL = Numeric_->lnz;
+      const int nnzU = Numeric_->unz;
 
-
-      L_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzL);
-      U_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzU);
+      // Create CSR matrices - L gets U's data, U gets L's data
+      L_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzU);
+      U_ = new matrix::Csr(A_->getNumRows(), A_->getNumColumns(), nnzL);
       L_->allocateMatrixData(memory::HOST);
       U_->allocateMatrixData(memory::HOST);
 
-      // Extract L and U factors from the numeric factorization
-      // Note: KLU does not support CSR format directly, so we use CSC format
-      // and switch between L and U and their column and row data.
       int ok = klu_extract(Numeric_,
-                           Symbolic_,
-                           U_->getRowData(memory::HOST),
-                           U_->getColData(memory::HOST),
-                           U_->getValues(memory::HOST),
-                           L_->getRowData(memory::HOST),
-                           L_->getColData(memory::HOST),
-                           L_->getValues(memory::HOST),
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           nullptr,
-                           &Common_);
+                          Symbolic_,
+                          U_->getRowData(memory::HOST),  // L CSC colptr -> U CSR rowptr
+                          U_->getColData(memory::HOST),  // L CSC rowidx -> U CSR colidx
+                          U_->getValues(memory::HOST),   // L CSC values -> U CSR values
+                          L_->getRowData(memory::HOST),  // U CSC colptr -> L CSR rowptr
+                          L_->getColData(memory::HOST),  // U CSC rowidx -> L CSR colidx
+                          L_->getValues(memory::HOST),   // U CSC values -> L CSR values
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          nullptr,
+                          &Common_);
 
       L_->setUpdated(memory::HOST);
       U_->setUpdated(memory::HOST);
@@ -370,7 +359,6 @@ namespace ReSolve
     }
     return U_;
   }
-
 
   /**
    * @brief Get the lower triangular factor L.

--- a/resolve/LinSolverDirectKLU.hpp
+++ b/resolve/LinSolverDirectKLU.hpp
@@ -39,6 +39,8 @@ namespace ReSolve
     int solve(vector_type* rhs, vector_type* x) override;
     int solve(vector_type* x) override;
 
+    matrix::Sparse* getLFactorCsr() override;
+    matrix::Sparse* getUFactorCsr() override;
     matrix::Sparse* getLFactor() override;
     matrix::Sparse* getUFactor() override;
     index_type*     getPOrdering() override;


### PR DESCRIPTION
## Description
 
 _GLU was not working on non-symmetric matrices. The initial code was failing because the combined L and U factor matrix was unsorted._
 
 _Closes #324 _

 ## Proposed changes
 
 _The fix is minimally invasive and requires only switching the L and U factors obtained from KLU. As described in #251 
ND is no diagonal. If we have $`A`$ in CSR and we take a factorization assuming it's actually in CSC representation, we are getting $`A^T=LU`$.
Crucially, $`L, U`$ are in CSC format. If we interpret them as CSR matrices (effectively transposing them), we get
$`A=\tilde{L}\tilde{U}`$, where $`\tilde{L}`$ is the reinterpretation of $`U`$ as CSR and $`\tilde{U}`$ is the reinterpretation of $`L`$. The original explanation has a method for getting around the fact that now the scaling is in $'L'$, not $'U'$, but this is not needed as glu only uses the symbolic factorization of KLU._

_Currently I wrote new functions for getting L and U factors and combining them. Eventually we will want to replace the old ones. Let's discuss whether it should be part of this PR or not._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [ ] All tests pass. Code tested on
     - [ ] CPU backend (N/A)
     - [ ] CUDA backend
     - [ ] HIP backend (N/A)
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
