### PR TITLE
Put sorting within KLU instead of within other solver logic.

### DIFF
--- a/resolve/LinSolverDirectCuSolverGLU.cpp
+++ b/resolve/LinSolverDirectCuSolverGLU.cpp
@@ -1,8 +1,6 @@
 #include "LinSolverDirectCuSolverGLU.hpp"
 
-#include <algorithm>
 #include <cstring> // includes memcpy
-#include <vector>
 
 #include <resolve/Profiling.hpp>
 #include <resolve/matrix/Csr.hpp>
@@ -235,10 +233,6 @@ namespace ReSolve
       {
         M_col[count++] = U_col[j];
       }
-    }
-    for (index_type i = 0; i < n; ++i) // this is crucial, turns out somehow the indices are not sorted
-    {
-      std::sort(M_col + M_row[i], M_col + M_row[i + 1]);
     }
   }
 

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -1,9 +1,7 @@
 #include "LinSolverDirectCuSolverRf.hpp"
 
-#include <algorithm>
 #include <cassert>
 #include <cstring> // includes memcpy
-#include <vector>
 
 #include <resolve/matrix/Csc.hpp>
 #include <resolve/matrix/Csr.hpp>
@@ -108,16 +106,6 @@ namespace ReSolve
 
     status_cusolverrf_ = cusolverRfSetResetValuesFastMode(handle_cusolverrf_, CUSOLVERRF_RESET_VALUES_FAST_MODE_ON);
     error_sum += status_cusolverrf_;
-    // sort L and U columns
-    for (index_type i = 0; i < n; ++i)
-    {
-      std::sort(L->getColData(memory::HOST) + L->getRowData(memory::HOST)[i],
-                L->getColData(memory::HOST) + L->getRowData(memory::HOST)[i + 1]);
-      std::sort(U->getColData(memory::HOST) + U->getRowData(memory::HOST)[i],
-                U->getColData(memory::HOST) + U->getRowData(memory::HOST)[i + 1]);
-    }
-    L->setUpdated(memory::HOST);
-    U->setUpdated(memory::HOST);
     L->syncData(memory::DEVICE);
     U->syncData(memory::DEVICE);
     status_cusolverrf_ = cusolverRfSetupDevice(n,

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -297,10 +297,11 @@ namespace ReSolve
                            nullptr,
                            nullptr,
                            &Common_);
-      // Sort the row indices in L and U to ensure they are in ordered CSR format
+      // Sort the column indices in L and U to ensure they are in ordered CSR format
+      // WARNING: Values are not sorted. We currently don't use values from KLU across solvers. If we ever decide to, we will need to change this.
       for (index_type i = 0; i < A_->getNumRows(); ++i)
       {
-        std::sort(L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i],
+        std::sort(L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i], //Sort L's column indices from the start of Row i to the start of Row i+1 (non inclusive)
                   L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i + 1]);
         std::sort(U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i],
                   U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i + 1]);

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -301,7 +301,7 @@ namespace ReSolve
       // WARNING: Values are not sorted. We currently don't use values from KLU across solvers. If we ever decide to, we will need to change this.
       for (index_type i = 0; i < A_->getNumRows(); ++i)
       {
-        std::sort(L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i], // Sort L's column indices from the start of Row i to the start of Row i+1 (non inclusive)
+        std::sort(L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i], // Sort L's column indices from the start of Row i to the start of Row i+1 (non inclusive).
                   L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i + 1]);
         std::sort(U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i],
                   U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i + 1]);

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -1,7 +1,9 @@
 #include "LinSolverDirectKLU.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <vector>
 
 #include <resolve/matrix/Csc.hpp>
 #include <resolve/matrix/Csr.hpp>
@@ -295,6 +297,14 @@ namespace ReSolve
                            nullptr,
                            nullptr,
                            &Common_);
+      // Sort the row indices in L and U to ensure they are in ordered CSR format
+      for (index_type i = 0; i < A_->getNumRows(); ++i)
+      {
+        std::sort(L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i],
+                  L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i + 1]);
+        std::sort(U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i],
+                  U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i + 1]);
+      }
 
       L_->setUpdated(memory::HOST);
       U_->setUpdated(memory::HOST);

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -301,7 +301,7 @@ namespace ReSolve
       // WARNING: Values are not sorted. We currently don't use values from KLU across solvers. If we ever decide to, we will need to change this.
       for (index_type i = 0; i < A_->getNumRows(); ++i)
       {
-        std::sort(L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i], //Sort L's column indices from the start of Row i to the start of Row i+1 (non inclusive)
+        std::sort(L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i], // Sort L's column indices from the start of Row i to the start of Row i+1 (non inclusive)
                   L_->getColData(memory::HOST) + L_->getRowData(memory::HOST)[i + 1]);
         std::sort(U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i],
                   U_->getColData(memory::HOST) + U_->getRowData(memory::HOST)[i + 1]);

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -842,10 +842,6 @@ namespace ReSolve
         M_col[count++] = U_col[j];
       }
     }
-    for (index_type i = 0; i < n; ++i) // this is crucial, turns out somehow the indices are not sorted
-    {
-      std::sort(M_col + M_row[i], M_col + M_row[i + 1]);
-    }
   }
 
   /**


### PR DESCRIPTION
## Description
 
 _Our solvers currently deal with unsorted factors internally, rather than requiring sorted factors from KLU._
 
Closes #358
Starts #357 
 
 ## Proposed changes
 
 _Removed duplicate code and explained the rationale in comments._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
