### PR TITLE
Fix warning on r_KLU_rocsolverrf_asym6x6

### DIFF
--- a/examples/experimental/r_KLU_rocsolverrf_asym6x6.cpp
+++ b/examples/experimental/r_KLU_rocsolverrf_asym6x6.cpp
@@ -65,7 +65,7 @@ int main()
     csr_row_ptr[i] += csr_row_ptr[i - 1];
   }
 
-  // Fill CSR arrays
+  // Fill CSR arrays.
   std::vector<int> temp_row_ptr = csr_row_ptr;
   for (size_t col = 0; col < static_cast<size_t>(n); ++col)
   {


### PR DESCRIPTION
## Description
 
There were some integer conversion warnings on `r_KLU_rocsolverrf_asym6x6` due to the use of `std::vector`, which is indexed differently from Re::Solve storage.

```
ReSolve/examples/experimental/r_KLU_rocsolverrf_asym6x6.cpp:52:37: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]
   52 |   std::vector<int>    csr_row_ptr(n + 1, 0);
```
 
 ## Proposed changes
 
Use `static_cast` to ensure the proper integer types are used to index `std::vector` and to instantiate Re::Solve matrices and vectors.
 
 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [N/A] The new code follows Re::Solve style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
 
 
 ## Further comments
 
We could consider avoiding the use of `std::vector` here altogether. I'm for keeping it, as this is an example, and users should be free to use whatever storage they wish.