### PR TITLE
Synchronize devices after HIP functions

### DIFF
--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -195,7 +195,7 @@ namespace ReSolve
                                    A->getNumRows(),
                                    d_r,
                                    norm,
-                                   workspace_->getNormBuffer() /* at least 8192 bytes */);
+                                   workspace_->getNormBuffer() /* this is at least 8192 bytes */);
     mem_.deviceSynchronize();
     if (status != 0)
     {

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -195,8 +195,8 @@ namespace ReSolve
                                    A->getNumRows(),
                                    d_r,
                                    norm,
-                                   workspace_->getNormBuffer() /* at least 8192 bytes */);
-
+                                   workspace_->getNormBuffer() /* at least 8192 bytes */);                                  
+    mem_.deviceSynchronize();
     if (status != 0)
     {
       io::Logger::warning() << "Vector inf nrm returned " << status << "\n";
@@ -268,7 +268,7 @@ namespace ReSolve
 
     // Values on the device are updated now -- mark them as such!
     A_csr->setUpdated(memory::DEVICE);
-
+    mem_.deviceSynchronize();
     return error_sum;
   }
 
@@ -331,7 +331,7 @@ namespace ReSolve
     error_sum += status;
     // Values on the device are updated now -- mark them as such!
     At->setUpdated(memory::DEVICE);
-
+    mem_.deviceSynchronize();
     return error_sum;
   }
 
@@ -357,6 +357,7 @@ namespace ReSolve
     // check values in A and diag
     cuda::leftScale(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -382,6 +383,7 @@ namespace ReSolve
     index_type  n         = A->getNumRows();
     cuda::rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -398,6 +400,7 @@ namespace ReSolve
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz    = A->getNnz();
     cuda::addConst(nnz, alpha, values);
+    mem_.deviceSynchronize();
     return 0;
   }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -195,7 +195,7 @@ namespace ReSolve
                                    A->getNumRows(),
                                    d_r,
                                    norm,
-                                   workspace_->getNormBuffer() /* at least 8192 bytes */);
+                                   workspace_->getNormBuffer() /* at least 8192 bytes */);                                  
     mem_.deviceSynchronize();
     if (status != 0)
     {

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -195,7 +195,7 @@ namespace ReSolve
                                    A->getNumRows(),
                                    d_r,
                                    norm,
-                                   workspace_->getNormBuffer() /* at least 8192 bytes */);                                  
+                                   workspace_->getNormBuffer() /* at least 8192 bytes */);
     mem_.deviceSynchronize();
     if (status != 0)
     {

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -195,7 +195,7 @@ namespace ReSolve
                                    A->getNumRows(),
                                    d_r,
                                    norm,
-                                   workspace_->getNormBuffer() /* this is at least 8192 bytes */);
+                                   workspace_->getNormBuffer() /* at least 8192 bytes */);
     mem_.deviceSynchronize();
     if (status != 0)
     {

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -195,8 +195,8 @@ namespace ReSolve
                                    A->getNumRows(),
                                    d_r,
                                    norm,
-                                   workspace_->getNormBuffer() /* at least 8192 bytes */);                                  
-    mem_.deviceSynchronize();
+                                   workspace_->getNormBuffer() /* at least 8192 bytes */);
+
     if (status != 0)
     {
       io::Logger::warning() << "Vector inf nrm returned " << status << "\n";
@@ -268,7 +268,7 @@ namespace ReSolve
 
     // Values on the device are updated now -- mark them as such!
     A_csr->setUpdated(memory::DEVICE);
-    mem_.deviceSynchronize();
+
     return error_sum;
   }
 
@@ -331,7 +331,7 @@ namespace ReSolve
     error_sum += status;
     // Values on the device are updated now -- mark them as such!
     At->setUpdated(memory::DEVICE);
-    mem_.deviceSynchronize();
+
     return error_sum;
   }
 
@@ -357,7 +357,6 @@ namespace ReSolve
     // check values in A and diag
     cuda::leftScale(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
-    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -383,7 +382,6 @@ namespace ReSolve
     index_type  n         = A->getNumRows();
     cuda::rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
-    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -400,7 +398,6 @@ namespace ReSolve
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz    = A->getNnz();
     cuda::addConst(nnz, alpha, values);
-    mem_.deviceSynchronize();
     return 0;
   }
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -239,6 +239,7 @@ namespace ReSolve
 
     // Values on the device are updated now -- mark them as such!
     A_csr->setUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
 
     return error_sum;
   }
@@ -294,6 +295,8 @@ namespace ReSolve
     error_sum += status;
     // Values on the device are updated now -- mark them as such!
     At->setUpdated(memory::DEVICE);
+    // synching device is necessary on HIP
+    mem_.deviceSynchronize();
 
     return error_sum;
   }
@@ -311,6 +314,7 @@ namespace ReSolve
     real_type* values = A->getValues(memory::DEVICE);
     index_type nnz    = A->getNnz();
     hip::addConst(nnz, alpha, values);
+    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -336,6 +340,7 @@ namespace ReSolve
     // check values in A and diag
     hip::leftScale(n, a_row_ptr, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -361,6 +366,7 @@ namespace ReSolve
     index_type  n         = A->getNumRows();
     hip::rightScale(n, a_row_ptr, a_col_idx, a_vals, diag_data);
     A->setUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
     return 0;
   }
 

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -295,7 +295,6 @@ namespace ReSolve
     error_sum += status;
     // Values on the device are updated now -- mark them as such!
     At->setUpdated(memory::DEVICE);
-    // synching device is necessary on HIP
     mem_.deviceSynchronize();
 
     return error_sum;

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -40,6 +40,8 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.transpose(3, 3);
   result += test.transpose(5, 3);
   result += test.transpose(3, 5);
+  result += test.transpose(10,10);
+  result += test.transpose(256, 256);
   result += test.transpose(1024, 1024);
   result += test.transpose(1024, 2048);
   result += test.transpose(2048, 1024);

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -40,7 +40,7 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.transpose(3, 3);
   result += test.transpose(5, 3);
   result += test.transpose(3, 5);
-  result += test.transpose(10,10);
+  result += test.transpose(10, 10);
   result += test.transpose(256, 256);
   result += test.transpose(1024, 1024);
   result += test.transpose(1024, 2048);


### PR DESCRIPTION
## Description
 
 _Some implementations of HIP and CUDA functions did not force a device synchronize. This caused some operations to be executed out of order of what the user would expect._

Please prioritize this review as the code is currently broken and this fixes it.
 
 Closes #334

 ## Proposed changes
 
 _I added a device synchronize at the end of these functions. I also added tests of the specific transpose sizes that were failing._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [ ] CPU backend - N/A
     - [x] CUDA backend 
     - [x] HIP backend 
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
