### PR TITLE
Implement A := c*A+I method in MatrixHandler

### DIFF
--- a/resolve/matrix/CMakeLists.txt
+++ b/resolve/matrix/CMakeLists.txt
@@ -30,7 +30,7 @@ set(Matrix_HEADER_INSTALL io.hpp Sparse.hpp Coo.hpp Csr.hpp Csc.hpp
 
 # Build shared library ReSolve::matrix
 add_library(resolve_matrix SHARED ${Matrix_SRC})
-target_link_libraries(resolve_matrix PRIVATE resolve_logger resolve_vector)
+target_link_libraries(resolve_matrix PRIVATE resolve_logger resolve_vector resolve_workspace)
 
 # Link to CUDA ReSolve backend if CUDA is support enabled
 if(RESOLVE_USE_CUDA)

--- a/resolve/matrix/CMakeLists.txt
+++ b/resolve/matrix/CMakeLists.txt
@@ -30,7 +30,7 @@ set(Matrix_HEADER_INSTALL io.hpp Sparse.hpp Coo.hpp Csr.hpp Csc.hpp
 
 # Build shared library ReSolve::matrix
 add_library(resolve_matrix SHARED ${Matrix_SRC})
-target_link_libraries(resolve_matrix PRIVATE resolve_logger resolve_vector resolve_workspace)
+target_link_libraries(resolve_matrix PRIVATE resolve_logger resolve_vector)
 
 # Link to CUDA ReSolve backend if CUDA is support enabled
 if(RESOLVE_USE_CUDA)

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -352,6 +352,31 @@ namespace ReSolve
   }
 
   /**
+   * @brief Multiply csr matrix by a constant and add I.
+   * @param[in,out] A - Sparse CSR matrix
+   * @param[in] alpha - scalar parameter
+   * @param[in] memspace - Device where the operation is computed
+   * @return 0 if successful, 1 otherwise
+   */
+  int MatrixHandler::scaleAddI(matrix::Csr* A, real_type alpha, memory::MemorySpace memspace)
+  {
+    assert(A->getSparseFormat() == matrix::Sparse::COMPRESSED_SPARSE_ROW && "Matrix is assumed to be in CSR format.\n");
+    assert(A->getValues(memspace) != nullptr && "Matrix values are null!\n");
+    assert(A->getNumRows() == A->getNumColumns() && "Matrix must be square.\n");
+    using namespace ReSolve::memory;
+    switch (memspace)
+    {
+    case HOST:
+      return cpuImpl_->scaleAddI(A, alpha);
+      break;
+    case DEVICE:
+      return devImpl_->scaleAddI(A, alpha);
+      break;
+    }
+    return 1;
+  }
+
+  /**
    * @brief If CUDA support is enabled in the handler.
    *
    * @return true

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -62,6 +62,8 @@ namespace ReSolve
 
     void addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
 
+    int scaleAddI(matrix::Csr* A, real_type alpha, memory::MemorySpace memspace);
+
     /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped
     int  matvec(matrix::Sparse*     A,
                 vector_type*        vec_x,

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -434,7 +434,7 @@ namespace ReSolve
    * @param[in] pattern - precalculated sparsity pattern
    * @return 0 if successful, 1 otherwise
    */
-  static int scaleAddII(matrix::Csr* A, real_type alpha, ScaleAddIBuffer* pattern)
+  static int scaleAddIWithPattern(matrix::Csr* A, real_type alpha, ScaleAddIBuffer* pattern)
   {
     scaleConst(A, alpha);
 
@@ -507,7 +507,7 @@ namespace ReSolve
     if (workspace_->scaleAddISetup())
     {
       ScaleAddIBuffer* pattern = workspace_->getScaleAddIBuffer();
-      return scaleAddII(A, alpha, pattern);
+      return scaleAddIWithPattern(A, alpha, pattern);
     }
 
     scaleConst(A, alpha);

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -421,7 +421,7 @@ namespace ReSolve
    */
   static int updateMatrix(matrix::Sparse* A, index_type* row_data, index_type* col_data, real_type* val_data, index_type nnz)
   {
-    if (A->destroyMatrixData(memory::HOST) == -1)
+    if (A->destroyMatrixData(memory::HOST) != 0)
     {
       return 1;
     }
@@ -502,7 +502,8 @@ namespace ReSolve
    */
   int MatrixHandlerCpu::scaleAddI(matrix::Csr* A, real_type alpha)
   {
-    if (index_type info = scaleConst(A, alpha), info == 1)
+    index_type info = scaleConst(A, alpha);
+    if (info == 1)
     {
       return info;
     }

--- a/resolve/matrix/MatrixHandlerCpu.cpp
+++ b/resolve/matrix/MatrixHandlerCpu.cpp
@@ -447,12 +447,6 @@ namespace ReSolve
           new_nnz_count++;
           diagonal_added = true;
         }
-        else if (original_col_indices[j] < i && !diagonal_added)
-        {
-          // Handle elements before diagonal
-          new_values[new_nnz_count] = original_values[j];
-          new_nnz_count++;
-        }
         else if (original_col_indices[j] > i && !diagonal_added)
         {
           // Insert diagonal if not found yet
@@ -465,7 +459,8 @@ namespace ReSolve
         }
         else
         {
-          // Elements after diagonal or diagonal already handled
+          // Elements before diagonal, elements after diagonal and the
+          // diagonal is already handled
           new_values[new_nnz_count] = original_values[j];
           new_nnz_count++;
         }
@@ -531,13 +526,6 @@ namespace ReSolve
           new_nnz_count++;
           diagonal_added = true;
         }
-        else if (original_col_indices[j] < i && !diagonal_added)
-        {
-          // Handle elements before diagonal
-          new_values[new_nnz_count]      = original_values[j];
-          new_col_indices[new_nnz_count] = original_col_indices[j];
-          new_nnz_count++;
-        }
         else if (original_col_indices[j] > i && !diagonal_added)
         {
           // Insert diagonal if not found yet
@@ -552,7 +540,8 @@ namespace ReSolve
         }
         else
         {
-          // Elements after diagonal or diagonal already handled
+          // Elements before diagonal, elements after diagonal and the
+          // diagonal is already handled
           new_values[new_nnz_count]      = original_values[j];
           new_col_indices[new_nnz_count] = original_col_indices[j];
           new_nnz_count++;

--- a/resolve/matrix/MatrixHandlerCpu.hpp
+++ b/resolve/matrix/MatrixHandlerCpu.hpp
@@ -46,6 +46,8 @@ namespace ReSolve
 
     int addConst(matrix::Sparse* A, real_type alpha) override;
 
+    int scaleAddI(matrix::Csr* A, real_type alpha) override;
+
     virtual int matvec(matrix::Sparse*  A,
                        vector_type*     vec_x,
                        vector_type*     vec_result,

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -400,4 +400,19 @@ namespace ReSolve
     cuda::addConst(nnz, alpha, values);
     return 0;
   }
+
+  /**
+   * @brief Add a constant to the nonzero values of a csr matrix,
+   *        then add the identity matrix.
+   *
+   * @param[in,out] A - Sparse CSR matrix
+   * @param[in] alpha - constant to the added
+   * @return 0 if successful, 1 otherwise
+   */
+  int MatrixHandlerCpu::scaleAddI(matrix::Csr* A, real_type alpha)
+  {
+    // NOT IMPLEMENTED
+    return 1;
+  }
+
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerCuda.hpp
+++ b/resolve/matrix/MatrixHandlerCuda.hpp
@@ -45,6 +45,8 @@ namespace ReSolve
 
     int rightScale(matrix::Csr* A, vector_type* diag) override;
 
+    int scaleAddI(matrix::Csr* A, real_type alpha) override;
+
     virtual int matvec(matrix::Sparse*  A,
                        vector_type*     vec_x,
                        vector_type*     vec_result,

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -369,4 +369,18 @@ namespace ReSolve
     return 0;
   }
 
+  /**
+   * @brief Add a constant to the nonzero values of a csr matrix,
+   *        then add the identity matrix.
+   *
+   * @param[in,out] A - Sparse CSR matrix
+   * @param[in] alpha - constant to the added
+   * @return 0 if successful, 1 otherwise
+   */
+  int MatrixHandlerCpu::scaleAddI(matrix::Csr* A, real_type alpha)
+  {
+    // NOT IMPLEMENTED
+    return 1;
+  }
+
 } // namespace ReSolve

--- a/resolve/matrix/MatrixHandlerHip.hpp
+++ b/resolve/matrix/MatrixHandlerHip.hpp
@@ -43,7 +43,10 @@ namespace ReSolve
 
     int rightScale(matrix::Csr* A, vector_type* diag) override;
 
-    int         addConst(matrix::Sparse* A, real_type alpha) override;
+    int addConst(matrix::Sparse* A, real_type alpha) override;
+
+    int scaleAddI(matrix::Csr* A, real_type alpha) override;
+
     virtual int matvec(matrix::Sparse*  A,
                        vector_type*     vec_x,
                        vector_type*     vec_result,

--- a/resolve/matrix/MatrixHandlerImpl.hpp
+++ b/resolve/matrix/MatrixHandlerImpl.hpp
@@ -46,6 +46,8 @@ namespace ReSolve
 
     virtual int addConst(matrix::Sparse* A, real_type alpha) = 0;
 
+    virtual int scaleAddI(matrix::Csr* A, real_type alpha) = 0;
+
     virtual int matvec(matrix::Sparse*  A,
                        vector_type*     vec_x,
                        vector_type*     vec_result,

--- a/resolve/workspace/LinAlgWorkspaceCpu.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.cpp
@@ -1,5 +1,6 @@
 #include "LinAlgWorkspaceCpu.hpp"
 
+#include <cassert>
 #include <cstddef>
 
 namespace ReSolve
@@ -10,6 +11,7 @@ namespace ReSolve
 
   LinAlgWorkspaceCpu::~LinAlgWorkspaceCpu()
   {
+    delete scaleaddi_buffer_;
   }
 
   void LinAlgWorkspaceCpu::initializeHandles()
@@ -18,7 +20,29 @@ namespace ReSolve
 
   void LinAlgWorkspaceCpu::resetLinAlgWorkspace()
   {
-    // No resources to reset in CPU workspace
-    return;
+    delete scaleaddi_buffer_;
+    scaleaddi_buffer_ = nullptr;
   }
+
+  bool LinAlgWorkspaceCpu::scaleAddISetup()
+  {
+    return scaleaddi_setup_done_;
+  }
+
+  void LinAlgWorkspaceCpu::scaleAddISetupDone()
+  {
+    scaleaddi_setup_done_ = true;
+  }
+
+  ScaleAddIBuffer* LinAlgWorkspaceCpu::getScaleAddIBuffer()
+  {
+    return scaleaddi_buffer_;
+  }
+
+  void LinAlgWorkspaceCpu::setScaleAddIBuffer(ScaleAddIBuffer* buffer)
+  {
+    assert(scaleaddi_buffer_ == nullptr);
+    scaleaddi_buffer_ = buffer;
+  }
+
 } // namespace ReSolve

--- a/resolve/workspace/LinAlgWorkspaceCpu.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.cpp
@@ -19,18 +19,6 @@ namespace ReSolve
   {
   }
 
-  void ScaleAddIBuffer::setRowData(index_type* row_data, index_type array_size)
-  {
-    assert(static_cast<size_t>(array_size) == row_data_.size());
-    std::copy(row_data_.begin(), row_data_.end(), row_data);
-  }
-
-  void ScaleAddIBuffer::setColumnData(index_type* col_data, index_type array_size)
-  {
-    assert(static_cast<size_t>(array_size) == col_data_.size());
-    std::copy(col_data_.begin(), col_data_.end(), col_data);
-  }
-
   index_type* ScaleAddIBuffer::getRowData()
   {
     return row_data_.data();
@@ -102,7 +90,7 @@ namespace ReSolve
 
   ScaleAddIBuffer* LinAlgWorkspaceCpu::getScaleAddIBuffer()
   {
-    assert(ScaleAddIBuffer != nullptr);
+    assert(scaleaddi_buffer_ != nullptr);
     return scaleaddi_buffer_;
   }
 

--- a/resolve/workspace/LinAlgWorkspaceCpu.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.cpp
@@ -1,10 +1,76 @@
 #include "LinAlgWorkspaceCpu.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 
 namespace ReSolve
 {
+  /**
+   * @brief Store sparsity pattern
+   *
+   * @param[in] row_data - pointer to row data (array of integers, length:nrows+1)
+   * @param[in] nrows - number of rows
+   * @param[in] col_data - pointer to column data (array of integers, length: nnz)
+   * @param[in] nnz - number of non-zeros
+   */
+  ScaleAddIBuffer::ScaleAddIBuffer(index_type* row_data, index_type nrows, index_type* col_data, index_type nnz)
+    : row_data_(row_data, row_data + nrows + 1), col_data_(col_data, col_data + nnz)
+  {
+  }
+
+  void ScaleAddIBuffer::setRowData(index_type* row_data, index_type array_size)
+  {
+    assert(static_cast<size_t>(array_size) == row_data_.size());
+    std::copy(row_data_.begin(), row_data_.end(), row_data);
+  }
+
+  void ScaleAddIBuffer::setColumnData(index_type* col_data, index_type array_size)
+  {
+    assert(static_cast<size_t>(array_size) == col_data_.size());
+    std::copy(col_data_.begin(), col_data_.end(), col_data);
+  }
+
+  index_type* ScaleAddIBuffer::getRowData()
+  {
+    return row_data_.data();
+  }
+
+  index_type* ScaleAddIBuffer::getColumnData()
+  {
+    return col_data_.data();
+  }
+
+  /**
+   * @brief get number of matrix rows
+   *
+   * @return number of matrix rows.
+   */
+  index_type ScaleAddIBuffer::getNumRows()
+  {
+    return static_cast<index_type>(row_data_.size()) - 1;
+  }
+
+  /**
+   * @brief get number of matrix columns
+   *
+   * @return number of matrix columns.
+   */
+  index_type ScaleAddIBuffer::getNumColumns()
+  {
+    return getNumRows();
+  }
+
+  /**
+   * @brief Get number of non-zeros.
+   *
+   * @return number of non-zeros
+   */
+  index_type ScaleAddIBuffer::getNnz()
+  {
+    return static_cast<index_type>(col_data_.size());
+  }
+
   LinAlgWorkspaceCpu::LinAlgWorkspaceCpu()
   {
   }
@@ -36,6 +102,7 @@ namespace ReSolve
 
   ScaleAddIBuffer* LinAlgWorkspaceCpu::getScaleAddIBuffer()
   {
+    assert(ScaleAddIBuffer != nullptr);
     return scaleaddi_buffer_;
   }
 

--- a/resolve/workspace/LinAlgWorkspaceCpu.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.cpp
@@ -19,11 +19,21 @@ namespace ReSolve
   {
   }
 
+  /**
+   * @brief Retrieve row sparsity pattern
+   *
+   * @return precalculated row pointers
+   */
   index_type* ScaleAddIBuffer::getRowData()
   {
     return row_data_.data();
   }
 
+  /**
+   * @brief Retrieve column sparsity pattern
+   *
+   * @return precalculated column indices
+   */
   index_type* ScaleAddIBuffer::getColumnData()
   {
     return col_data_.data();

--- a/resolve/workspace/LinAlgWorkspaceCpu.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.cpp
@@ -14,8 +14,8 @@ namespace ReSolve
    * @param[in] col_data - pointer to column data (array of integers, length: nnz)
    * @param[in] nnz - number of non-zeros
    */
-  ScaleAddIBuffer::ScaleAddIBuffer(index_type* row_data, index_type nrows, index_type* col_data, index_type nnz)
-    : row_data_(row_data, row_data + nrows + 1), col_data_(col_data, col_data + nnz)
+  ScaleAddIBuffer::ScaleAddIBuffer(std::vector<index_type> row_data, std::vector<index_type> col_data)
+    : row_data_(std::move(row_data)), col_data_(std::move(col_data))
   {
   }
 

--- a/resolve/workspace/LinAlgWorkspaceCpu.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.hpp
@@ -1,7 +1,18 @@
 #pragma once
 
+#include <vector>
+
+#include <resolve/Common.hpp>
+
 namespace ReSolve
 {
+  struct ScaleAddIBuffer
+  {
+    std::vector<index_type> row_data_; ///< row data (HOST)
+    std::vector<index_type> col_data_; ///< column data (HOST)
+    index_type              nnz;
+  };
+
   class LinAlgWorkspaceCpu
   {
   public:
@@ -9,6 +20,15 @@ namespace ReSolve
     ~LinAlgWorkspaceCpu();
     void initializeHandles();
     void resetLinAlgWorkspace();
+    bool             scaleAddISetup();
+    void             scaleAddISetupDone();
+    ScaleAddIBuffer* getScaleAddIBuffer();
+    void             setScaleAddIBuffer(ScaleAddIBuffer* buffer);
+
+  private:
+    // check if setup is done for scaleAddI i.e. if buffer is allocated, csr structure is set etc.
+    bool             scaleaddi_setup_done_{false};
+    ScaleAddIBuffer* scaleaddi_buffer_{nullptr};
   };
 
 } // namespace ReSolve

--- a/resolve/workspace/LinAlgWorkspaceCpu.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.hpp
@@ -10,8 +10,8 @@ namespace ReSolve
   {
   public:
     ScaleAddIBuffer(index_type* row_data, index_type nrows, index_type* col_data, index_type nnz);
-    void       getRowData(index_type* row_data, index_type array_size);
-    void       getColumnData(index_type* col_data, index_type array_size);
+    index_type* getRowData();
+    index_type* getColumnData();
     index_type getNumRows();
     index_type getNumColumns();
     index_type getNnz();

--- a/resolve/workspace/LinAlgWorkspaceCpu.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.hpp
@@ -6,11 +6,19 @@
 
 namespace ReSolve
 {
-  struct ScaleAddIBuffer
+  class ScaleAddIBuffer
   {
-    std::vector<index_type> row_data_; ///< row data (HOST)
-    std::vector<index_type> col_data_; ///< column data (HOST)
-    index_type              nnz;
+  public:
+    ScaleAddIBuffer(index_type* row_data, index_type nrows, index_type* col_data, index_type nnz);
+    void       getRowData(index_type* row_data, index_type array_size);
+    void       getColumnData(index_type* col_data, index_type array_size);
+    index_type getNumRows();
+    index_type getNumColumns();
+    index_type getNnz();
+
+  private:
+    std::vector<index_type> row_data_;
+    std::vector<index_type> col_data_;
   };
 
   class LinAlgWorkspaceCpu

--- a/resolve/workspace/LinAlgWorkspaceCpu.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCpu.hpp
@@ -9,7 +9,7 @@ namespace ReSolve
   class ScaleAddIBuffer
   {
   public:
-    ScaleAddIBuffer(index_type* row_data, index_type nrows, index_type* col_data, index_type nnz);
+    ScaleAddIBuffer(std::vector<index_type> row_data, std::vector<index_type> col_data);
     index_type* getRowData();
     index_type* getColumnData();
     index_type getNumRows();

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -705,9 +705,10 @@ namespace ReSolve
        * @pre A is a valid, allocated CSR matrix
        * @invariant A
        * @param[in] A matrix::Csr* pointer to the matrix to be verified
+       * @param[in] alpha matrix scale factor
        * @return bool true if the matrix is valid, false otherwise
        */
-      bool verifyScaleAddICsrMatrix(matrix::Csr* A, real_type scale)
+      bool verifyScaleAddICsrMatrix(matrix::Csr* A, real_type alpha)
       {
         // Check if the matrix is valid
         if (A == nullptr)
@@ -727,7 +728,7 @@ namespace ReSolve
         index_type* scaled_row_ptr  = A->getRowData(memory::HOST);
         real_type*  scaled_value    = A->getValues(memory::HOST);
 
-        const real_type expected = 30. * scale + 1.;
+        const real_type expected = 30. * alpha + 1.;
 
         // Verify values - each element scaled by scale. Diagonal elements should be  1.
         for (index_type i = 0; i < n; ++i)

--- a/tests/unit/matrix/MatrixHandlerTests.hpp
+++ b/tests/unit/matrix/MatrixHandlerTests.hpp
@@ -725,7 +725,6 @@ namespace ReSolve
         }
 
         index_type* scaled_row_ptr  = A->getRowData(memory::HOST);
-        index_type* scaled_col_idx = A->getColData(memory::HOST);
         real_type*  scaled_value    = A->getValues(memory::HOST);
 
         const real_type expected = 30. * scale + 1.;

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -76,6 +76,8 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.rightScale(1024, 2048);
   workspace.resetLinAlgWorkspace();
   result += test.rightScale(2048, 1024);
+  workspace.resetLinAlgWorkspace();
+  result += test.scaleAddI(100);
   std::cout << "\n";
 }
 


### PR DESCRIPTION
## Description
 
 _Please describe the issue that is addressed (bug, new feature,
 documentation, enhancement, etc.). Please also include relevant motivation and
 context. List any dependencies that are required for this change._
 
This is part of #393. 
 
 ## Proposed changes
 
 _Describe how your changes here address the issue and why the proposed changes
 should be accepted._
 
This adds a new member function `MatrixHandler::scaleAddI` to compute  A := c*A+I. The sparsity pattern (row pointers and column indices) are stored in `LinAlgWorkspaceCpu` and reused by future calculations. One must check if the diagonal element is already nonzero and add 1 or add a new nonzero element to the matrix.

The test verifies that the sum of rows is 1 larger than the sum of the original row scaled by c.

 ## Checklist
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code._
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 _If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc._
