### PR TITLE
added methods to extract F Factors

### DIFF
--- a/resolve/LinSolverDirect.cpp
+++ b/resolve/LinSolverDirect.cpp
@@ -23,6 +23,7 @@ namespace ReSolve
   {
     L_ = nullptr;
     U_ = nullptr;
+    F_ = nullptr;
     P_ = nullptr;
     Q_ = nullptr;
   }
@@ -140,6 +141,14 @@ namespace ReSolve
    * @brief Placeholder function for upper triangular factor.
    */
   matrix::Sparse* LinSolverDirect::getUFactor()
+  {
+    return nullptr;
+  }
+
+  /**
+   * @brief Placeholder function for full factor matrix.
+   */
+  matrix::Sparse* LinSolverDirect::getFFactor()
   {
     return nullptr;
   }

--- a/resolve/LinSolverDirect.hpp
+++ b/resolve/LinSolverDirect.hpp
@@ -42,12 +42,14 @@ namespace ReSolve
     virtual matrix::Sparse* getUFactorCsr();
     virtual matrix::Sparse* getLFactor();
     virtual matrix::Sparse* getUFactor();
+    virtual matrix::Sparse* getFFactor();
     virtual index_type*     getPOrdering();
     virtual index_type*     getQOrdering();
 
   protected:
     matrix::Sparse* L_{nullptr};
     matrix::Sparse* U_{nullptr};
+    matrix::Sparse* F_{nullptr};
     index_type*     P_{nullptr};
     index_type*     Q_{nullptr};
   };

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -369,13 +369,17 @@ namespace ReSolve
   {
     if (!factors_extracted_)
     {
+      const int n = Symbolic_->n;
       const int nnzL = Numeric_->lnz;
       const int nnzU = Numeric_->unz;
+      const int nnzF = Numeric_->Offp [n];
 
       L_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzL);
       U_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzU);
+      F_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzF);
       L_->allocateMatrixData(memory::HOST);
       U_->allocateMatrixData(memory::HOST);
+      F_->allocateMatrixData(memory::HOST);
 
       int ok = klu_extract(Numeric_,
                            Symbolic_,
@@ -385,9 +389,9 @@ namespace ReSolve
                            U_->getColData(memory::HOST),
                            U_->getRowData(memory::HOST),
                            U_->getValues(memory::HOST),
-                           nullptr,
-                           nullptr,
-                           nullptr,
+                           F_->getColData(memory::HOST),
+                           F_->getRowData(memory::HOST),
+                           F_->getValues(memory::HOST),
                            nullptr,
                            nullptr,
                            nullptr,
@@ -396,6 +400,7 @@ namespace ReSolve
 
       L_->setUpdated(memory::HOST);
       U_->setUpdated(memory::HOST);
+      F_->setUpdated(memory::HOST);
       (void) ok; // TODO: Check status in ok before setting `factors_extracted_`
       factors_extracted_ = true;
     }
@@ -411,13 +416,18 @@ namespace ReSolve
   {
     if (!factors_extracted_)
     {
+      const int n = Symbolic_->n;
       const int nnzL = Numeric_->lnz;
       const int nnzU = Numeric_->unz;
+      const int nnzF = Numeric_->Offp [n];
 
       L_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzL);
       U_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzU);
+      F_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzF);
       L_->allocateMatrixData(memory::HOST);
       U_->allocateMatrixData(memory::HOST);
+      F_->allocateMatrixData(memory::HOST);
+
       int ok = klu_extract(Numeric_,
                            Symbolic_,
                            L_->getColData(memory::HOST),
@@ -426,9 +436,9 @@ namespace ReSolve
                            U_->getColData(memory::HOST),
                            U_->getRowData(memory::HOST),
                            U_->getValues(memory::HOST),
-                           nullptr,
-                           nullptr,
-                           nullptr,
+                           F_->getColData(memory::HOST),
+                           F_->getRowData(memory::HOST),
+                           F_->getValues(memory::HOST),
                            nullptr,
                            nullptr,
                            nullptr,
@@ -437,11 +447,56 @@ namespace ReSolve
 
       L_->setUpdated(memory::HOST);
       U_->setUpdated(memory::HOST);
-
+      F_->setUpdated(memory::HOST);
       (void) ok; // TODO: Check status in ok before setting `factors_extracted_`
       factors_extracted_ = true;
     }
     return U_;
+  }
+
+  /**
+   * @brief Get the factor F of the matrix A.
+   */
+  matrix::Sparse* LinSolverDirectKLU::getFFactor()
+  {
+    if (!factors_extracted_)
+    {
+      const int n = Symbolic_->n;
+      const int nnzL = Numeric_->lnz;
+      const int nnzU = Numeric_->unz;
+      const int nnzF = Numeric_->Offp [n];
+
+      L_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzL);
+      U_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzU);
+      F_ = new matrix::Csc(A_->getNumRows(), A_->getNumColumns(), nnzF);
+      L_->allocateMatrixData(memory::HOST);
+      U_->allocateMatrixData(memory::HOST);
+      F_->allocateMatrixData(memory::HOST);
+
+      int ok = klu_extract(Numeric_,
+                           Symbolic_,
+                           L_->getColData(memory::HOST),
+                           L_->getRowData(memory::HOST),
+                           L_->getValues(memory::HOST),
+                           U_->getColData(memory::HOST),
+                           U_->getRowData(memory::HOST),
+                           U_->getValues(memory::HOST),
+                           F_->getColData(memory::HOST),
+                           F_->getRowData(memory::HOST),
+                           F_->getValues(memory::HOST),
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           &Common_);
+
+      L_->setUpdated(memory::HOST);
+      U_->setUpdated(memory::HOST);
+      F_->setUpdated(memory::HOST);
+      (void) ok; // TODO: Check status in ok before setting `factors_extracted_`
+      factors_extracted_ = true;
+    }
+    return F_;
   }
 
   /**

--- a/resolve/LinSolverDirectKLU.hpp
+++ b/resolve/LinSolverDirectKLU.hpp
@@ -43,6 +43,7 @@ namespace ReSolve
     matrix::Sparse* getUFactorCsr() override;
     matrix::Sparse* getLFactor() override;
     matrix::Sparse* getUFactor() override;
+    matrix::Sparse* getFFactor() override;
     index_type*     getPOrdering() override;
     index_type*     getQOrdering() override;
 


### PR DESCRIPTION
## Description
 
 _ReSolve was completely ignoring the existence of F in the KLU factorization. The user will now have methods to examine F to at least see if ignoring F is valid mathematically._
 
 _Closes #338. Is necessary for solving #332  _

 ## Proposed changes
 
 The changes allow the user to debug, verify the existence and magnitude of nonzero entries in F, and use F in an external solver should a method for this arise._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [ ] All tests pass. Code tested on
     - [ ] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [ ] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [ ] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
