### PR TITLE
Fix CPU-only build failure for HyKKT Permutation test

### DIFF
--- a/resolve/hykkt/permutation/Permutation.cpp
+++ b/resolve/hykkt/permutation/Permutation.cpp
@@ -49,6 +49,7 @@ namespace ReSolve
         out::error() << "No GPU support enabled, and memory space set to DEVICE.\n";
         exit(1);
       }
+      devImpl_ = nullptr;
 #endif
     }
 


### PR DESCRIPTION
## Description
 
The segfault would occur when destructing a `Permutation` object because the `devImpl_` would be deleted when it should not have been.
 
Closes #347 
 
 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
 