### PR TITLE
Bug: update `MatrixHandler::addConst` return type to int (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,5 @@ It is seamless from the user perspective and fixed many bugs.
 14. Various Spack updates.
 
 15. Added examples/sysGmres.cpp to demonstrate how to use SystemSolver with GMRES. 
+
+16. Updated MatrixHandler::addConst to return integer error codes instead of void.

--- a/resolve/matrix/MatrixHandler.cpp
+++ b/resolve/matrix/MatrixHandler.cpp
@@ -337,18 +337,19 @@ namespace ReSolve
    * @param[in] memspace - Device where the operation is computed
    * @return 0 if successful, 1 otherwise
    */
-  void MatrixHandler::addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace)
+  int MatrixHandler::addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
     switch (memspace)
     {
     case HOST:
-      cpuImpl_->addConst(A, alpha);
+      return cpuImpl_->addConst(A, alpha);
       break;
     case DEVICE:
-      devImpl_->addConst(A, alpha);
+      return devImpl_->addConst(A, alpha);
       break;
     }
+    return 1;
   }
 
   /**

--- a/resolve/matrix/MatrixHandler.hpp
+++ b/resolve/matrix/MatrixHandler.hpp
@@ -60,7 +60,7 @@ namespace ReSolve
 
     int rightScale(matrix::Csr* A, vector_type* diag, memory::MemorySpace memspace);
 
-    void addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
+    int addConst(matrix::Sparse* A, real_type alpha, memory::MemorySpace memspace);
 
     /// Should compute vec_result := alpha*A*vec_x + beta*vec_result, but at least on cpu alpha and beta are flipped
     int  matvec(matrix::Sparse*     A,


### PR DESCRIPTION
* Bug: update MatrixHandler::addConst return type to int

* Doc: Update CHANGELOG.md

## Description
 
 External PR #402 merged to a local branch. Passing through CI pipeline before merging to `develop`.

 Closes #395
 
 @maanasArora

 

 ## Proposed changes
 
Correct the return type for `MatrixHandler::addConst`.

 ## Checklist
 
- [x] All tests pass. Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
