### PR TITLE
Disallow sloppy calls to functions that allocate memory when they shouldn't.

### DIFF
--- a/examples/ExampleHelper.hpp
+++ b/examples/ExampleHelper.hpp
@@ -142,14 +142,10 @@ namespace ReSolve
                        ReSolve::vector::Vector* r,
                        ReSolve::vector::Vector* x)
       {
+        assert(res_ != nullptr && "resetSystem should be called after setSystem");
         A_ = A;
         r_ = r;
         x_ = x;
-        if (res_ == nullptr)
-        {
-          res_ = new ReSolve::vector::Vector(A->getNumRows());
-        }
-
         computeNorms();
       }
 

--- a/examples/gluRefactor.cpp
+++ b/examples/gluRefactor.cpp
@@ -264,7 +264,14 @@ int gluRefactor(int argc, char* argv[])
     RESOLVE_RANGE_POP("Triangular solve");
 
     // Print summary of the results
-    helper.resetSystem(A, vec_rhs, vec_x);
+    if (i == 0)
+    {
+      helper.setSystem(A, vec_rhs, vec_x);
+    }
+    else
+    {
+      helper.resetSystem(A, vec_rhs, vec_x);
+    }
     helper.printSummary();
 
   } // for (int i = 0; i < num_systems; ++i)

--- a/examples/gpuRefactor.cpp
+++ b/examples/gpuRefactor.cpp
@@ -260,7 +260,7 @@ int gpuRefactor(int argc, char* argv[])
       std::cout << "KLU solve status: " << status << std::endl;
 
       // Print summary of results
-      helper.resetSystem(A, vec_rhs, vec_x);
+      helper.setSystem(A, vec_rhs, vec_x);
       helper.printShortSummary();
 
       if (i == 1)

--- a/examples/kluFactor.cpp
+++ b/examples/kluFactor.cpp
@@ -184,8 +184,14 @@ int main(int argc, char* argv[])
 
     status = KLU.solve(vec_rhs, vec_x);
     std::cout << "KLU solve status: " << status << std::endl;
-
-    helper.resetSystem(A, vec_rhs, vec_x);
+    if (i == 0)
+    {
+      helper.setSystem(A, vec_rhs, vec_x);
+    }
+    else
+    {
+      helper.resetSystem(A, vec_rhs, vec_x);
+    }
     helper.printShortSummary();
     if (is_iterative_refinement)
     {

--- a/examples/kluRefactor.cpp
+++ b/examples/kluRefactor.cpp
@@ -191,7 +191,14 @@ int main(int argc, char* argv[])
     status = KLU->solve(vec_rhs, vec_x);
     std::cout << "KLU solve status: " << status << std::endl;
 
-    helper.resetSystem(A, vec_rhs, vec_x);
+    if (i == 0)
+    {
+      helper.setSystem(A, vec_rhs, vec_x);
+    }
+    else
+    {
+      helper.resetSystem(A, vec_rhs, vec_x);
+    }
     helper.printShortSummary();
     if (is_iterative_refinement)
     {

--- a/examples/randGmres.cpp
+++ b/examples/randGmres.cpp
@@ -183,7 +183,7 @@ int runGmresExample(int argc, char* argv[])
   FGMRES.solve(vec_rhs, vec_x);
 
   // Print summary of results
-  helper.resetSystem(A, vec_rhs, vec_x);
+  helper.setSystem(A, vec_rhs, vec_x);
   std::cout << "\nRandomized GMRES result on " << hwbackend << "\n";
   std::cout << "---------------------------------\n";
   helper.printIrSummary(&FGMRES);

--- a/examples/sysRefactor.cpp
+++ b/examples/sysRefactor.cpp
@@ -320,7 +320,14 @@ int sysRefactor(int argc, char* argv[])
     std::cout << "Triangular solve status: " << status << std::endl;
 
     // Print summary of results
-    helper.resetSystem(A, vec_rhs, vec_x);
+    if (i == 0)
+    {
+      helper.setSystem(A, vec_rhs, vec_x);
+    }
+    else
+    {
+      helper.resetSystem(A, vec_rhs, vec_x);
+    }
     helper.printShortSummary();
     if ((i > 1) && is_iterative_refinement)
     {

--- a/resolve/LinSolverDirect.cpp
+++ b/resolve/LinSolverDirect.cpp
@@ -55,6 +55,7 @@ namespace ReSolve
   {
     if (A == nullptr)
     {
+      out::error() << "LinSolverDirect::setup: input matrix A is nullptr" << std::endl;
       return 1;
     }
     A_ = A;

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -79,6 +79,7 @@ namespace ReSolve
     if (setup_completed_)
     {
       out::error() << "LinSolverDirectCuSolverRf::setup should only be called one." << std::endl;
+      return 1;
     }
 
     if (d_P_ == nullptr)
@@ -88,6 +89,7 @@ namespace ReSolve
     else
     {
       out::error() << "d_P_ should be nullptr on call to LinSolverDirectCuSolverRf::setup." << std::endl;
+      return 1;
     }
 
     if (d_Q_ == nullptr)
@@ -97,6 +99,7 @@ namespace ReSolve
     else
     {
       out::error() << "d_Q_ should be nullptr on call to LinSolverDirectCuSolverRf::setup." << std::endl;
+      return 1;
     }
 
     if (d_T_ == nullptr)
@@ -106,6 +109,7 @@ namespace ReSolve
     else
     {
       out::error() << "d_T_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" << std::endl;
+      return 1;
     }
 
     mem_.copyArrayHostToDevice(d_P_, P, n);

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -78,7 +78,7 @@ namespace ReSolve
 
     if (setup_completed_)
     {
-      out::error() << "LinSolverDirectCuSolverRf::setup should only be called one." << std::endl;
+      out::error() << "Trying to setup LinSolverDirectCuSolverRf, but the setup has been already done! " << std::endl;
       return 1;
     }
 
@@ -88,7 +88,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_P_ should be nullptr on call to LinSolverDirectCuSolverRf::setup." << std::endl;
+      out::error() << "Trying to allocate permutation vector P in " << __func__ << " in LinSolverDirectCuSolverRf, but the permutation vector P is already allocated! " << std::endl;
       return 1;
     }
 
@@ -98,7 +98,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectCuSolverRf::setup." << std::endl;
+      out::error() << "Trying to allocate permutation vector Q in " << __func__ << " in LinSolverDirectCuSolverRf, but the permutation vector Q is already allocated! " << std::endl;
       return 1;
     }
 
@@ -108,7 +108,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_T_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" << std::endl;
+      out::error() << "Trying to allocate temporary vector T in " << __func__ << " in LinSolverDirectCuSolverRf, but the temporary vector T is already allocated! " << std::endl;
       return 1;
     }
 

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -76,13 +76,18 @@ namespace ReSolve
     this->A_      = A;
     index_type n  = A_->getNumRows();
 
+    if (setup_completed_)
+    {
+      out::error() << "LinSolverDirectCuSolverRf::setup should only be called one." << std::endl;
+    }
+
     if (d_P_ == nullptr)
     {
       mem_.allocateArrayOnDevice(&d_P_, n);
     }
     else
     {
-      out::error() << "d_P_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" << std::endl;
+      out::error() << "d_P_ should be nullptr on call to LinSolverDirectCuSolverRf::setup." << std::endl;
     }
 
     if (d_Q_ == nullptr)
@@ -91,7 +96,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" << std::endl;
+      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectCuSolverRf::setup." << std::endl;
     }
 
     if (d_T_ == nullptr)

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -50,6 +50,7 @@ namespace ReSolve
    *
    * Sets up the cuSolverRf factorization for the given matrix A and its
    * L and U factors. The permutation vectors P and Q are also set up.
+   * This function should not be called more than once for the same object.
    *
    * @param[in] A - pointer to the matrix A
    * @param[in] L - pointer to the lower triangular factor L in CSR
@@ -75,31 +76,32 @@ namespace ReSolve
     this->A_      = A;
     index_type n  = A_->getNumRows();
 
-    // Remember - P and Q are generally CPU variables!
-    // Factorization data is stored in the handle.
-    // If function is called again, destroy the old handle to get rid of old data.
-    if (setup_completed_)
-    {
-      cusolverRfDestroy(handle_cusolverrf_);
-      cusolverRfCreate(&handle_cusolverrf_);
-    }
-
     if (d_P_ == nullptr)
     {
       mem_.allocateArrayOnDevice(&d_P_, n);
+    }
+    else
+    {
+      out::error() << "d_P_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" std::endl;
     }
 
     if (d_Q_ == nullptr)
     {
       mem_.allocateArrayOnDevice(&d_Q_, n);
     }
-
-    if (d_T_ != nullptr)
+    else
     {
-      mem_.deleteOnDevice(d_T_);
+      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" std::endl;
     }
 
-    mem_.allocateArrayOnDevice(&d_T_, n);
+    if (d_T_ == nullptr)
+    {
+      mem_.allocateArrayOnDevice(&d_T_, n);
+    }
+    else
+    {
+      out::error() << "d_T_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" std::endl;
+    }
 
     mem_.copyArrayHostToDevice(d_P_, P, n);
     mem_.copyArrayHostToDevice(d_Q_, Q, n);

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -82,7 +82,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_P_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" std::endl;
+      out::error() << "d_P_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" << std::endl;
     }
 
     if (d_Q_ == nullptr)
@@ -91,7 +91,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" std::endl;
+      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" << std::endl;
     }
 
     if (d_T_ == nullptr)
@@ -100,7 +100,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_T_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" std::endl;
+      out::error() << "d_T_ should be nullptr on call to LinSolverDirectCuSolverRf::setup" << std::endl;
     }
 
     mem_.copyArrayHostToDevice(d_P_, P, n);

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -127,7 +127,7 @@ namespace ReSolve
     if (Symbolic_ == nullptr)
     {
       out::error() << "Symbolic_ factorization failed with Common_.status = "
-                   << Common_.status << "\n";
+                   << Common_.status << std::endl;
       return 1;
     }
     return 0;
@@ -167,6 +167,8 @@ namespace ReSolve
 
     if (Numeric_ == nullptr)
     {
+      out::error() << "Numeric_ factorization failed with Common_.status = "
+                   << Common_.status << std::endl;
       return 1;
     }
     else

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -84,7 +84,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_P_ should be nullptr on call to LinSolverDirectRocSolverRf::setup." << std::endl;
+      out::error() << "Trying to allocate permutation vector P in " << __func__ << " in LinSolverDirectRocSolverRf, but the permutation vector P is already allocated! " << std::endl;
       return 1;
     }
 
@@ -94,7 +94,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectRocSolverRf::setup." << std::endl;
+      out::error() << "Trying to allocate permutation vector Q in " << __func__ << " in LinSolverDirectRocSolverRf, but the permutation vector Q is already allocated! " << std::endl;
       return 1;
     }
     mem_.copyArrayHostToDevice(d_P_, P, n);

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -84,7 +84,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_P_ should be nullptr on call to LinSolverDirectRocSolverRf::setup" << std::endl;
+      out::error() << "d_P_ should be nullptr on call to LinSolverDirectRocSolverRf::setup." << std::endl;
     }
 
     if (d_Q_ == nullptr)
@@ -93,7 +93,7 @@ namespace ReSolve
     }
     else
     {
-      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectRocSolverRf::setup" << std::endl;
+      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectRocSolverRf::setup." << std::endl;
     }
     mem_.copyArrayHostToDevice(d_P_, P, n);
     mem_.copyArrayHostToDevice(d_Q_, Q, n);

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -85,6 +85,7 @@ namespace ReSolve
     else
     {
       out::error() << "d_P_ should be nullptr on call to LinSolverDirectRocSolverRf::setup." << std::endl;
+      return 1;
     }
 
     if (d_Q_ == nullptr)
@@ -94,6 +95,7 @@ namespace ReSolve
     else
     {
       out::error() << "d_Q_ should be nullptr on call to LinSolverDirectRocSolverRf::setup." << std::endl;
+      return 1;
     }
     mem_.copyArrayHostToDevice(d_P_, P, n);
     mem_.copyArrayHostToDevice(d_Q_, Q, n);

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -82,10 +82,18 @@ namespace ReSolve
     {
       mem_.allocateArrayOnDevice(&d_P_, n);
     }
+    else
+    {
+      out::error() << "d_P_ should be nullptr on call to LinSolverDirectRocSolverRf::setup" << std::endl;
+    }
 
     if (d_Q_ == nullptr)
     {
       mem_.allocateArrayOnDevice(&d_Q_, n);
+    }
+    else
+    {
+      out::error() << "d_Q_ should be nullptr on call to LinSolverDirectRocSolverRf::setup" << std::endl;
     }
     mem_.copyArrayHostToDevice(d_P_, P, n);
     mem_.copyArrayHostToDevice(d_Q_, Q, n);

--- a/resolve/LinSolverIterative.cpp
+++ b/resolve/LinSolverIterative.cpp
@@ -26,6 +26,7 @@ namespace ReSolve
   {
     if (A == nullptr)
     {
+      out::error() << "LinSolverIterative::setup: input matrix A is nullptr" << std::endl;
       return 1;
     }
     this->A_ = A;

--- a/resolve/MemoryUtils.hpp
+++ b/resolve/MemoryUtils.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <cstring> // <- declares `memcpy`
-#include <resolve/utilities/logger/Logger.hpp>
 
 #include <resolve/resolve_defs.hpp>
+#include <resolve/utilities/logger/Logger.hpp>
 
 namespace ReSolve
 {
   using out = ReSolve::io::Logger;
+
   namespace memory
   {
     enum MemorySpace
@@ -88,18 +89,18 @@ namespace ReSolve
     {
       std::size_t arraysize = static_cast<std::size_t>(n) * sizeof(T);
       *v                    = new T[arraysize];
-      if (*v== nullptr)
+      if (*v == nullptr)
       {
         out::error() << "Memory allocation on host failed for size " << arraysize << " bytes." << std::endl;
         return 1;
       }
-      return 0; 
+      return 0;
     }
 
     template <typename T>
     int deleteOnHost(T* v)
     {
-      if (v== nullptr)
+      if (v == nullptr)
       {
         out::error() << "Trying to delete nullptr on host!" << std::endl;
         return 1;

--- a/resolve/MemoryUtils.hpp
+++ b/resolve/MemoryUtils.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <cstring> // <- declares `memcpy`
+#include <resolve/utilities/logger/Logger.hpp>
 
 #include <resolve/resolve_defs.hpp>
 
 namespace ReSolve
 {
+  using out = ReSolve::io::Logger;
   namespace memory
   {
     enum MemorySpace
@@ -86,12 +88,22 @@ namespace ReSolve
     {
       std::size_t arraysize = static_cast<std::size_t>(n) * sizeof(T);
       *v                    = new T[arraysize];
-      return *v == nullptr ? 1 : 0;
+      if (*v== nullptr)
+      {
+        out::error() << "Memory allocation on host failed for size " << arraysize << " bytes." << std::endl;
+        return 1;
+      }
+      return 0; 
     }
 
     template <typename T>
     int deleteOnHost(T* v)
     {
+      if (v== nullptr)
+      {
+        out::error() << "Trying to delete nullptr on host!" << std::endl;
+        return 1;
+      }
       delete[] v;
       v = nullptr;
       return 0;

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -372,10 +372,6 @@ namespace ReSolve
                                                       vectorHandler_,
                                                       gs_);
     }
-    else
-    {
-      // do nothing
-    }
 
     return 0;
   }
@@ -393,32 +389,43 @@ namespace ReSolve
       factorizationSolver_->setup(A_);
       return factorizationSolver_->analyze();
     }
+    out::error() << "Analyze method not set to a valid method!" << std::endl;
     return 1;
   }
 
   int SystemSolver::factorize()
   {
+    if (A_ == nullptr)
+    {
+      out::error() << "System matrix not set!\n";
+      return 1;
+    }
     if (factorizationMethod_ == "klu")
     {
       is_solve_on_device_ = false;
       return factorizationSolver_->factorize();
     }
+    out::error() << "Factorization method not set to a valid method!" << std::endl;
     return 1;
   }
 
   int SystemSolver::refactorize()
   {
+    if (A_ == nullptr)
+    {
+      out::error() << "System matrix not set!\n";
+      return 1;
+    }
     if (refactorizationMethod_ == "klu")
     {
       return factorizationSolver_->refactorize();
     }
-
     if (refactorizationMethod_ == "glu" || refactorizationMethod_ == "cusolverrf" || refactorizationMethod_ == "rocsolverrf")
     {
       is_solve_on_device_ = true;
       return refactorizationSolver_->refactorize();
     }
-
+    out::error() << "Refactorization method not set to a valid method!" << std::endl;
     return 1;
   }
 

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -389,7 +389,8 @@ namespace ReSolve
       factorizationSolver_->setup(A_);
       return factorizationSolver_->analyze();
     }
-    out::error() << "Analyze method not set to a valid method!" << std::endl;
+    out::error() << "Analysis method " << factorizationSolver_ << " not recognized!\n"
+                 << "Available options: klu.\n";
     return 1;
   }
 
@@ -405,7 +406,8 @@ namespace ReSolve
       is_solve_on_device_ = false;
       return factorizationSolver_->factorize();
     }
-    out::error() << "Factorization method not set to a valid method!" << std::endl;
+    out::error() << "Factorization method << factorizationSolver_ << not recognized!\n"
+                 << "Available options: klu.\n";
     return 1;
   }
 
@@ -425,7 +427,8 @@ namespace ReSolve
       is_solve_on_device_ = true;
       return refactorizationSolver_->refactorize();
     }
-    out::error() << "Refactorization method not set to a valid method!" << std::endl;
+    out::error() << "Refactorization method " << refactorizationSolver_ << " not recognized!\n"
+                 << "Available options: klu, glu, cusolverrf, rocsolverrf.\n";
     return 1;
   }
 

--- a/resolve/matrix/io.cpp
+++ b/resolve/matrix/io.cpp
@@ -386,7 +386,11 @@ namespace ReSolve
         Logger::error() << "Empty input to updateArrayFromFile function ..." << std::endl;
         return;
       }
-
+      if (p_rhs == nullptr)
+      {
+        Logger::error() << "Null pointer to array in updateArrayFromFile function ..." << std::endl;
+        return;
+      }
       real_type*        rhs = *p_rhs;
       std::stringstream ss;
       std::string       line;
@@ -399,11 +403,6 @@ namespace ReSolve
       }
       ss << line;
       ss >> n >> m;
-
-      if (rhs == nullptr)
-      {
-        rhs = new real_type[n];
-      }
       real_type  a;
       index_type i = 0;
       while (file >> a)

--- a/resolve/matrix/io.cpp
+++ b/resolve/matrix/io.cpp
@@ -388,7 +388,7 @@ namespace ReSolve
       }
       if (p_rhs == nullptr)
       {
-        Logger::error() << "Memory not allocated for updateArrayFromFile function."<< std::endl;
+        Logger::error() << "Memory not allocated for updateArrayFromFile function." << std::endl;
         return;
       }
       real_type*        rhs = *p_rhs;

--- a/resolve/matrix/io.cpp
+++ b/resolve/matrix/io.cpp
@@ -383,12 +383,12 @@ namespace ReSolve
     {
       if (!file)
       {
-        Logger::error() << "Empty input to updateArrayFromFile function ..." << std::endl;
+        Logger::error() << "Empty input to updateArrayFromFile function." << std::endl;
         return;
       }
       if (p_rhs == nullptr)
       {
-        Logger::error() << "Null pointer to array in updateArrayFromFile function ..." << std::endl;
+        Logger::error() << "Memory not allocated for updateArrayFromFile function."<< std::endl;
         return;
       }
       real_type*        rhs = *p_rhs;

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -632,7 +632,7 @@ namespace ReSolve
      * In case of multivectors, entire multivector is set to the constant.
      *
      * @param[in] C          - Constant (real number)
-     * @param[in] memspace   - Memory space of the data to be set to 0 (HOST or DEVICE)
+     * @param[in] memspace   - Memory space of the data to be set to constant (HOST or DEVICE)
      *
      */
     int Vector::setToConst(real_type C, memory::MemorySpace memspace)

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -681,7 +681,8 @@ namespace ReSolve
       case HOST:
         if (h_data_ == nullptr)
         {
-          out::error() << "Trying to set vector host values, but the values are not allocated!" << std::endl;
+          out::error() << "In Vector setToConst: trying to set host data to constant, "
+                       << "but host data not allocated!" << std::endl;
           return 1;
         }
         mem_.setArrayToConstOnHost(&h_data_[n_size_ * j], constant, n_size_);
@@ -691,7 +692,8 @@ namespace ReSolve
       case DEVICE:
         if (d_data_ == nullptr)
         {
-          out::error() << "Trying to set vector values on the device, but the memory is not allocated!" << std::endl;
+          out::error() << "In Vector setToConst: trying to set device data to constant, "
+                       << "but device data not allocated!" << std::endl;
           return 1;
         }
         mem_.setArrayToConstOnDevice(&d_data_[n_size_ * j], constant, n_size_);

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -681,8 +681,8 @@ namespace ReSolve
       case HOST:
         if (h_data_ == nullptr)
         {
-          h_data_        = new real_type[n_capacity_ * k_];
-          owns_cpu_data_ = true;
+          out::error() << "Trying to set vector host values, but the values are not allocated!" << std::endl;
+          return 1;
         }
         mem_.setArrayToConstOnHost(&h_data_[n_size_ * j], C, n_size_);
         cpu_updated_[j] = true;
@@ -691,8 +691,8 @@ namespace ReSolve
       case DEVICE:
         if (d_data_ == nullptr)
         {
-          mem_.allocateArrayOnDevice(&d_data_, n_capacity_ * k_);
-          owns_gpu_data_ = true;
+          out::error() << "Trying to set vector device values, but the values are not allocated!" << std::endl;
+          return 1;
         }
         mem_.setArrayToConstOnDevice(&d_data_[n_size_ * j], C, n_size_);
         cpu_updated_[j] = false;

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -631,7 +631,7 @@ namespace ReSolve
      *
      * In case of multivectors, entire multivector is set to the constant.
      *
-     * @param[in] constant          - Constant (real number)
+     * @param[in] constant   - Constant (real number)
      * @param[in] memspace   - Memory space of the data to be set to constant (HOST or DEVICE)
      *
      */
@@ -668,12 +668,12 @@ namespace ReSolve
      * @brief set the data of a single vector in a multivector to a given constant.
      *
      * @param[in] j          - Index of a vector in a multivector
-     * @param[in] C          - Constant (real number)
+     * @param[in] constant   - Constant (real number)
      * @param[in] memspace   - Memory space of the data to be set to 0 (HOST or DEVICE)
      *
      * @pre   _j_ < _k_ i.e,, _j_ is smaller than the total number of vectors in multivector.
      */
-    int Vector::setToConst(index_type j, real_type C, memory::MemorySpace memspace)
+    int Vector::setToConst(index_type j, real_type constant, memory::MemorySpace memspace)
     {
       using namespace ReSolve::memory;
       switch (memspace)
@@ -684,7 +684,7 @@ namespace ReSolve
           out::error() << "Trying to set vector host values, but the values are not allocated!" << std::endl;
           return 1;
         }
-        mem_.setArrayToConstOnHost(&h_data_[n_size_ * j], C, n_size_);
+        mem_.setArrayToConstOnHost(&h_data_[n_size_ * j], constant, n_size_);
         cpu_updated_[j] = true;
         gpu_updated_[j] = false;
         break;
@@ -694,7 +694,7 @@ namespace ReSolve
           out::error() << "Trying to set vector device values, but the values are not allocated!" << std::endl;
           return 1;
         }
-        mem_.setArrayToConstOnDevice(&d_data_[n_size_ * j], C, n_size_);
+        mem_.setArrayToConstOnDevice(&d_data_[n_size_ * j], constant, n_size_);
         cpu_updated_[j] = false;
         gpu_updated_[j] = true;
         break;

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -631,11 +631,11 @@ namespace ReSolve
      *
      * In case of multivectors, entire multivector is set to the constant.
      *
-     * @param[in] C          - Constant (real number)
+     * @param[in] constant          - Constant (real number)
      * @param[in] memspace   - Memory space of the data to be set to constant (HOST or DEVICE)
      *
      */
-    int Vector::setToConst(real_type C, memory::MemorySpace memspace)
+    int Vector::setToConst(real_type constant, memory::MemorySpace memspace)
     {
       using namespace ReSolve::memory;
       switch (memspace)
@@ -646,7 +646,7 @@ namespace ReSolve
           h_data_        = new real_type[n_capacity_ * k_];
           owns_cpu_data_ = true;
         }
-        mem_.setArrayToConstOnHost(h_data_, C, n_size_ * k_);
+        mem_.setArrayToConstOnHost(h_data_, constant, n_size_ * k_);
         setHostUpdated(true);
         setDeviceUpdated(false);
         break;
@@ -656,7 +656,7 @@ namespace ReSolve
           mem_.allocateArrayOnDevice(&d_data_, n_capacity_ * k_);
           owns_gpu_data_ = true;
         }
-        mem_.setArrayToConstOnDevice(d_data_, C, n_size_ * k_);
+        mem_.setArrayToConstOnDevice(d_data_, constant, n_size_ * k_);
         setHostUpdated(false);
         setDeviceUpdated(true);
         break;

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -691,7 +691,7 @@ namespace ReSolve
       case DEVICE:
         if (d_data_ == nullptr)
         {
-          out::error() << "Trying to set vector device values, but the values are not allocated!" << std::endl;
+          out::error() << "Trying to set vector values on the device, but the memory is not allocated!" << std::endl;
           return 1;
         }
         mem_.setArrayToConstOnDevice(&d_data_[n_size_ * j], constant, n_size_);

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -8,15 +8,15 @@
 #include <resolve/matrix/Csc.hpp>
 #include <resolve/matrix/Csr.hpp>
 #include <resolve/matrix/MatrixHandler.hpp>
+#include <resolve/utilities/logger/Logger.hpp>
 #include <resolve/vector/Vector.hpp>
 #include <resolve/workspace/LinAlgWorkspace.hpp>
-#include <resolve/utilities/logger/Logger.hpp>
 #include <tests/unit/TestBase.hpp>
-
 
 namespace ReSolve
 {
   using out = io::Logger;
+
   namespace tests
   {
 

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -10,10 +10,13 @@
 #include <resolve/matrix/MatrixHandler.hpp>
 #include <resolve/vector/Vector.hpp>
 #include <resolve/workspace/LinAlgWorkspace.hpp>
+#include <resolve/utilities/logger/Logger.hpp>
 #include <tests/unit/TestBase.hpp>
+
 
 namespace ReSolve
 {
+  using out = io::Logger;
   namespace tests
   {
 
@@ -616,6 +619,7 @@ namespace ReSolve
         // Check if the matrix is valid
         if (A == nullptr)
         {
+          out::error() << "Matrix pointer is NULL in " << __func__ << std::endl;
           return false;
         }
 
@@ -697,6 +701,7 @@ namespace ReSolve
         // Check if the matrix is valid
         if (A == nullptr)
         {
+          out::error() << "Matrix pointer is NULL in " << __func__ << std::endl;
           return false;
         }
 
@@ -780,6 +785,7 @@ namespace ReSolve
         // Check if the vector is valid
         if (scaled_vec == nullptr)
         {
+          out::error() << "Vector pointer is NULL in " << __func__ << std::endl;
           return false;
         }
 


### PR DESCRIPTION
## Description
 
 _Memory allocation can be incidental in ReSolve rather than explicitly defined by the user. Multiple calls to functions that should only be called once, or calls to function without first calling a prerequisite function are allowed. Addresses (no commitment that it fully closes) #295 and #19. I'd like your opinion on whether you think it closes these issues. Currently the code allows the user to set a vector to a constant without allocating it. I am ambivalent, but I do think it should be allowed over all. Let me know your thoughts._

 ## Proposed changes
 
 _Fixed typos, removed the ability to sloppy synch or sloppily call functions out of order._
 
 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] No merge conflicts.
- [x] The changes are included within the changelog.
