### PR TITLE
cmake-format

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,19 @@
+# -*- Python -*-
+
+with section("format"):
+
+    # How wide to allow formatted cmake files
+    line_width = 80
+
+    # How many spaces to tab for indent
+    tab_size = 2
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = False
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing
+    # parenthesis on its own line.
+    dangle_parens = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+    - id: cmake-format
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.7
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Re::Solve Changelog
 
+## Changes to Re::Solve since release 0.99.2
+
+- Added cmake-format
+
 ## Changes to Re::Solve in release 0.99.2
 
 ### Major Features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project(ReSolve VERSION "0.99.2")
 
 set(CMAKE_CXX_STANDARD 11)
 
-set(PACKAGE_NAME  "ReSolve")
+set(PACKAGE_NAME "ReSolve")
 set(PACKAGE_TARNAME "resolve")
 
 # Prohibit in-source build
@@ -21,38 +21,52 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "In-source build prohibited.")
 endif()
 
-if (MSVC)
+if(MSVC)
   set(CMAKE_CXX_FLAGS "/Wall")
 else()
   set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wconversion -Wpedantic")
 endif()
 
-option(RESOLVE_TEST_WITH_BSUB "Use `jsrun` instead of `mpirun` commands when running tests" OFF)
-option(RESOLVE_USE_KLU  "Use KLU, AMD and COLAMD libraries from SuiteSparse" OFF)
+option(RESOLVE_TEST_WITH_BSUB
+       "Use `jsrun` instead of `mpirun` commands when running tests" OFF
+)
+option(RESOLVE_USE_KLU "Use KLU, AMD and COLAMD libraries from SuiteSparse" OFF)
 option(RESOLVE_USE_LUSOL "Build the LUSOL library" OFF)
 option(RESOLVE_USE_CUDA "Use CUDA language and SDK" OFF)
-option(RESOLVE_USE_HIP  "Use HIP language and ROCm library" OFF)
+option(RESOLVE_USE_HIP "Use HIP language and ROCm library" OFF)
 option(RESOLVE_USE_PROFILING "Set profiling tracers in the code" OFF)
 
-option(RESOLVE_USE_GPU  "Use GPU device for computations" OFF)
+option(RESOLVE_USE_GPU "Use GPU device for computations" OFF)
 mark_as_advanced(FORCE RESOLVE_USE_GPU)
 
 option(RESOLVE_USE_ASAN "Enable the address sanitizer" OFF)
 option(RESOLVE_USE_UBSAN "Enable the undefined behavior sanitizer" OFF)
-option(RESOLVE_USE_DOXYGEN "Use Doxygen to generate Re::Solve documentation" OFF)
-set(RESOLVE_CTEST_OUTPUT_DIR ${PROJECT_BINARY_DIR} CACHE PATH "Directory where CTest outputs are saved")
+option(RESOLVE_USE_DOXYGEN "Use Doxygen to generate Re::Solve documentation"
+       OFF
+)
+set(RESOLVE_CTEST_OUTPUT_DIR
+    ${PROJECT_BINARY_DIR}
+    CACHE PATH "Directory where CTest outputs are saved"
+)
 
-# update this if more fortran code is added. this should be good enough for now though
+# update this if more fortran code is added. this should be good enough for now
+# though
 if(RESOLVE_USE_LUSOL)
   enable_language(Fortran)
 endif()
 
 if(RESOLVE_USE_CUDA)
-  set(RESOLVE_USE_GPU ON CACHE BOOL "Using CUDA GPU!" FORCE)
+  set(RESOLVE_USE_GPU
+      ON
+      CACHE BOOL "Using CUDA GPU!" FORCE
+  )
 endif()
 
 if(RESOLVE_USE_HIP)
-  set(RESOLVE_USE_GPU ON CACHE BOOL "Using HIP GPU!" FORCE)
+  set(RESOLVE_USE_GPU
+      ON
+      CACHE BOOL "Using HIP GPU!" FORCE
+  )
 endif()
 
 # MacOS specific things
@@ -66,24 +80,25 @@ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 # Add CMake sources from `cmake` dir
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-# Including clang-format cmake files to do automatic checking of formating
-# TODO: Set up clang-format
-#include(./cmake/clang-format)
+# Including clang-format cmake files to do automatic checking of formating TODO:
+# Set up clang-format include(./cmake/clang-format)
 
-# This will create target `doxygen` for building documentation locally.
-# For now, this target is intended only for developers who want to test
-# different documentation configurations. To have Doxygen configuration
-# changed at readthedocs, update `docs/doxygen/Doxyfile.in` accordingly.
-if (RESOLVE_USE_DOXYGEN)
+# This will create target `doxygen` for building documentation locally. For now,
+# this target is intended only for developers who want to test different
+# documentation configurations. To have Doxygen configuration changed at
+# readthedocs, update `docs/doxygen/Doxyfile.in` accordingly.
+if(RESOLVE_USE_DOXYGEN)
   include(ReSolveFindDoxygen)
 endif()
 
-
-if (RESOLVE_USE_KLU)
+if(RESOLVE_USE_KLU)
   include(FindSuiteSparse)
   if(NOT SUITESPARSE_LIBRARY)
     message(STATUS "Cannot find KLU, disabling SuiteSparse module ...")
-    set(RESOLVE_USE_KLU OFF CACHE BOOL "Build without SuiteSparse module." FORCE)
+    set(RESOLVE_USE_KLU
+        OFF
+        CACHE BOOL "Build without SuiteSparse module." FORCE
+    )
   endif()
 else()
   message(STATUS "Not using SuiteSparse KLU")
@@ -102,7 +117,10 @@ if(RESOLVE_USE_CUDA)
   endif()
 
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES 60 CACHE STRING "Selects CUDA architectures")
+    set(CMAKE_CUDA_ARCHITECTURES
+        60
+        CACHE STRING "Selects CUDA architectures"
+    )
   endif()
 
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
@@ -123,12 +141,11 @@ endif(RESOLVE_USE_HIP)
 # The binary dir is already a global include directory
 configure_file(
   ${CMAKE_SOURCE_DIR}/resolve/resolve_defs.hpp.in
-  ${CMAKE_BINARY_DIR}/resolve/resolve_defs.hpp)
-install(
-  FILES ${CMAKE_BINARY_DIR}/resolve/resolve_defs.hpp
-  DESTINATION include/resolve
-  )
-
+  ${CMAKE_BINARY_DIR}/resolve/resolve_defs.hpp
+)
+install(FILES ${CMAKE_BINARY_DIR}/resolve/resolve_defs.hpp
+        DESTINATION include/resolve
+)
 
 # Enable testing
 enable_testing()
@@ -140,31 +157,38 @@ add_subdirectory(resolve)
 include(CMakePackageConfigHelpers)
 
 # Creates a version file for the package
-write_basic_package_version_file(ReSolveConfigVersion.cmake
-                                 VERSION ${CMAKE_PROJECT_VERSION}
-                                 COMPATIBILITY AnyNewerVersion)
-
-# Generate install rules for targets
-install(EXPORT ReSolveTargets
-        FILE ReSolveTargets.cmake
-        NAMESPACE ReSolve::
-        DESTINATION share/resolve/cmake
+write_basic_package_version_file(
+  ReSolveConfigVersion.cmake
+  VERSION ${CMAKE_PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion
 )
 
+# Generate install rules for targets
+install(
+  EXPORT ReSolveTargets
+  FILE ReSolveTargets.cmake
+  NAMESPACE ReSolve::
+  DESTINATION share/resolve/cmake
+)
 
 # Creates a config file
-configure_package_config_file(./cmake/ReSolveConfig.cmake.in
-                              ${CMAKE_CURRENT_BINARY_DIR}/ReSolveConfig.cmake
-                              INSTALL_DESTINATION share/resolve/cmake)
+configure_package_config_file(
+  ./cmake/ReSolveConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/ReSolveConfig.cmake
+  INSTALL_DESTINATION share/resolve/cmake
+)
 
 # Generates install rules for cmake config files
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ReSolveConfig.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/ReSolveConfigVersion.cmake"
-        DESTINATION share/resolve/cmake)
+              "${CMAKE_CURRENT_BINARY_DIR}/ReSolveConfigVersion.cmake"
+        DESTINATION share/resolve/cmake
+)
 
 # Add usage examples
 add_subdirectory(examples)
 
 # Add tests
-set(RESOLVE_CTEST_OUTPUT_DIR ${PROJECT_BINARY_DIR} CACHE PATH "Directory where CTest outputs are saved")
+set(RESOLVE_CTEST_OUTPUT_DIR
+    ${PROJECT_BINARY_DIR}
+    CACHE PATH "Directory where CTest outputs are saved"
+)
 add_subdirectory(tests)

--- a/cmake/FindSuiteSparse.cmake
+++ b/cmake/FindSuiteSparse.cmake
@@ -9,43 +9,44 @@ Author(s):
 - Cameron Rutherford <cameron.rutherford@pnnl.gov>
 
 ]]
-set(SUITESPARSE_MODULES
-  amd
-  colamd
-  klu
-  suitesparseconfig)
+set(SUITESPARSE_MODULES amd colamd klu suitesparseconfig)
 
-find_library(SUITESPARSE_LIBRARY
-  NAMES
-  ${SUITESPARSE_MODULES}
-  PATHS
-  ${SUITESPARSE_DIR} $ENV{SUITESPARSE_DIR} ${SUITESPARSE_ROOT_DIR}
-  ENV LD_LIBRARY_PATH ENV DYLD_LIBRARY_PATH
-  PATH_SUFFIXES
-  lib64 lib)
+find_library(
+  SUITESPARSE_LIBRARY
+  NAMES ${SUITESPARSE_MODULES}
+  PATHS ${SUITESPARSE_DIR}
+        $ENV{SUITESPARSE_DIR}
+        ${SUITESPARSE_ROOT_DIR}
+        ENV
+        LD_LIBRARY_PATH
+        ENV
+        DYLD_LIBRARY_PATH
+  PATH_SUFFIXES lib64 lib
+)
 
 if(SUITESPARSE_LIBRARY)
   set(SUITESPARSE_LIBRARY CACHE FILEPATH "Path to Suitesparse library")
-  get_filename_component(SUITESPARSE_LIBRARY_DIR ${SUITESPARSE_LIBRARY} DIRECTORY CACHE "Suitesparse library directory")
+  get_filename_component(
+    SUITESPARSE_LIBRARY_DIR ${SUITESPARSE_LIBRARY} DIRECTORY CACHE
+    "Suitesparse library directory"
+  )
   message(STATUS "Found Suitesparse libraries in: " ${SUITESPARSE_LIBRARY_DIR})
   mark_as_advanced(SUITESPARSE_LIBRARY SUITESPARSE_LIBRARY_DIR)
   if(NOT SUITESPARSE_DIR)
-    get_filename_component(SUITESPARSE_DIR ${SUITESPARSE_LIBRARY_DIR} DIRECTORY CACHE)
+    get_filename_component(
+      SUITESPARSE_DIR ${SUITESPARSE_LIBRARY_DIR} DIRECTORY CACHE
+    )
   endif()
 endif()
 
 # Find SUITESPARSE header path and ensure all needed files are there
-find_path(SUITESPARSE_INCLUDE_DIR
-  NAMES
-  amd.h
-  colamd.h
-  klu.h
-  SuiteSparse_config.h
-  PATHS
-  ${SUITESPARSE_DIR} $ENV{SUITESPARSE_DIR} ${SUITESPARSE_ROOT_DIR} ${SUITESPARSE_LIBRARY_DIR}/..
-  PATH_SUFFIXES
-  include
-  include/suitesparse)
+find_path(
+  SUITESPARSE_INCLUDE_DIR
+  NAMES amd.h colamd.h klu.h SuiteSparse_config.h
+  PATHS ${SUITESPARSE_DIR} $ENV{SUITESPARSE_DIR} ${SUITESPARSE_ROOT_DIR}
+        ${SUITESPARSE_LIBRARY_DIR}/..
+  PATH_SUFFIXES include include/suitesparse
+)
 
 if(SUITESPARSE_LIBRARY)
   message(STATUS "Found Suitesparse include: ${SUITESPARSE_INCLUDE_DIR}")
@@ -54,9 +55,11 @@ if(SUITESPARSE_LIBRARY)
   add_library(SUITESPARSE INTERFACE IMPORTED)
   target_include_directories(SUITESPARSE INTERFACE ${SUITESPARSE_INCLUDE_DIR})
   foreach(mod ${SUITESPARSE_MODULES})
-    find_library(suitesparse_${mod}
+    find_library(
+      suitesparse_${mod}
       NAMES ${mod}
-      HINTS ${SUITESPARSE_LIBRARY_DIR})
+      HINTS ${SUITESPARSE_LIBRARY_DIR}
+    )
     if(suitesparse_${mod})
       message(STATUS "Found suitesparse internal library " ${mod})
       target_link_libraries(SUITESPARSE INTERFACE ${suitesparse_${mod}})
@@ -67,15 +70,25 @@ if(SUITESPARSE_LIBRARY)
   endforeach(mod)
 else()
   if(NOT SUITESPARSE_ROOT_DIR)
-    message(STATUS "Suitesparse dir not found! Please provide correct filepath.")
-    set(SUITESPARSE_DIR ${SUITESPARSE_DIR} CACHE PATH "Path to Suitesparse installation root.")
+    message(
+      STATUS "Suitesparse dir not found! Please provide correct filepath."
+    )
+    set(SUITESPARSE_DIR
+        ${SUITESPARSE_DIR}
+        CACHE PATH "Path to Suitesparse installation root."
+    )
     unset(SUITESPARSE_LIBRARY CACHE)
     unset(SUITESPARSE_INCLUDE_DIR CACHE)
     unset(SUITESPARSE_LIBRARY_DIR CACHE)
   elseif(NOT SUITESPARSE_LIBRARY)
-    message(STATUS "Suitesparse library not found! Please provide correct filepath.")
+    message(
+      STATUS "Suitesparse library not found! Please provide correct filepath."
+    )
   endif()
   if(SUITESPARSE_ROOT_DIR AND NOT SUITESPARSE_INCLUDE_DIR)
-    message(STATUS "Suitesparse include dir not found! Please provide correct filepath.")
+    message(
+      STATUS
+        "Suitesparse include dir not found! Please provide correct filepath."
+    )
   endif()
 endif()

--- a/cmake/ReSolveFindCudaLibraries.cmake
+++ b/cmake/ReSolveFindCudaLibraries.cmake
@@ -1,21 +1,17 @@
-# Exports target `resolve_cuda` which finds all cuda libraries needed by resolve.
-
+# Exports target `resolve_cuda` which finds all cuda libraries needed by
+# resolve.
 
 add_library(resolve_cuda INTERFACE)
 
 find_package(CUDAToolkit REQUIRED)
 
-target_link_libraries(resolve_cuda INTERFACE
-  CUDA::cusolver 
-  CUDA::cublas
-  CUDA::cusparse
-  CUDA::cudart
-  )
+target_link_libraries(
+  resolve_cuda INTERFACE CUDA::cusolver CUDA::cublas CUDA::cusparse
+                         CUDA::cudart
+)
 
 if(RESOLVE_USE_PROFILING)
-  target_link_libraries(resolve_cuda INTERFACE
-    CUDA::nvToolsExt
-  )
+  target_link_libraries(resolve_cuda INTERFACE CUDA::nvToolsExt)
 endif()
 
 install(TARGETS resolve_cuda EXPORT ReSolveTargets)

--- a/cmake/ReSolveFindDoxygen.cmake
+++ b/cmake/ReSolveFindDoxygen.cmake
@@ -10,51 +10,52 @@ Command `make doxygen` will create Doxygen documentation in the
 ]]
 find_package(Doxygen)
 
-if ( DOXYGEN_FOUND )
-  set( DOXYGEN_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/doxygen )
+if(DOXYGEN_FOUND)
+  set(DOXYGEN_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/doxygen)
   # set( DOXYGEN_CREATE_SUBDIRS YES )
-  set( DOXYGEN_COLLABORATION_GRAPH YES )
-  set( DOXYGEN_EXTRACT_ALL YES )
-  set( DOXYGEN_CLASS_DIAGRAMS YES )
-  set( DOXYGEN_HIDE_UNDOC_RELATIONS NO )
-  set( DOXYGEN_HAVE_DOT YES )
-  set( DOXYGEN_CLASS_GRAPH YES )
-  set( DOXYGEN_CALL_GRAPH YES )
-  set( DOXYGEN_CALLER_GRAPH YES )
-  set( DOXYGEN_COLLABORATION_GRAPH YES )
-  set( DOXYGEN_BUILTIN_STL_SUPPORT YES )
-  set( DOXYGEN_EXTRACT_PRIVATE YES )
-  set( DOXYGEN_EXTRACT_PACKAGE YES )
-  set( DOXYGEN_EXTRACT_STATIC YES )
-  set( DOXYGEN_EXTRACT_LOCALMETHODS YES )
-  set( DOXYGEN_UML_LOOK YES )
-  set( DOXYGEN_UML_LIMIT_NUM_FIELDS 50 )
-  set( DOXYGEN_TEMPLATE_RELATIONS YES )
-  set( DOXYGEN_DOT_GRAPH_MAX_NODES 100 )
-  set( DOXYGEN_MAX_DOT_GRAPH_DEPTH 0 )
-  set( DOXYGEN_DOT_TRANSPARENT YES )
-  set( DOXYGEN_DOT_IMAGE_FORMAT svg )
-  set( DOXYGEN_INTERACTIVE_SVG YES )
+  set(DOXYGEN_COLLABORATION_GRAPH YES)
+  set(DOXYGEN_EXTRACT_ALL YES)
+  set(DOXYGEN_CLASS_DIAGRAMS YES)
+  set(DOXYGEN_HIDE_UNDOC_RELATIONS NO)
+  set(DOXYGEN_HAVE_DOT YES)
+  set(DOXYGEN_CLASS_GRAPH YES)
+  set(DOXYGEN_CALL_GRAPH YES)
+  set(DOXYGEN_CALLER_GRAPH YES)
+  set(DOXYGEN_COLLABORATION_GRAPH YES)
+  set(DOXYGEN_BUILTIN_STL_SUPPORT YES)
+  set(DOXYGEN_EXTRACT_PRIVATE YES)
+  set(DOXYGEN_EXTRACT_PACKAGE YES)
+  set(DOXYGEN_EXTRACT_STATIC YES)
+  set(DOXYGEN_EXTRACT_LOCALMETHODS YES)
+  set(DOXYGEN_UML_LOOK YES)
+  set(DOXYGEN_UML_LIMIT_NUM_FIELDS 50)
+  set(DOXYGEN_TEMPLATE_RELATIONS YES)
+  set(DOXYGEN_DOT_GRAPH_MAX_NODES 100)
+  set(DOXYGEN_MAX_DOT_GRAPH_DEPTH 0)
+  set(DOXYGEN_DOT_TRANSPARENT YES)
+  set(DOXYGEN_DOT_IMAGE_FORMAT svg)
+  set(DOXYGEN_INTERACTIVE_SVG YES)
   set(DOXYGEN_DISABLE_INDEX NO)
   set(DOXYGEN_FULL_SIDEBAR NO)
   set(DOXYGEN_GENERATE_TREEVIEW YES)
-  set(DOXYGEN_HTML_EXTRA_STYLESHEET 
+  set(DOXYGEN_HTML_EXTRA_STYLESHEET
       "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome.css"
       # "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-custom/custom.css"
-      #"${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-sidebar-only.css"
-      #"${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-sidebar-only-darkmode-toggle.css"
+      # "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-sidebar-only.css"
+      # "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-sidebar-only-darkmode-toggle.css"
       # "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-custom/custom-alternative.css"
-     )
-set(DOXYGEN_HTML_EXTRA_FILES 
+  )
+  set(DOXYGEN_HTML_EXTRA_FILES
       "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js"
       "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-fragment-copy-button.js"
       "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-paragraph-link.js"
       "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-custom/toggle-alternative-theme.js"
       "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-interactive-toc.js"
-      "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-tabs.js")
+      "${CMAKE_SOURCE_DIR}/docs/doxygen-awesome-css/doxygen-awesome-tabs.js"
+  )
   set(DOXYGEN_HTML_COLORSTYLE LIGHT)
-  doxygen_add_docs( doxygen ${CMAKE_SOURCE_DIR}/resolve )
+  doxygen_add_docs(doxygen ${CMAKE_SOURCE_DIR}/resolve)
 
 else()
-  message( "Doxygen need to be installed to generate the doxygen documentation" )
+  message("Doxygen need to be installed to generate the doxygen documentation")
 endif()

--- a/cmake/ReSolveFindHipLibraries.cmake
+++ b/cmake/ReSolveFindHipLibraries.cmake
@@ -1,6 +1,5 @@
 # Exports target `resolve_hip` which finds all hip libraries needed by resolve.
 
-
 add_library(resolve_hip INTERFACE)
 
 find_package(hip REQUIRED)
@@ -8,29 +7,27 @@ find_package(rocblas REQUIRED)
 find_package(rocsparse REQUIRED)
 find_package(rocsolver REQUIRED)
 
-target_link_libraries(resolve_hip INTERFACE 
-  hip::host 
-  hip::device
-  roc::rocblas
-  roc::rocsparse
-  roc::rocsolver
+target_link_libraries(
+  resolve_hip INTERFACE hip::host hip::device roc::rocblas roc::rocsparse
+                        roc::rocsolver
 )
 
 if(RESOLVE_USE_PROFILING)
   find_package(rocprofiler-sdk REQUIRED)
   find_package(rocprofiler-sdk-roctx REQUIRED)
-  target_link_libraries(resolve_hip INTERFACE
-    rocprofiler-sdk::rocprofiler-sdk
-    rocprofiler-sdk-roctx::rocprofiler-sdk-roctx
+  target_link_libraries(
+    resolve_hip INTERFACE rocprofiler-sdk::rocprofiler-sdk
+                          rocprofiler-sdk-roctx::rocprofiler-sdk-roctx
   )
 endif()
 
-# HIP/ROCm targets still don't have include directories set correctly
-# We need this little hack for now :/
+# HIP/ROCm targets still don't have include directories set correctly We need
+# this little hack for now :/
 get_target_property(hip_includes hip::device INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "HIP include directories found at: ${hip_includes}")
 
-target_include_directories(resolve_hip INTERFACE 
-  $<BUILD_INTERFACE:${hip_includes}>)
+target_include_directories(
+  resolve_hip INTERFACE $<BUILD_INTERFACE:${hip_includes}>
+)
 
 install(TARGETS resolve_hip EXPORT ReSolveTargets)

--- a/cmake/ReSolveFindHipLibraries.cmake
+++ b/cmake/ReSolveFindHipLibraries.cmake
@@ -21,7 +21,7 @@ if(RESOLVE_USE_PROFILING)
   )
 endif()
 
-# HIP/ROCm targets still don't have include directories set correctly We need
+# HIP/ROCm targets still don't have include directories set correctly. We need
 # this little hack for now :/
 get_target_property(hip_includes hip::device INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "HIP include directories found at: ${hip_includes}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,16 +41,15 @@ if(RESOLVE_USE_KLU)
 
 endif(RESOLVE_USE_KLU)
 
-
 set(installable_executables "")
 
 # Install all examples in bin directory
-list(APPEND installable_executables  rand_gmres.exe)
+list(APPEND installable_executables rand_gmres.exe)
 
 if(RESOLVE_USE_KLU)
-  list(APPEND installable_executables kluFactor.exe
-                                      kluRefactor.exe
-                                      sysRefactor.exe)
+  list(APPEND installable_executables kluFactor.exe kluRefactor.exe
+       sysRefactor.exe
+  )
 
   if(RESOLVE_USE_GPU)
     list(APPEND installable_executables gpuRefactor.exe)
@@ -62,8 +61,7 @@ if(RESOLVE_USE_KLU)
 
 endif(RESOLVE_USE_KLU)
 
-install(TARGETS ${installable_executables}
-        RUNTIME DESTINATION bin)
+install(TARGETS ${installable_executables} RUNTIME DESTINATION bin)
 
 add_subdirectory(experimental)
 
@@ -98,10 +96,18 @@ set(asym_rhs_path /data/b_asymmetric)
 
 # Install directory with example on how to consume ReSolve
 install(DIRECTORY resolve_consumer DESTINATION share/examples)
-install(FILES ${PROJECT_SOURCE_DIR}/tests/functionality/${RESOLVE_CONSUMER_APP} DESTINATION share/examples/resolve_consumer RENAME consumer.cpp)
-install(FILES ${PROJECT_SOURCE_DIR}/tests/functionality/TestHelper.hpp DESTINATION share/examples/resolve_consumer)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/tests/functionality/${RESOLVE_CONSUMER_APP}
+  DESTINATION share/examples/resolve_consumer
+  RENAME consumer.cpp
+)
+install(FILES ${PROJECT_SOURCE_DIR}/tests/functionality/TestHelper.hpp
+        DESTINATION share/examples/resolve_consumer
+)
 
-# Shell script argumets:
-#    1. Path to where resolve is installed.
-#    2. Path to data directory
-add_custom_target(test_install COMMAND ${CONSUMER_PATH}/test.sh  ${CMAKE_INSTALL_PREFIX} ${test_data_dir} ${sym_matrix_path} ${sym_rhs_path}) 
+# Shell script argumets: 1. Path to where resolve is installed. 2. Path to data
+# directory
+add_custom_target(
+  test_install COMMAND ${CONSUMER_PATH}/test.sh ${CMAKE_INSTALL_PREFIX}
+                       ${test_data_dir} ${sym_matrix_path} ${sym_rhs_path}
+)

--- a/examples/experimental/CMakeLists.txt
+++ b/examples/experimental/CMakeLists.txt
@@ -11,16 +11,24 @@ if(RESOLVE_USE_KLU)
   # Create KLU+CUDA examples
   if(RESOLVE_USE_CUDA)
 
-    # Build example where matrix is factorized once, refactorized once and then the preconditioner is REUSED
-    add_executable(klu_rf_fgmres_reuse_refactorization.exe r_KLU_rf_FGMRES_reuse_factorization.cpp)
-    target_link_libraries(klu_rf_fgmres_reuse_refactorization.exe PRIVATE ReSolve)
+    # Build example where matrix is factorized once, refactorized once and then
+    # the preconditioner is REUSED
+    add_executable(
+      klu_rf_fgmres_reuse_refactorization.exe
+      r_KLU_rf_FGMRES_reuse_factorization.cpp
+    )
+    target_link_libraries(
+      klu_rf_fgmres_reuse_refactorization.exe PRIVATE ReSolve
+    )
 
     # Build example where matrix data is updated
     add_executable(klu_glu_values_update.exe r_KLU_GLU_matrix_values_update.cpp)
     target_link_libraries(klu_glu_values_update.exe PRIVATE ReSolve)
 
     # Example in which factorization is redone if solution is bad
-    add_executable(klu_cusolverrf_check_redo.exe r_KLU_cusolverrf_redo_factorization.cpp)
+    add_executable(
+      klu_cusolverrf_check_redo.exe r_KLU_cusolverrf_redo_factorization.cpp
+    )
     target_link_libraries(klu_cusolverrf_check_redo.exe PRIVATE ReSolve)
 
   endif(RESOLVE_USE_CUDA)
@@ -29,28 +37,30 @@ if(RESOLVE_USE_KLU)
   if(RESOLVE_USE_HIP)
 
     # Example in which factorization is redone if solution is bad
-    add_executable(klu_rocsolverrf_check_redo.exe r_KLU_rocsolverrf_redo_factorization.cpp)
+    add_executable(
+      klu_rocsolverrf_check_redo.exe r_KLU_rocsolverrf_redo_factorization.cpp
+    )
     target_link_libraries(klu_rocsolverrf_check_redo.exe PRIVATE ReSolve)
 
-    add_executable(r_KLU_rocsolverrf_asym6x6.exe r_KLU_rocsolverrf_asym6x6.cpp) # Example with refactorization on GPU with the same system (from kalmarek).
+    add_executable(r_KLU_rocsolverrf_asym6x6.exe r_KLU_rocsolverrf_asym6x6.cpp
+    )# Example with refactorization on GPU with the same system (from kalmarek).
     target_link_libraries(r_KLU_rocsolverrf_asym6x6.exe PRIVATE ReSolve)
 
   endif(RESOLVE_USE_HIP)
 
 endif(RESOLVE_USE_KLU)
 
-
 set(installable_executables "")
 
 # Install all examples in bin directory
-list(APPEND installable_executables  rand_gmres.exe)
+list(APPEND installable_executables rand_gmres.exe)
 
 if(RESOLVE_USE_KLU)
 
   if(RESOLVE_USE_CUDA)
     list(APPEND installable_executables klu_glu_values_update.exe
-                                        klu_cusolverrf_check_redo.exe
-                                        klu_rf_fgmres_reuse_refactorization.exe)
+         klu_cusolverrf_check_redo.exe klu_rf_fgmres_reuse_refactorization.exe
+    )
   endif(RESOLVE_USE_CUDA)
 
   if(RESOLVE_USE_HIP)
@@ -58,5 +68,4 @@ if(RESOLVE_USE_KLU)
   endif(RESOLVE_USE_HIP)
 endif(RESOLVE_USE_KLU)
 
-install(TARGETS ${installable_executables}
-        RUNTIME DESTINATION bin)
+install(TARGETS ${installable_executables} RUNTIME DESTINATION bin)

--- a/examples/resolve_consumer/CMakeLists.txt
+++ b/examples/resolve_consumer/CMakeLists.txt
@@ -1,7 +1,7 @@
-# Example of how to consume Resolve as package via cmake
-# Below is a standard example of a CMakeLists.txt file that ultizies Resolve
-# See the Readme on how to build and install ReSolve
-#----------------------------------------------------------------------------------
+# Example of how to consume Resolve as package via cmake Below is a standard
+# example of a CMakeLists.txt file that ultizies Resolve See the Readme on how
+# to build and install ReSolve
+# ----------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.20)
 
 project(resolve_consumer LANGUAGES CXX)
@@ -13,9 +13,13 @@ find_package(ReSolve REQUIRED)
 add_executable(consume.exe consumer.cpp)
 target_link_libraries(consume.exe PRIVATE ReSolve::ReSolve)
 
-#------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------
 # Testing of exported Resolve Configurations
 enable_testing()
 
-# RESOLVE_DATA is set in test.sh and is the file path the matrix data files used in the testKLU_Rf_FGMRES.
-add_test(NAME resolve_consumer COMMAND $<TARGET_FILE:consume.exe> "-d" "${ReSolve_DATA_DIR}" "-i" "-m" "${ReSolve_MATRICES}" "-r" "${ReSolve_RHS}")
+# RESOLVE_DATA is set in test.sh and is the file path the matrix data files used
+# in the testKLU_Rf_FGMRES.
+add_test(NAME resolve_consumer
+         COMMAND $<TARGET_FILE:consume.exe> "-d" "${ReSolve_DATA_DIR}" "-i"
+                 "-m" "${ReSolve_MATRICES}" "-r" "${ReSolve_RHS}"
+)

--- a/resolve/CMakeLists.txt
+++ b/resolve/CMakeLists.txt
@@ -22,25 +22,19 @@ set(ReSolve_SRC
     SystemSolver.cpp
 )
 
-set(ReSolve_KLU_SRC
-  LinSolverDirectKLU.cpp
-)
+set(ReSolve_KLU_SRC LinSolverDirectKLU.cpp)
 
-set(ReSolve_LUSOL_SRC
-  LinSolverDirectLUSOL.cpp
-)
+set(ReSolve_LUSOL_SRC LinSolverDirectLUSOL.cpp)
 
 # C++ code that links to CUDA SDK libraries
 set(ReSolve_CUDASDK_SRC
-    LinSolverDirectCuSolverGLU.cpp
-    LinSolverDirectCuSolverRf.cpp
+    LinSolverDirectCuSolverGLU.cpp LinSolverDirectCuSolverRf.cpp
     LinSolverDirectCuSparseILU0.cpp
 )
 
 # C++ code that links to ROCm libraries
-set(ReSolve_ROCM_SRC
-    LinSolverDirectRocSolverRf.cpp
-    LinSolverDirectRocSparseILU0.cpp
+set(ReSolve_ROCM_SRC LinSolverDirectRocSolverRf.cpp
+                     LinSolverDirectRocSparseILU0.cpp
 )
 
 # Header files to be installed
@@ -54,25 +48,20 @@ set(ReSolve_HEADER_INSTALL
     LinSolverDirectCpuILU0.hpp
     SystemSolver.hpp
     GramSchmidt.hpp
-    MemoryUtils.hpp)
-
-set(ReSolve_KLU_HEADER_INSTALL
-    LinSolverDirectKLU.hpp
+    MemoryUtils.hpp
 )
 
-set(ReSolve_LUSOL_HEADER_INSTALL
-  LinSolverDirectLUSOL.hpp
-)
+set(ReSolve_KLU_HEADER_INSTALL LinSolverDirectKLU.hpp)
+
+set(ReSolve_LUSOL_HEADER_INSTALL LinSolverDirectLUSOL.hpp)
 
 set(ReSolve_CUDA_HEADER_INSTALL
-    LinSolverDirectCuSolverGLU.hpp
-    LinSolverDirectCuSolverRf.hpp
+    LinSolverDirectCuSolverGLU.hpp LinSolverDirectCuSolverRf.hpp
     LinSolverDirectCuSparseILU0.hpp
 )
 
-set(ReSolve_ROCM_HEADER_INSTALL
-  LinSolverDirectRocSolverRf.hpp
-  LinSolverDirectRocSparseILU0.hpp
+set(ReSolve_ROCM_HEADER_INSTALL LinSolverDirectRocSolverRf.hpp
+                                LinSolverDirectRocSparseILU0.hpp
 )
 
 # Now, build workspaces
@@ -93,19 +82,11 @@ if(RESOLVE_USE_KLU)
   list(APPEND ReSolve_HEADER_INSTALL ${ReSolve_KLU_HEADER_INSTALL})
 endif()
 
-set(ReSolve_Targets_List
-    resolve_matrix
-    resolve_vector
-    resolve_random
-    resolve_logger
-    resolve_tpl
-    resolve_workspace
+set(ReSolve_Targets_List resolve_matrix resolve_vector resolve_random
+                         resolve_logger resolve_tpl resolve_workspace
 )
 
-set(ReSolve_Object_List
-    resolve_options
-    resolve_version
-)
+set(ReSolve_Object_List resolve_options resolve_version)
 
 if(RESOLVE_USE_LUSOL)
   add_subdirectory(lusol)
@@ -142,7 +123,9 @@ endif()
 if(RESOLVE_USE_ASAN)
   add_library(resolve_asan INTERFACE)
   target_compile_options(resolve_asan INTERFACE "-fsanitize=address")
-  target_link_libraries(resolve_asan INTERFACE "-fsanitize=address -fno-omit-frame-pointer")
+  target_link_libraries(
+    resolve_asan INTERFACE "-fsanitize=address -fno-omit-frame-pointer"
+  )
   target_link_libraries(resolve_tpl INTERFACE resolve_asan)
   list(APPEND ReSolve_Targets_List resolve_asan)
 endif()
@@ -151,7 +134,9 @@ endif()
 if(RESOLVE_USE_UBSAN)
   add_library(resolve_ubsan INTERFACE)
   target_compile_options(resolve_ubsan INTERFACE "-fsanitize=undefined")
-  target_link_libraries(resolve_ubsan INTERFACE "-fsanitize=undefined -fno-omit-frame-pointer")
+  target_link_libraries(
+    resolve_ubsan INTERFACE "-fsanitize=undefined -fno-omit-frame-pointer"
+  )
   target_link_libraries(resolve_tpl INTERFACE resolve_ubsan)
   list(APPEND ReSolve_Targets_List resolve_ubsan)
 endif()
@@ -162,9 +147,9 @@ install(TARGETS ${ReSolve_Targets_List} EXPORT ReSolveTargets)
 # Create ReSolve library
 add_library(ReSolve SHARED ${ReSolve_SRC})
 
-target_include_directories(ReSolve INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  ReSolve INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+                    $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(ReSolve PUBLIC ${ReSolve_Targets_List})
@@ -173,20 +158,26 @@ target_link_libraries(ReSolve PRIVATE ${ReSolve_Object_List})
 if(RESOLVE_USE_PROFILING)
   if(NOT RESOLVE_USE_GPU)
     # Noting to do for profiling on the host for now.
-    message(NOTICE "Profiling support enabled, but Re::Solve does not create tracer annotations for host code.")
+    message(
+      NOTICE
+      "Profiling support enabled, but Re::Solve does not create tracer annotations for host code."
+    )
     message(NOTICE "This profiling support option will have no effect.")
   endif()
 endif(RESOLVE_USE_PROFILING)
 
 # Install targets
-install(TARGETS ReSolve
-        EXPORT ReSolveTargets
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+install(
+  TARGETS ReSolve
+  EXPORT ReSolveTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
 
 # install include headers
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/resolve/ # source directory
-        DESTINATION include/resolve # target directory
-        FILES_MATCHING # install only matched files
-        PATTERN "*.hpp" # select header files
+install(
+  DIRECTORY ${CMAKE_SOURCE_DIR}/resolve/ # source directory
+  DESTINATION include/resolve # target directory
+  FILES_MATCHING # install only matched files
+  PATTERN "*.hpp" # select header files
 )

--- a/resolve/cpu/CMakeLists.txt
+++ b/resolve/cpu/CMakeLists.txt
@@ -6,13 +6,9 @@
 
 ]]
 
-set(ReSolve_CPU_SRC
-    MemoryUtils.cpp
-)
+set(ReSolve_CPU_SRC MemoryUtils.cpp)
 
-set(ReSolve_CPU_HEADER_INSTALL
-    CpuMemory.hpp
-)
+set(ReSolve_CPU_HEADER_INSTALL CpuMemory.hpp)
 
 # First create dummy backend
 add_library(resolve_backend_cpu SHARED ${ReSolve_CPU_SRC})

--- a/resolve/cuda/CMakeLists.txt
+++ b/resolve/cuda/CMakeLists.txt
@@ -6,26 +6,19 @@
 
 ]]
 
-set(ReSolve_CUDA_SRC
-    cudaKernels.cu
-    cudaSketchingKernels.cu
-    cudaVectorKernels.cu
-    MemoryUtils.cu
+set(ReSolve_CUDA_SRC cudaKernels.cu cudaSketchingKernels.cu
+                     cudaVectorKernels.cu MemoryUtils.cu
 )
 
 set(ReSolve_CUDA_HEADER_INSTALL
-    cudaKernels.h
-    cudaSketchingKernels.h
-    cudaVectorKernels.h
-    CudaMemory.hpp
+    cudaKernels.h cudaSketchingKernels.h cudaVectorKernels.h CudaMemory.hpp
     cuda_check_errors.hpp
 )
 
 set_source_files_properties(${ReSolve_CUDA_SRC} PROPERTIES LANGUAGE CUDA)
 
-# First create CUDA backend 
-# (this should really be CUDA _API_ backend, 
-# separate backend will be needed for CUDA SDK)
+# First create CUDA backend (this should really be CUDA _API_ backend, separate
+# backend will be needed for CUDA SDK)
 add_library(resolve_backend_cuda SHARED ${ReSolve_CUDA_SRC})
 target_link_libraries(resolve_backend_cuda PRIVATE resolve_logger)
 target_link_libraries(resolve_backend_cuda PUBLIC resolve_cuda)

--- a/resolve/hip/CMakeLists.txt
+++ b/resolve/hip/CMakeLists.txt
@@ -6,26 +6,19 @@
 
 ]]
 
-set(ReSolve_HIP_SRC
-    hipKernels.hip
-    hipSketchingKernels.hip
-    hipVectorKernels.hip
-    MemoryUtils.hip
+set(ReSolve_HIP_SRC hipKernels.hip hipSketchingKernels.hip hipVectorKernels.hip
+                    MemoryUtils.hip
 )
 
 set(ReSolve_HIP_HEADER_INSTALL
-    hipKernels.h
-    hipSketchingKernels.h
-    hipVectorKernels.h
-    HipMemory.hpp
+    hipKernels.h hipSketchingKernels.h hipVectorKernels.h HipMemory.hpp
     hip_check_errors.hpp
 )
 
 set_source_files_properties(${ReSolve_HIP_SRC} PROPERTIES LANGUAGE HIP)
 
-# First create HIP backend 
-# (this should really be HIP _API_ backend, 
-# separate backend will be needed for HIP SDK)
+# First create HIP backend (this should really be HIP _API_ backend, separate
+# backend will be needed for HIP SDK)
 add_library(resolve_backend_hip SHARED ${ReSolve_HIP_SRC})
 target_link_libraries(resolve_backend_hip PRIVATE resolve_logger)
 target_link_libraries(resolve_backend_hip PUBLIC resolve_hip)

--- a/resolve/matrix/CMakeLists.txt
+++ b/resolve/matrix/CMakeLists.txt
@@ -18,23 +18,14 @@ set(Matrix_SRC
 )
 
 # C++ code that depends on CUDA SDK libraries
-set(Matrix_CUDASDK_SRC
-    MatrixHandlerCuda.cpp
-)
+set(Matrix_CUDASDK_SRC MatrixHandlerCuda.cpp)
 
 # and on HIP
-set(Matrix_ROCM_SRC
-  MatrixHandlerHip.cpp
-)
+set(Matrix_ROCM_SRC MatrixHandlerHip.cpp)
 
 # Header files to be installed
-set(Matrix_HEADER_INSTALL
-    io.hpp
-    Sparse.hpp
-    Coo.hpp
-    Csr.hpp
-    Csc.hpp
-    MatrixHandler.hpp
+set(Matrix_HEADER_INSTALL io.hpp Sparse.hpp Coo.hpp Csr.hpp Csc.hpp
+                          MatrixHandler.hpp
 )
 
 # Build shared library ReSolve::matrix
@@ -42,24 +33,24 @@ add_library(resolve_matrix SHARED ${Matrix_SRC})
 target_link_libraries(resolve_matrix PRIVATE resolve_logger resolve_vector)
 
 # Link to CUDA ReSolve backend if CUDA is support enabled
-if (RESOLVE_USE_CUDA)
+if(RESOLVE_USE_CUDA)
   target_sources(resolve_matrix PRIVATE ${Matrix_CUDASDK_SRC})
   target_link_libraries(resolve_matrix PUBLIC resolve_backend_cuda)
 endif()
 
-if (RESOLVE_USE_HIP)
+if(RESOLVE_USE_HIP)
   target_sources(resolve_matrix PRIVATE ${Matrix_ROCM_SRC})
   target_link_libraries(resolve_matrix PUBLIC resolve_backend_hip)
 endif()
 
 # Link to dummy device backend if GPU support is not enabled
-if (NOT RESOLVE_USE_GPU)
+if(NOT RESOLVE_USE_GPU)
   target_link_libraries(resolve_matrix PUBLIC resolve_backend_cpu)
 endif()
 
-target_include_directories(resolve_matrix INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  resolve_matrix INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+                           $<INSTALL_INTERFACE:include>
 )
 
 install(FILES ${Matrix_HEADER_INSTALL} DESTINATION include/resolve/matrix)

--- a/resolve/random/CMakeLists.txt
+++ b/resolve/random/CMakeLists.txt
@@ -7,72 +7,57 @@
 ]]
 
 # C++ code
-set(Random_SRC 
-    RandomSketchingCountCpu.cpp
-    RandomSketchingFWHTCpu.cpp
-    cpuSketchingKernels.cpp
-    SketchingHandler.cpp
+set(Random_SRC RandomSketchingCountCpu.cpp RandomSketchingFWHTCpu.cpp
+               cpuSketchingKernels.cpp SketchingHandler.cpp
 )
 
 # C++ code that depends on CUDA SDK libraries
-set(Random_CUDASDK_SRC 
-    RandomSketchingCountCuda.cpp
-    RandomSketchingFWHTCuda.cpp
-)
+set(Random_CUDASDK_SRC RandomSketchingCountCuda.cpp RandomSketchingFWHTCuda.cpp)
 
 # C++ code that depends on ROCm libraries
-set(Random_ROCM_SRC 
-    RandomSketchingCountHip.cpp
-    RandomSketchingFWHTHip.cpp
-)
+set(Random_ROCM_SRC RandomSketchingCountHip.cpp RandomSketchingFWHTHip.cpp)
 
 # Header files to be installed
 set(Random_HEADER_INSTALL
-    RandomSketchingImpl.hpp
-    RandomSketchingCountCpu.hpp
-    RandomSketchingFWHTCpu.hpp
-    cpuSketchingKernels.h
-    SketchingHandler.hpp
+    RandomSketchingImpl.hpp RandomSketchingCountCpu.hpp
+    RandomSketchingFWHTCpu.hpp cpuSketchingKernels.h SketchingHandler.hpp
 )
 
 # Header files to be installed when HIP support is enabled
-set(Random_ROCM_HEADER_INSTALL
-    RandomSketchingCountHip.hpp
-    RandomSketchingFWHTHip.hpp
+set(Random_ROCM_HEADER_INSTALL RandomSketchingCountHip.hpp
+                               RandomSketchingFWHTHip.hpp
 )
 
 # Header files to be installed when HIP support is enabled
-set(Random_CUDASDK_HEADER_INSTALL
-    RandomSketchingCountCuda.hpp
-    RandomSketchingFWHTCuda.hpp
+set(Random_CUDASDK_HEADER_INSTALL RandomSketchingCountCuda.hpp
+                                  RandomSketchingFWHTCuda.hpp
 )
-
 
 # Build shared library ReSolve::random
 add_library(resolve_random SHARED ${Random_SRC})
 target_link_libraries(resolve_random PRIVATE resolve_logger resolve_vector)
 
 # Link to CUDA ReSolve backend if CUDA is support enabled
-if (RESOLVE_USE_CUDA)
+if(RESOLVE_USE_CUDA)
   target_sources(resolve_random PRIVATE ${Random_CUDASDK_SRC})
   target_link_libraries(resolve_random PUBLIC resolve_backend_cuda)
   list(APPEND Random_HEADER_INSTALL ${Random_CUDASDK_HEADER_INSTALL})
 endif()
 
-if (RESOLVE_USE_HIP)
+if(RESOLVE_USE_HIP)
   target_sources(resolve_random PRIVATE ${Random_ROCM_SRC})
   target_link_libraries(resolve_random PUBLIC resolve_backend_hip)
   list(APPEND Random_HEADER_INSTALL ${Random_ROCM_HEADER_INSTALL})
 endif()
 
 # Link to dummy device backend if GPU support is not enabled
-if (NOT RESOLVE_USE_GPU)
+if(NOT RESOLVE_USE_GPU)
   target_link_libraries(resolve_random PUBLIC resolve_backend_cpu)
 endif()
 
-target_include_directories(resolve_random INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  resolve_random INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+                           $<INSTALL_INTERFACE:include>
 )
 
 install(FILES ${Random_HEADER_INSTALL} DESTINATION include/resolve/random)

--- a/resolve/utilities/logger/CMakeLists.txt
+++ b/resolve/utilities/logger/CMakeLists.txt
@@ -6,21 +6,19 @@
 
 ]]
 
-set(Logger_SRC 
-  Logger.cpp
-)
+set(Logger_SRC Logger.cpp)
 
-set(Logger_HEADER_INSTALL
-  Logger.hpp
-)
+set(Logger_HEADER_INSTALL Logger.hpp)
 
 # Build shared library ReSolve
 add_library(resolve_logger SHARED ${Logger_SRC})
 
-target_include_directories(resolve_logger PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  resolve_logger
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> $<INSTALL_INTERFACE:include>
 )
 
-install(FILES ${Logger_HEADER_INSTALL} DESTINATION include/resolve/utilities/logger)
+install(FILES ${Logger_HEADER_INSTALL}
+        DESTINATION include/resolve/utilities/logger
+)

--- a/resolve/utilities/params/CMakeLists.txt
+++ b/resolve/utilities/params/CMakeLists.txt
@@ -6,22 +6,20 @@
 
 ]]
 
-set(Options_SRC 
-  CliOptions.cpp
-)
+set(Options_SRC CliOptions.cpp)
 
-set(Options_HEADER_INSTALL
-  CliOptions.hpp
-)
+set(Options_HEADER_INSTALL CliOptions.hpp)
 
 # Build shared library ReSolve
 add_library(resolve_options OBJECT ${Options_SRC})
 set_property(TARGET resolve_options PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(resolve_options PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  resolve_options
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> $<INSTALL_INTERFACE:include>
 )
 
-install(FILES ${Options_HEADER_INSTALL} DESTINATION include/resolve/utilities/params)
+install(FILES ${Options_HEADER_INSTALL}
+        DESTINATION include/resolve/utilities/params
+)

--- a/resolve/utilities/version/CMakeLists.txt
+++ b/resolve/utilities/version/CMakeLists.txt
@@ -6,22 +6,20 @@
 
 ]]
 
-set(Logger_SRC 
-  version.cpp
-)
+set(Logger_SRC version.cpp)
 
-set(Logger_HEADER_INSTALL
-  version.hpp
-)
+set(Logger_HEADER_INSTALL version.hpp)
 
 # Build shared library ReSolve
 add_library(resolve_version OBJECT ${Logger_SRC})
 set_property(TARGET resolve_version PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories(resolve_version PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  resolve_version
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> $<INSTALL_INTERFACE:include>
 )
 
-install(FILES ${Logger_HEADER_INSTALL} DESTINATION include/resolve/utilities/version)
+install(FILES ${Logger_HEADER_INSTALL}
+        DESTINATION include/resolve/utilities/version
+)

--- a/resolve/vector/CMakeLists.txt
+++ b/resolve/vector/CMakeLists.txt
@@ -7,27 +7,16 @@
 ]]
 
 # C++ code
-set(Vector_SRC 
-    Vector.cpp
-    VectorHandler.cpp
-    VectorHandlerCpu.cpp
-)
+set(Vector_SRC Vector.cpp VectorHandler.cpp VectorHandlerCpu.cpp)
 
 # C++ code that depends on CUDA SDK libraries
-set(Vector_CUDASDK_SRC 
-    VectorHandlerCuda.cpp
-)
+set(Vector_CUDASDK_SRC VectorHandlerCuda.cpp)
 
-#and hip
-set(Vector_ROCM_SRC 
-    VectorHandlerHip.cpp
-)
+# and hip
+set(Vector_ROCM_SRC VectorHandlerHip.cpp)
 
 # Header files to be installed
-set(Vector_HEADER_INSTALL
-    Vector.hpp
-    VectorHandler.hpp
-)
+set(Vector_HEADER_INSTALL Vector.hpp VectorHandler.hpp)
 
 add_library(resolve_vector SHARED ${Vector_SRC})
 target_link_libraries(resolve_vector PRIVATE resolve_logger)
@@ -49,9 +38,9 @@ if(NOT RESOLVE_USE_GPU)
   target_link_libraries(resolve_vector PUBLIC resolve_backend_cpu)
 endif(NOT RESOLVE_USE_GPU)
 
-target_include_directories(resolve_vector INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+  resolve_vector INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+                           $<INSTALL_INTERFACE:include>
 )
 
 install(FILES ${Vector_HEADER_INSTALL} DESTINATION include/resolve/vector)

--- a/resolve/workspace/CMakeLists.txt
+++ b/resolve/workspace/CMakeLists.txt
@@ -7,24 +7,16 @@
 ]]
 
 # C++ code
-set(ReSolve_Workspace_SRC
-  LinAlgWorkspaceCpu.cpp
-)
+set(ReSolve_Workspace_SRC LinAlgWorkspaceCpu.cpp)
 
 # C++ code that depends on CUDA SDK libraries
-set(ReSolve_Workspace_CUDASDK_SRC
-    LinAlgWorkspaceCUDA.cpp
-)
+set(ReSolve_Workspace_CUDASDK_SRC LinAlgWorkspaceCUDA.cpp)
 
-set(ReSolve_Workspace_ROCM_SRC
-  LinAlgWorkspaceHIP.cpp
-)
+set(ReSolve_Workspace_ROCM_SRC LinAlgWorkspaceHIP.cpp)
 
 set(ReSolve_Workspace_HEADER_INSTALL
-  LinAlgWorkspace.hpp
-  LinAlgWorkspaceCpu.hpp
-  LinAlgWorkspaceCUDA.hpp
-  LinAlgWorkspaceHIP.hpp
+    LinAlgWorkspace.hpp LinAlgWorkspaceCpu.hpp LinAlgWorkspaceCUDA.hpp
+    LinAlgWorkspaceHIP.hpp
 )
 
 add_library(resolve_workspace SHARED ${ReSolve_Workspace_SRC})
@@ -40,11 +32,13 @@ if(RESOLVE_USE_HIP)
   target_link_libraries(resolve_workspace PUBLIC resolve_backend_hip)
 endif()
 
-target_include_directories(resolve_workspace PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-  $<INSTALL_INTERFACE:include>
+target_include_directories(
+  resolve_workspace
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}> $<INSTALL_INTERFACE:include>
 )
 
 # install include headers
-install(FILES ${ReSolve_Workspace_HEADER_INSTALL} DESTINATION include/resolve/workspace)
+install(FILES ${ReSolve_Workspace_HEADER_INSTALL}
+        DESTINATION include/resolve/workspace
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,5 +6,5 @@
 
 ]]
 
-add_subdirectory(functionality) 
+add_subdirectory(functionality)
 add_subdirectory(unit)

--- a/tests/functionality/CMakeLists.txt
+++ b/tests/functionality/CMakeLists.txt
@@ -7,7 +7,7 @@
 ]]
 
 # Build basic version test
-add_executable(version.exe testVersion.cpp) 
+add_executable(version.exe testVersion.cpp)
 target_link_libraries(version.exe PRIVATE ReSolve)
 
 # Build test for Krylov solvers
@@ -44,7 +44,6 @@ if(RESOLVE_USE_LUSOL)
   target_link_libraries(lusol_test.exe PRIVATE ReSolve)
 endif()
 
-
 # Install tests
 set(installable_tests version.exe)
 list(APPEND installable_tests rand_gmres_test.exe)
@@ -53,8 +52,7 @@ list(APPEND installable_tests sys_rand_gmres_test.exe)
 if(RESOLVE_USE_KLU)
   list(APPEND installable_tests klu_klu_test.exe)
   if(RESOLVE_USE_GPU)
-    list(APPEND installable_tests klu_rf_test.exe
-                                  sys_refactor_test.exe)
+    list(APPEND installable_tests klu_rf_test.exe sys_refactor_test.exe)
   endif(RESOLVE_USE_GPU)
 
   if(RESOLVE_USE_CUDA)
@@ -66,8 +64,9 @@ if(RESOLVE_USE_LUSOL)
   list(APPEND installable_tests lusol_test.exe)
 endif()
 
-install(TARGETS ${installable_tests} 
-        RUNTIME DESTINATION bin/resolve/tests/functionality)
+install(TARGETS ${installable_tests}
+        RUNTIME DESTINATION bin/resolve/tests/functionality
+)
 
 # Install directory with data files
 install(DIRECTORY data DESTINATION bin/resolve/tests/functionality)
@@ -79,67 +78,189 @@ set(sym_rhs_path /data/rhs_ACTIVSg200_AC_renumbered_add9_ones_)
 set(asym_matrix_path /data/A_asymmetric)
 set(asym_rhs_path /data/b_asymmetric)
 
-
 add_test(NAME version COMMAND $<TARGET_FILE:version.exe>)
 
 if(RESOLVE_USE_LUSOL)
-  add_test(NAME lusol_test COMMAND $<TARGET_FILE:lusol_test.exe> "${test_data_dir}")
+  add_test(NAME lusol_test COMMAND $<TARGET_FILE:lusol_test.exe>
+                                   "${test_data_dir}"
+  )
 endif()
 
 # Krylov solvers tests (FGMRES)
-add_test(NAME sys_rand_count_fgmres_cgs2_test     COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "cgs2" "-s" "count")
-add_test(NAME sys_rand_count_fgmres_mgs_test      COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "mgs" "-s" "count")
-add_test(NAME sys_rand_count_fgmres_mgs2sync_test COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "mgs_two_sync" "-s" "count")
-add_test(NAME sys_rand_count_fgmres_mgspm_test    COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "mgs_pm" "-s" "count")
-add_test(NAME sys_rand_fwht_fgmres_cgs2_test      COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "cgs2" "-s" "fwht")
-add_test(NAME sys_rand_fwht_fgmres_mgs_test       COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "mgs" "-s" "fwht")
-add_test(NAME sys_rand_fwht_fgmres_mgs2sync_test  COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "mgs_two_sync" "-s" "fwht")
-add_test(NAME sys_rand_fwht_fgmres_mgspm_test     COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g" "mgs_pm" "-s" "fwht")
-add_test(NAME sys_fgmres_cgs2_test     COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "fgmres" "-g" "cgs2")
-add_test(NAME sys_fgmres_mgs_test      COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "fgmres" "-g" "mgs")
-add_test(NAME sys_fgmres_mgs2sync_test COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "fgmres" "-g" "mgs_two_sync")
-add_test(NAME sys_fgmres_mgspm_test    COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "fgmres" "-g" "mgs_pm")
+add_test(NAME sys_rand_count_fgmres_cgs2_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "cgs2" "-s" "count"
+)
+add_test(NAME sys_rand_count_fgmres_mgs_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "mgs" "-s" "count"
+)
+add_test(NAME sys_rand_count_fgmres_mgs2sync_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "mgs_two_sync" "-s" "count"
+)
+add_test(NAME sys_rand_count_fgmres_mgspm_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "mgs_pm" "-s" "count"
+)
+add_test(NAME sys_rand_fwht_fgmres_cgs2_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "cgs2" "-s" "fwht"
+)
+add_test(NAME sys_rand_fwht_fgmres_mgs_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "mgs" "-s" "fwht"
+)
+add_test(NAME sys_rand_fwht_fgmres_mgs2sync_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "mgs_two_sync" "-s" "fwht"
+)
+add_test(NAME sys_rand_fwht_fgmres_mgspm_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "randgmres" "-g"
+                 "mgs_pm" "-s" "fwht"
+)
+add_test(NAME sys_fgmres_cgs2_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "fgmres" "-g"
+                 "cgs2"
+)
+add_test(NAME sys_fgmres_mgs_test COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe>
+                                          "-i" "fgmres" "-g" "mgs"
+)
+add_test(NAME sys_fgmres_mgs2sync_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "fgmres" "-g"
+                 "mgs_two_sync"
+)
+add_test(NAME sys_fgmres_mgspm_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-i" "fgmres" "-g"
+                 "mgs_pm"
+)
 
 # Krylov solvers tests (GMRES)
-add_test(NAME sys_rand_count_gmres_cgs2_test     COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "cgs2" "-s" "count")
-add_test(NAME sys_rand_count_gmres_mgs_test      COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "mgs" "-s" "count")
-add_test(NAME sys_rand_count_gmres_mgs2sync_test COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "mgs_two_sync" "-s" "count")
-add_test(NAME sys_rand_count_gmres_mgspm_test    COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "mgs_pm" "-s" "count")
-add_test(NAME sys_rand_fwht_gmres_cgs2_test      COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "cgs2" "-s" "fwht")
-add_test(NAME sys_rand_fwht_gmres_mgs_test       COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "mgs" "-s" "fwht")
-add_test(NAME sys_rand_fwht_gmres_mgs2sync_test  COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "mgs_two_sync" "-s" "fwht")
-add_test(NAME sys_rand_fwht_gmres_mgspm_test     COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "randgmres" "-g" "mgs_pm" "-s" "fwht")
-add_test(NAME sys_gmres_cgs2_test     COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "fgmres" "-g" "cgs2")
-add_test(NAME sys_gmres_mgs_test      COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "fgmres" "-g" "mgs")
-add_test(NAME sys_gmres_mgs2sync_test COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "fgmres" "-g" "mgs_two_sync")
-add_test(NAME sys_gmres_mgspm_test    COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "fgmres" "-g" "mgs_pm")
+add_test(NAME sys_rand_count_gmres_cgs2_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "cgs2" "-s" "count"
+)
+add_test(NAME sys_rand_count_gmres_mgs_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "mgs" "-s" "count"
+)
+add_test(NAME sys_rand_count_gmres_mgs2sync_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "mgs_two_sync" "-s" "count"
+)
+add_test(NAME sys_rand_count_gmres_mgspm_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "mgs_pm" "-s" "count"
+)
+add_test(NAME sys_rand_fwht_gmres_cgs2_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "cgs2" "-s" "fwht"
+)
+add_test(NAME sys_rand_fwht_gmres_mgs_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "mgs" "-s" "fwht"
+)
+add_test(NAME sys_rand_fwht_gmres_mgs2sync_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "mgs_two_sync" "-s" "fwht"
+)
+add_test(NAME sys_rand_fwht_gmres_mgspm_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i"
+                 "randgmres" "-g" "mgs_pm" "-s" "fwht"
+)
+add_test(NAME sys_gmres_cgs2_test COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe>
+                                          "-x" "no" "-i" "fgmres" "-g" "cgs2"
+)
+add_test(NAME sys_gmres_mgs_test COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe>
+                                         "-x" "no" "-i" "fgmres" "-g" "mgs"
+)
+add_test(NAME sys_gmres_mgs2sync_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "fgmres"
+                 "-g" "mgs_two_sync"
+)
+add_test(NAME sys_gmres_mgspm_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "fgmres"
+                 "-g" "mgs_pm"
+)
 
 # Randomized GMRES solvers tested without SystemSolver class
-add_test(NAME rand_gmres_test    COMMAND $<TARGET_FILE:rand_gmres_test.exe>)
+add_test(NAME rand_gmres_test COMMAND $<TARGET_FILE:rand_gmres_test.exe>)
 
 if(RESOLVE_USE_KLU)
   # Using KLU as refactorization solver
-  add_test(NAME klu_klu_test    COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}") 
-  add_test(NAME klu_klu_ir_test COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}" "-i")
-  add_test(NAME klu_klu_asym_test COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}")
-  add_test(NAME klu_klu_asym_ir_test COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}" "-i") 
+  add_test(NAME klu_klu_test
+           COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m"
+                   "${sym_matrix_path}" "-r" "${sym_rhs_path}"
+  )
+  add_test(NAME klu_klu_ir_test
+           COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m"
+                   "${sym_matrix_path}" "-r" "${sym_rhs_path}" "-i"
+  )
+  add_test(NAME klu_klu_asym_test
+           COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m"
+                   "${asym_matrix_path}" "-r" "${asym_rhs_path}"
+  )
+  add_test(NAME klu_klu_asym_ir_test
+           COMMAND $<TARGET_FILE:klu_klu_test.exe> "-d" "${test_data_dir}" "-m"
+                   "${asym_matrix_path}" "-r" "${asym_rhs_path}" "-i"
+  )
 
   # CUDA-SDK specific tests
   if(RESOLVE_USE_CUDA)
-    add_test(NAME klu_rf_cuda_test    COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d" "${test_data_dir}")
-    add_test(NAME klu_rf_ir_cuda_test COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d" "${test_data_dir}" "-i")
-    add_test(NAME klu_glu_cuda_test   COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d" "${test_data_dir}" "-s" "glu")
-    add_test(NAME sys_refactor_cuda_test COMMAND $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d" "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}")
-    add_test(NAME sys_refactor_cuda_asym_test COMMAND $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d" "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}") 
-    add_test(NAME sys_glu_test COMMAND $<TARGET_FILE:sys_glu_test.exe> "${test_data_dir}" "-d" "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}")
-    add_test(NAME sys_glu_asym_test COMMAND $<TARGET_FILE:sys_glu_test.exe> "${test_data_dir}" "-d" "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}") 
+    add_test(NAME klu_rf_cuda_test COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d"
+                                           "${test_data_dir}"
+    )
+    add_test(NAME klu_rf_ir_cuda_test COMMAND $<TARGET_FILE:klu_rf_test.exe>
+                                              "-d" "${test_data_dir}" "-i"
+    )
+    add_test(NAME klu_glu_cuda_test COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d"
+                                            "${test_data_dir}" "-s" "glu"
+    )
+    add_test(
+      NAME sys_refactor_cuda_test
+      COMMAND
+        $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d"
+        "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}"
+    )
+    add_test(
+      NAME sys_refactor_cuda_asym_test
+      COMMAND
+        $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d"
+        "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}"
+    )
+    add_test(
+      NAME sys_glu_test
+      COMMAND
+        $<TARGET_FILE:sys_glu_test.exe> "${test_data_dir}" "-d"
+        "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}"
+    )
+    add_test(
+      NAME sys_glu_asym_test
+      COMMAND
+        $<TARGET_FILE:sys_glu_test.exe> "${test_data_dir}" "-d"
+        "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}"
+    )
   endif(RESOLVE_USE_CUDA)
 
   # ROCm specific tests
   if(RESOLVE_USE_HIP)
-    add_test(NAME rocsolver_rf_test       COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d" "${test_data_dir}")
-    add_test(NAME rocsolver_rf_ir_test    COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d" "${test_data_dir}" "-i")
-    add_test(NAME sys_refactor_hip_test COMMAND $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d" "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}")
-    add_test(NAME sys_refactor_hip_asym_test COMMAND $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d" "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}")
+    add_test(NAME rocsolver_rf_test COMMAND $<TARGET_FILE:klu_rf_test.exe> "-d"
+                                            "${test_data_dir}"
+    )
+    add_test(NAME rocsolver_rf_ir_test COMMAND $<TARGET_FILE:klu_rf_test.exe>
+                                               "-d" "${test_data_dir}" "-i"
+    )
+    add_test(
+      NAME sys_refactor_hip_test
+      COMMAND
+        $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d"
+        "${test_data_dir}" "-m" "${sym_matrix_path}" "-r" "${sym_rhs_path}"
+    )
+    add_test(
+      NAME sys_refactor_hip_asym_test
+      COMMAND
+        $<TARGET_FILE:sys_refactor_test.exe> "${test_data_dir}" "-d"
+        "${test_data_dir}" "-m" "${asym_matrix_path}" "-r" "${asym_rhs_path}"
+    )
   endif(RESOLVE_USE_HIP)
 endif(RESOLVE_USE_KLU)

--- a/tests/unit/matrix/CMakeLists.txt
+++ b/tests/unit/matrix/CMakeLists.txt
@@ -20,7 +20,9 @@ target_link_libraries(runMatrixHandlerTests.exe PRIVATE ReSolve resolve_matrix)
 
 # Build matrix factorization tests
 add_executable(runMatrixFactorizationTests.exe runMatrixFactorizationTests.cpp)
-target_link_libraries(runMatrixFactorizationTests.exe PRIVATE ReSolve resolve_matrix)
+target_link_libraries(
+  runMatrixFactorizationTests.exe PRIVATE ReSolve resolve_matrix
+)
 
 # Build LUSOL-related tests
 if(RESOLVE_USE_LUSOL)
@@ -29,17 +31,24 @@ if(RESOLVE_USE_LUSOL)
 endif()
 
 # Install tests
-set(installable_tests runMatrixIoTests.exe runMatrixHandlerTests.exe runMatrixFactorizationTests.exe runSparseTests.exe)
+set(installable_tests runMatrixIoTests.exe runMatrixHandlerTests.exe
+                      runMatrixFactorizationTests.exe runSparseTests.exe
+)
 if(RESOLVE_USE_LUSOL)
   list(APPEND installable_tests runLUSOLTests.exe)
 endif()
-install(TARGETS ${installable_tests}
-        RUNTIME DESTINATION bin/resolve/tests/unit)
+install(TARGETS ${installable_tests} RUNTIME DESTINATION bin/resolve/tests/unit)
 
-add_test(NAME matrix_test               COMMAND $<TARGET_FILE:runMatrixIoTests.exe>)
-add_test(NAME matrix_handler_test       COMMAND $<TARGET_FILE:runMatrixHandlerTests.exe>)
-add_test(NAME matrix_factorization_test COMMAND $<TARGET_FILE:runMatrixFactorizationTests.exe>)
-add_test(NAME sparse_matrix_test        COMMAND $<TARGET_FILE:runSparseTests.exe>)
+add_test(NAME matrix_test COMMAND $<TARGET_FILE:runMatrixIoTests.exe>)
+add_test(NAME matrix_handler_test
+         COMMAND $<TARGET_FILE:runMatrixHandlerTests.exe>
+)
+add_test(NAME matrix_factorization_test
+         COMMAND $<TARGET_FILE:runMatrixFactorizationTests.exe>
+)
+add_test(NAME sparse_matrix_test COMMAND $<TARGET_FILE:runSparseTests.exe>)
 if(RESOLVE_USE_LUSOL)
-  add_test(NAME lusol_factorization_test COMMAND $<TARGET_FILE:runLUSOLTests.exe>)
+  add_test(NAME lusol_factorization_test
+           COMMAND $<TARGET_FILE:runLUSOLTests.exe>
+  )
 endif()

--- a/tests/unit/memory/CMakeLists.txt
+++ b/tests/unit/memory/CMakeLists.txt
@@ -11,11 +11,9 @@ add_executable(runMemoryUtilsTests.exe runMemoryUtilsTests.cpp)
 target_link_libraries(runMemoryUtilsTests.exe PRIVATE ReSolve)
 message(STATUS "Resolve libraries: ${resolve_backend_hip}")
 
-
 # Install tests
 set(installable_tests runMemoryUtilsTests.exe)
-install(TARGETS ${installable_tests} 
-        RUNTIME DESTINATION bin/resolve/tests/unit)
+install(TARGETS ${installable_tests} RUNTIME DESTINATION bin/resolve/tests/unit)
 
 # Add tests to run
 add_test(NAME memory_test COMMAND $<TARGET_FILE:runMemoryUtilsTests.exe>)

--- a/tests/unit/params/CMakeLists.txt
+++ b/tests/unit/params/CMakeLists.txt
@@ -12,7 +12,6 @@ target_link_libraries(runParamTests.exe PRIVATE ReSolve)
 
 # Install tests
 set(installable_tests runParamTests.exe)
-install(TARGETS ${installable_tests} 
-        RUNTIME DESTINATION bin/resolve/tests/unit)
+install(TARGETS ${installable_tests} RUNTIME DESTINATION bin/resolve/tests/unit)
 
 add_test(NAME param_test COMMAND $<TARGET_FILE:runParamTests.exe>)

--- a/tests/unit/utilities/logger/CMakeLists.txt
+++ b/tests/unit/utilities/logger/CMakeLists.txt
@@ -12,7 +12,6 @@ target_link_libraries(runLoggerTests.exe PRIVATE ReSolve resolve_logger)
 
 # Install tests
 set(installable_logger_tests runLoggerTests.exe)
-install(TARGETS ${installable_tests} 
-        RUNTIME DESTINATION bin/resolve/tests/unit)
+install(TARGETS ${installable_tests} RUNTIME DESTINATION bin/resolve/tests/unit)
 
 add_test(NAME logger_test COMMAND $<TARGET_FILE:runLoggerTests.exe>)

--- a/tests/unit/vector/CMakeLists.txt
+++ b/tests/unit/vector/CMakeLists.txt
@@ -19,10 +19,13 @@ add_executable(runGramSchmidtTests.exe runGramSchmidtTests.cpp)
 target_link_libraries(runGramSchmidtTests.exe PRIVATE ReSolve resolve_vector)
 
 # Install tests
-set(installable_tests runVectorTests.exe runVectorHandlerTests.exe runGramSchmidtTests.exe)
-install(TARGETS ${installable_tests} 
-        RUNTIME DESTINATION bin/resolve/tests/unit)
+set(installable_tests runVectorTests.exe runVectorHandlerTests.exe
+                      runGramSchmidtTests.exe
+)
+install(TARGETS ${installable_tests} RUNTIME DESTINATION bin/resolve/tests/unit)
 
 add_test(NAME vector_test COMMAND $<TARGET_FILE:runVectorTests.exe>)
-add_test(NAME vector_handler_test COMMAND $<TARGET_FILE:runVectorHandlerTests.exe>)
+add_test(NAME vector_handler_test
+         COMMAND $<TARGET_FILE:runVectorHandlerTests.exe>
+)
 add_test(NAME gram_schmidt_test COMMAND $<TARGET_FILE:runGramSchmidtTests.exe>)


### PR DESCRIPTION
 ## Description

This adds CMake formatting.  Adapted from [ExaGO](https://github.com/pnnl/ExaGO/blob/develop/.cmake-format.py)

 ## Proposed changes

- Added `.cmake-format.py` defining the desired format
- Added a stage in `.pre-commit-config.yaml` to apply the format
 
 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra` (apart from known issues).
- [N/A] The new code follows Re::Solve style guidelines.
- [N/A] There are unit tests for the new code.
- [N/A] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
Please review the formatting that was applied. We can try to change whatever doesn't look the way we want.