### PR TITLE
Add 3 new element-wise vector operations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Made Vector::copyDataTo able to copy from device to host and vice versa
 
-- Added `elementwiseDivide` vector operation.
+- Added `elementwiseDivide`, `elementwiseMax`, and `abs` vector operations.
 
 ## Changes to Re::Solve in release 0.99.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Made Vector::copyDataTo able to copy from device to host and vice versa
 
-- Added `scaleInv`, `max`, and `abs` vector operations.
+- Added `diagSolve`, `max`, and `abs` vector operations.
 
 ## Changes to Re::Solve in release 0.99.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Made Vector::copyDataTo able to copy from device to host and vice versa
 
-- Added `elementwiseDivide`, `elementwiseMax`, and `abs` vector operations.
+- Added `scaleInv`, `max`, and `abs` vector operations.
 
 ## Changes to Re::Solve in release 0.99.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Made Vector::copyDataTo able to copy from device to host and vice versa
 
+- Added `elementwiseDivide` vector operation.
+
 ## Changes to Re::Solve in release 0.99.2
 
 ### Major Features

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -84,17 +84,17 @@ namespace ReSolve
       }
 
       /**
-       * @brief Divides a vector's elements by another vector's elements
+       * @brief Multiplies vector by an inverse of a diagonal matrix.
        *
        * @param[in]  n       - size of the vectors
-       * @param[in]  d_val   - divisor values
+       * @param[in]  d_val   - diagonal matrix values
        * @param[in, out] vec - vector to be divided. Changes in place.
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void scaleInv(index_type       n,
-                               const real_type* d_val,
-                               real_type*       vec)
+      __global__ void diagSolve(index_type       n,
+                                const real_type* d_val,
+                                real_type*       vec)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -102,7 +102,7 @@ namespace ReSolve
         // Check if the index is within bounds
         if (idx < n)
         {
-          // Divide the vector element by the corresponding divisor value
+          // Divide the vector element by the corresponding diag value
           vec[idx] /= d_val[idx];
         }
       }
@@ -200,18 +200,18 @@ namespace ReSolve
      * @brief Wrapper that divides a vector's elements by another vector's elements
      *
      * @param[in]  n       - size of the vectors
-     * @param[in]  divisor - divisor values
+     * @param[in]  diag - diag values
      * @param[in, out] vec - vector to be divided. Changes in place.
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void scaleInv(index_type       n,
-                  const real_type* divisor,
-                  real_type*       vec)
+    void diagSolve(index_type       n,
+                   const real_type* diag,
+                   real_type*       vec)
     {
       int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::scaleInv<<<num_blocks, block_size>>>(n, divisor, vec);
+      kernels::diagSolve<<<num_blocks, block_size>>>(n, diag, vec);
     }
 
     /**

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -90,9 +90,9 @@ namespace ReSolve
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void elementwiseDivide(index_type       n,
-                                        const real_type* d_val,
-                                        real_type*       vec)
+      __global__ void scaleInv(index_type       n,
+                               const real_type* d_val,
+                               real_type*       vec)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -114,9 +114,9 @@ namespace ReSolve
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void elementwiseMax(index_type       n,
-                                     const real_type* x,
-                                     real_type*       y)
+      __global__ void max(index_type       n,
+                          const real_type* x,
+                          real_type*       y)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -197,15 +197,15 @@ namespace ReSolve
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void elementwiseDivide(index_type       n,
-                           const real_type* divisor,
-                           real_type*       vec)
+    void scaleInv(index_type       n,
+                  const real_type* divisor,
+                  real_type*       vec)
     {
       // Define block size and number of blocks
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::elementwiseDivide<<<num_blocks, block_size>>>(n, divisor, vec);
+      kernels::scaleInv<<<num_blocks, block_size>>>(n, divisor, vec);
     }
 
     /**
@@ -217,15 +217,15 @@ namespace ReSolve
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void elementwiseMax(index_type       n,
-                        const real_type* x,
-                        real_type*       y)
+    void max(index_type       n,
+             const real_type* x,
+             real_type*       y)
     {
       // Define block size and number of blocks
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::elementwiseMax<<<num_blocks, block_size>>>(n, x, y);
+      kernels::max<<<num_blocks, block_size>>>(n, x, y);
     }
 
     /**

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -12,6 +12,8 @@
 #include <resolve/cuda/cudaKernels.h>
 #include <resolve/cuda/cudaVectorKernels.h>
 
+#include "resolve/Common.hpp"
+
 namespace ReSolve
 {
   namespace cuda
@@ -132,13 +134,15 @@ namespace ReSolve
       /**
        * @brief Computes the element-wise absolute value of a vector.
        *
-       * @param[in]      n - size of the vector
-       * @param[in, out] x - Vector values. Changes in place.
+       * @param[in]  n   - size of the vector
+       * @param[in]  in  - Vector input
+       * @param[out] out - Vector output
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void abs(index_type n,
-                          real_type* x)
+      __global__ void abs(index_type       n,
+                          const real_type* in,
+                          real_type*       out)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -147,7 +151,7 @@ namespace ReSolve
         if (idx < n)
         {
           // Compute absolute value of element
-          x[idx] = fabs(x[idx]);
+          out[idx] = fabs(in[idx]);
         }
       }
     } // namespace kernels
@@ -231,19 +235,21 @@ namespace ReSolve
     /**
      * @brief Wrapper that computes the element-wise absolute value of a vector.
      *
-     * @param[in]      n - size of the vector
-     * @param[in, out] x - Vector values. Changes in place.
+     * @param[in]  n   - size of the vector
+     * @param[in]  in  - Vector input
+     * @param[out] out - Vector output
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void abs(index_type n,
-             real_type* x)
+    void abs(index_type       n,
+             const real_type* in,
+             real_type*       out)
     {
       // Define block size and number of blocks
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::abs<<<num_blocks, block_size>>>(n, x);
+      kernels::abs<<<num_blocks, block_size>>>(n, in, out);
     }
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -105,6 +105,51 @@ namespace ReSolve
         }
       }
 
+      /**
+       * @brief Wrapper that computes the element-wise max of two vectors.
+       *
+       * @param[in]      n - size of the vectors
+       * @param[in]      x - First vector values
+       * @param[in, out] y - Second vector values. Changes in place.
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void elementwiseMax(index_type       n,
+                                     const real_type* x,
+                                     real_type*       y)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n)
+        {
+          // Compute maximum of elements
+          y[idx] = max(x[idx], y[idx]);
+        }
+      }
+
+      /**
+       * @brief Computes the element-wise absolute value of a vector.
+       *
+       * @param[in]      n - size of the vector
+       * @param[in, out] x - Vector values. Changes in place.
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void abs(index_type n,
+                          real_type* x)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n)
+        {
+          // Compute absolute value of element
+          x[idx] = fabs(x[idx]);
+        }
+      }
     } // namespace kernels
 
     void setArrayConst(index_type n, real_type val, real_type* arr)
@@ -161,6 +206,44 @@ namespace ReSolve
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::elementwiseDivide<<<num_blocks, block_size>>>(n, divisor, vec);
+    }
+
+    /**
+     * @brief Wrapper that computes the element-wise max of two vectors.
+     *
+     * @param[in]      n - size of the vectors
+     * @param[in]      x - First vector values
+     * @param[in, out] y - Second vector values. Changes in place.
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void elementwiseMax(index_type       n,
+                        const real_type* x,
+                        real_type*       y)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int       num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::elementwiseMax<<<num_blocks, block_size>>>(n, x, y);
+    }
+
+    /**
+     * @brief Wrapper that computes the element-wise absolute value of a vector.
+     *
+     * @param[in]      n - size of the vector
+     * @param[in, out] x - Vector values. Changes in place.
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void abs(index_type n,
+             real_type* x)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int       num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::abs<<<num_blocks, block_size>>>(n, x);
     }
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -81,6 +81,30 @@ namespace ReSolve
         }
       }
 
+      /**
+       * @brief Divides a vector's elements by another vector's elements
+       *
+       * @param[in]  n       - size of the vectors
+       * @param[in]  d_val   - divisor values
+       * @param[in, out] vec - vector to be divided. Changes in place.
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void elementwiseDivide(index_type       n,
+                                        const real_type* d_val,
+                                        real_type*       vec)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n)
+        {
+          // Divide the vector element by the corresponding divisor value
+          vec[idx] /= d_val[idx];
+        }
+      }
+
     } // namespace kernels
 
     void setArrayConst(index_type n, real_type val, real_type* arr)
@@ -117,6 +141,26 @@ namespace ReSolve
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
+    }
+
+    /**
+     * @brief Wrapper that divides a vector's elements by another vector's elements
+     *
+     * @param[in]  n       - size of the vectors
+     * @param[in]  divisor - divisor values
+     * @param[in, out] vec - vector to be divided. Changes in place.
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void elementwiseDivide(index_type       n,
+                           const real_type* divisor,
+                           real_type*       vec)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int       num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::elementwiseDivide<<<num_blocks, block_size>>>(n, divisor, vec);
     }
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -129,7 +129,7 @@ namespace ReSolve
         if (idx < n)
         {
           // Compute maximum of elements
-          out[idx] = max(x[idx], y[idx]);
+          out[idx] = fmax(x[idx], y[idx]);
         }
       }
 

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -108,17 +108,19 @@ namespace ReSolve
       }
 
       /**
-       * @brief Wrapper that computes the element-wise max of two vectors.
+       * @brief Computes the element-wise max of two vectors.
        *
-       * @param[in]      n - size of the vectors
-       * @param[in]      x - First vector values
-       * @param[in, out] y - Second vector values. Changes in place.
+       * @param[in]  n   - size of the vectors
+       * @param[in]  x   - First vector values
+       * @param[in]  y   - Second vector values
+       * @param[out] out - Output vector values
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
       __global__ void max(index_type       n,
                           const real_type* x,
-                          real_type*       y)
+                          const real_type* y,
+                          real_type*       out)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -127,7 +129,7 @@ namespace ReSolve
         if (idx < n)
         {
           // Compute maximum of elements
-          y[idx] = max(x[idx], y[idx]);
+          out[idx] = max(x[idx], y[idx]);
         }
       }
 
@@ -215,21 +217,23 @@ namespace ReSolve
     /**
      * @brief Wrapper that computes the element-wise max of two vectors.
      *
-     * @param[in]      n - size of the vectors
-     * @param[in]      x - First vector values
-     * @param[in, out] y - Second vector values. Changes in place.
+     * @param[in]  n   - size of the vectors
+     * @param[in]  x   - First vector values
+     * @param[in]  y   - Second vector values
+     * @param[out] out - Output vector values
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
     void max(index_type       n,
              const real_type* x,
-             real_type*       y)
+             const real_type* y,
+             real_type*       out)
     {
       // Define block size and number of blocks
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::max<<<num_blocks, block_size>>>(n, x, y);
+      kernels::max<<<num_blocks, block_size>>>(n, x, y, out);
     }
 
     /**

--- a/resolve/cuda/cudaVectorKernels.cu
+++ b/resolve/cuda/cudaVectorKernels.cu
@@ -158,6 +158,8 @@ namespace ReSolve
       }
     } // namespace kernels
 
+    constexpr index_type block_size = 256;
+
     void setArrayConst(index_type n, real_type val, real_type* arr)
     {
       index_type num_blocks;
@@ -207,9 +209,7 @@ namespace ReSolve
                   const real_type* divisor,
                   real_type*       vec)
     {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int       num_blocks = (n + block_size - 1) / block_size;
+      int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::scaleInv<<<num_blocks, block_size>>>(n, divisor, vec);
     }
@@ -229,9 +229,7 @@ namespace ReSolve
              const real_type* y,
              real_type*       out)
     {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int       num_blocks = (n + block_size - 1) / block_size;
+      int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::max<<<num_blocks, block_size>>>(n, x, y, out);
     }
@@ -249,9 +247,7 @@ namespace ReSolve
              const real_type* in,
              real_type*       out)
     {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int       num_blocks = (n + block_size - 1) / block_size;
+      int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::abs<<<num_blocks, block_size>>>(n, in, out);
     }

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -19,7 +19,7 @@ namespace ReSolve
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
     void scaleInv(index_type n, const real_type* divisor, real_type* vec);
-    void max(index_type n, const real_type* x, real_type* y);
+    void max(index_type n, const real_type* x, const real_type* y, real_type* out);
     void abs(index_type n, const real_type* in, real_type* out);
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -20,6 +20,6 @@ namespace ReSolve
     void scale(index_type n, const real_type* diag, real_type* vec);
     void scaleInv(index_type n, const real_type* divisor, real_type* vec);
     void max(index_type n, const real_type* x, real_type* y);
-    void abs(index_type n, real_type* x);
+    void abs(index_type n, const real_type* in, real_type* out);
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -18,5 +18,6 @@ namespace ReSolve
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
+    void elementwiseDivide(index_type n, const real_type* divisor, real_type* vec);
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -19,5 +19,7 @@ namespace ReSolve
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
     void elementwiseDivide(index_type n, const real_type* divisor, real_type* vec);
+    void elementwiseMax(index_type n, const real_type* x, real_type* y);
+    void abs(index_type n, real_type* x);
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -18,7 +18,7 @@ namespace ReSolve
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
-    void scaleInv(index_type n, const real_type* divisor, real_type* vec);
+    void diagSolve(index_type n, const real_type* diag, real_type* vec);
     void max(index_type n, const real_type* x, const real_type* y, real_type* out);
     void abs(index_type n, const real_type* in, real_type* out);
   } // namespace cuda

--- a/resolve/cuda/cudaVectorKernels.h
+++ b/resolve/cuda/cudaVectorKernels.h
@@ -18,8 +18,8 @@ namespace ReSolve
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
-    void elementwiseDivide(index_type n, const real_type* divisor, real_type* vec);
-    void elementwiseMax(index_type n, const real_type* x, real_type* y);
+    void scaleInv(index_type n, const real_type* divisor, real_type* vec);
+    void max(index_type n, const real_type* x, real_type* y);
     void abs(index_type n, real_type* x);
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -18,7 +18,7 @@ namespace ReSolve
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
-    void scaleInv(index_type n, const real_type* divisor, real_type* vec);
+    void diagSolve(index_type n, const real_type* diag, real_type* vec);
     void max(index_type n, const real_type* x, const real_type* y, real_type* out);
     void abs(index_type n, const real_type* in, real_type* out);
   } // namespace hip

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -20,6 +20,6 @@ namespace ReSolve
     void scale(index_type n, const real_type* diag, real_type* vec);
     void scaleInv(index_type n, const real_type* divisor, real_type* vec);
     void max(index_type n, const real_type* x, real_type* y);
-    void abs(index_type n, real_type* x);
+    void abs(index_type n, const real_type* in, real_type* out);
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -19,5 +19,7 @@ namespace ReSolve
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
     void elementwiseDivide(index_type n, const real_type* divisor, real_type* vec);
+    void elementwiseMax(index_type n, const real_type* x, real_type* y);
+    void abs(index_type n, real_type* x);
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -18,8 +18,8 @@ namespace ReSolve
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
-    void elementwiseDivide(index_type n, const real_type* divisor, real_type* vec);
-    void elementwiseMax(index_type n, const real_type* x, real_type* y);
+    void scaleInv(index_type n, const real_type* divisor, real_type* vec);
+    void max(index_type n, const real_type* x, real_type* y);
     void abs(index_type n, real_type* x);
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -19,7 +19,7 @@ namespace ReSolve
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
     void scaleInv(index_type n, const real_type* divisor, real_type* vec);
-    void max(index_type n, const real_type* x, real_type* y);
+    void max(index_type n, const real_type* x, const real_type* y, real_type* out);
     void abs(index_type n, const real_type* in, real_type* out);
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.h
+++ b/resolve/hip/hipVectorKernels.h
@@ -18,5 +18,6 @@ namespace ReSolve
     void setArrayConst(index_type n, real_type val, real_type* arr);
     void addConst(index_type n, real_type val, real_type* arr);
     void scale(index_type n, const real_type* diag, real_type* vec);
+    void elementwiseDivide(index_type n, const real_type* divisor, real_type* vec);
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -121,13 +121,15 @@ namespace ReSolve {
       /**
        * @brief Computes the element-wise absolute value of a vector.
        *
-       * @param[in]      n - size of the vector
-       * @param[in, out] x - Vector values. Changes in place.
+       * @param[in]  n   - size of the vector
+       * @param[in]  in  - Vector input
+       * @param[out] out - Vector output
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void abs(index_type n,
-                          real_type* x)
+      __global__ void abs(index_type       n,
+                          const real_type* in,
+                          real_type*       out)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -136,7 +138,7 @@ namespace ReSolve {
         if (idx < n)
         {
           // Compute absolute value of element
-          x[idx] = fabs(x[idx]);
+          out[idx] = fabs(in[idx]);
         }
       }
     } // namespace kernels
@@ -220,19 +222,21 @@ namespace ReSolve {
     /**
      * @brief Wrapper that computes the element-wise absolute value of a vector.
      *
-     * @param[in]      n - size of the vector
-     * @param[in, out] x - Vector values. Changes in place.
+     * @param[in]  n   - size of the vector
+     * @param[in]  in  - Vector input
+     * @param[out] out - Vector output
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void abs(index_type n,
-             real_type* x)
+    void abs(index_type       n,
+             const real_type* in,
+             real_type*       out)
     {
       // Define block size and number of blocks
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::abs<<<num_blocks, block_size>>>(n, x);
+      kernels::abs<<<num_blocks, block_size>>>(n, in, out);
     }
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -71,17 +71,17 @@ namespace ReSolve {
       }
 
       /**
-       * @brief Divides a vector's elements by another vector's elements
+       * @brief Multiplies vector by an inverse of a diagonal matrix.
        *
        * @param[in]  n       - size of the vectors
-       * @param[in]  d_val   - divisor values
+       * @param[in]  d_val   - diagonal matrix values
        * @param[in, out] vec - vector to be divided. Changes in place.
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void scaleInv(index_type       n,
-                                        const real_type* d_val,
-                                        real_type*       vec)
+      __global__ void diagSolve(index_type       n,
+                                const real_type* d_val,
+                                real_type*       vec)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -89,7 +89,7 @@ namespace ReSolve {
         // Check if the index is within bounds
         if (idx < n)
         {
-          // Divide the vector element by the corresponding divisor value
+          // Divide the vector element by the corresponding diag value
           vec[idx] /= d_val[idx];
         }
       }
@@ -187,18 +187,18 @@ namespace ReSolve {
      * @brief Wrapper that divides a vector's elements by another vector's elements
      *
      * @param[in]  n       - size of the vectors
-     * @param[in]  divisor - divisor values
+     * @param[in]  diag - diag values
      * @param[in, out] vec - vector to be divided. Changes in place.
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void scaleInv(index_type       n,
-                           const real_type* divisor,
+    void diagSolve(index_type       n,
+                           const real_type* diag,
                            real_type*       vec)
     {
       int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::scaleInv<<<num_blocks, block_size>>>(n, divisor, vec);
+      kernels::diagSolve<<<num_blocks, block_size>>>(n, diag, vec);
     }
 
     /**

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -79,7 +79,7 @@ namespace ReSolve {
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void elementwiseDivide(index_type       n,
+      __global__ void scaleInv(index_type       n,
                                         const real_type* d_val,
                                         real_type*       vec)
       {
@@ -103,7 +103,7 @@ namespace ReSolve {
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
-      __global__ void elementwiseMax(index_type       n,
+      __global__ void max(index_type       n,
                                      const real_type* x,
                                      real_type*       y)
       {
@@ -186,7 +186,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void elementwiseDivide(index_type       n,
+    void scaleInv(index_type       n,
                            const real_type* divisor,
                            real_type*       vec)
     {
@@ -194,7 +194,7 @@ namespace ReSolve {
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::elementwiseDivide<<<num_blocks, block_size>>>(n, divisor, vec);
+      kernels::scaleInv<<<num_blocks, block_size>>>(n, divisor, vec);
     }
 
     /**
@@ -206,7 +206,7 @@ namespace ReSolve {
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void elementwiseMax(index_type       n,
+    void max(index_type       n,
                         const real_type* x,
                         real_type*       y)
     {
@@ -214,7 +214,7 @@ namespace ReSolve {
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::elementwiseMax<<<num_blocks, block_size>>>(n, x, y);
+      kernels::max<<<num_blocks, block_size>>>(n, x, y);
     }
 
     /**

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -145,6 +145,8 @@ namespace ReSolve {
       }
     } // namespace kernels
 
+    constexpr index_type block_size = 256;
+
     void setArrayConst(index_type n, real_type c, real_type* v)
     {
       index_type num_blocks;
@@ -194,9 +196,7 @@ namespace ReSolve {
                            const real_type* divisor,
                            real_type*       vec)
     {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int       num_blocks = (n + block_size - 1) / block_size;
+      int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::scaleInv<<<num_blocks, block_size>>>(n, divisor, vec);
     }
@@ -216,9 +216,7 @@ namespace ReSolve {
              const real_type* y,
              real_type*       out)
     {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int       num_blocks = (n + block_size - 1) / block_size;
+      int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::max<<<num_blocks, block_size>>>(n, x, y, out);
     }
@@ -236,9 +234,7 @@ namespace ReSolve {
              const real_type* in,
              real_type*       out)
     {
-      // Define block size and number of blocks
-      const int block_size = 256;
-      int       num_blocks = (n + block_size - 1) / block_size;
+      int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::abs<<<num_blocks, block_size>>>(n, in, out);
     }

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -69,6 +69,30 @@ namespace ReSolve {
           vec[idx] *= diag[idx];
         }
       }
+
+      /**
+       * @brief Divides a vector's elements by another vector's elements
+       *
+       * @param[in]  n       - size of the vectors
+       * @param[in]  d_val   - divisor values
+       * @param[in, out] vec - vector to be divided. Changes in place.
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void elementwiseDivide(index_type       n,
+                                        const real_type* d_val,
+                                        real_type*       vec)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n)
+        {
+          // Divide the vector element by the corresponding divisor value
+          vec[idx] /= d_val[idx];
+        }
+      }
     } // namespace kernels
 
     void setArrayConst(index_type n, real_type c, real_type* v)
@@ -105,6 +129,26 @@ namespace ReSolve {
       int num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::scale<<<num_blocks, block_size>>>(n, diag, vec);
+    }
+
+    /**
+     * @brief Wrapper that divides a vector's elements by another vector's elements
+     *
+     * @param[in]  n       - size of the vectors
+     * @param[in]  divisor - divisor values
+     * @param[in, out] vec - vector to be divided. Changes in place.
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void elementwiseDivide(index_type       n,
+                           const real_type* divisor,
+                           real_type*       vec)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int       num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::elementwiseDivide<<<num_blocks, block_size>>>(n, divisor, vec);
     }
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -95,17 +95,19 @@ namespace ReSolve {
       }
 
       /**
-       * @brief Wrapper that computes the element-wise max of two vectors.
+       * @brief Computes the element-wise max of two vectors.
        *
-       * @param[in]      n - size of the vectors
-       * @param[in]      x - First vector values
-       * @param[in, out] y - Second vector values. Changes in place.
+       * @param[in]  n   - size of the vectors
+       * @param[in]  x   - First vector values
+       * @param[in]  y   - Second vector values
+       * @param[out] out - Output vector values
        *
        * @todo Decide how to allow user to configure grid and block sizes.
        */
       __global__ void max(index_type       n,
-                                     const real_type* x,
-                                     real_type*       y)
+                          const real_type* x,
+                          const real_type* y,
+                          real_type*       out)
       {
         // Get the index of the element to be processed
         index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
@@ -114,7 +116,7 @@ namespace ReSolve {
         if (idx < n)
         {
           // Compute maximum of elements
-          y[idx] = max(x[idx], y[idx]);
+          out[idx] = max(x[idx], y[idx]);
         }
       }
 
@@ -202,21 +204,23 @@ namespace ReSolve {
     /**
      * @brief Wrapper that computes the element-wise max of two vectors.
      *
-     * @param[in]      n - size of the vectors
-     * @param[in]      x - First vector values
-     * @param[in, out] y - Second vector values. Changes in place.
+     * @param[in]  n   - size of the vectors
+     * @param[in]  x   - First vector values
+     * @param[in]  y   - Second vector values
+     * @param[out] out - Output vector values
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
     void max(index_type       n,
-                        const real_type* x,
-                        real_type*       y)
+             const real_type* x,
+             const real_type* y,
+             real_type*       out)
     {
       // Define block size and number of blocks
       const int block_size = 256;
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
-      kernels::max<<<num_blocks, block_size>>>(n, x, y);
+      kernels::max<<<num_blocks, block_size>>>(n, x, y, out);
     }
 
     /**

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -116,7 +116,7 @@ namespace ReSolve {
         if (idx < n)
         {
           // Compute maximum of elements
-          out[idx] = max(x[idx], y[idx]);
+          out[idx] = fmax(x[idx], y[idx]);
         }
       }
 

--- a/resolve/hip/hipVectorKernels.hip
+++ b/resolve/hip/hipVectorKernels.hip
@@ -93,6 +93,52 @@ namespace ReSolve {
           vec[idx] /= d_val[idx];
         }
       }
+
+      /**
+       * @brief Wrapper that computes the element-wise max of two vectors.
+       *
+       * @param[in]      n - size of the vectors
+       * @param[in]      x - First vector values
+       * @param[in, out] y - Second vector values. Changes in place.
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void elementwiseMax(index_type       n,
+                                     const real_type* x,
+                                     real_type*       y)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n)
+        {
+          // Compute maximum of elements
+          y[idx] = max(x[idx], y[idx]);
+        }
+      }
+
+      /**
+       * @brief Computes the element-wise absolute value of a vector.
+       *
+       * @param[in]      n - size of the vector
+       * @param[in, out] x - Vector values. Changes in place.
+       *
+       * @todo Decide how to allow user to configure grid and block sizes.
+       */
+      __global__ void abs(index_type n,
+                          real_type* x)
+      {
+        // Get the index of the element to be processed
+        index_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+        // Check if the index is within bounds
+        if (idx < n)
+        {
+          // Compute absolute value of element
+          x[idx] = fabs(x[idx]);
+        }
+      }
     } // namespace kernels
 
     void setArrayConst(index_type n, real_type c, real_type* v)
@@ -149,6 +195,44 @@ namespace ReSolve {
       int       num_blocks = (n + block_size - 1) / block_size;
       // Launch the kernel
       kernels::elementwiseDivide<<<num_blocks, block_size>>>(n, divisor, vec);
+    }
+
+    /**
+     * @brief Wrapper that computes the element-wise max of two vectors.
+     *
+     * @param[in]      n - size of the vectors
+     * @param[in]      x - First vector values
+     * @param[in, out] y - Second vector values. Changes in place.
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void elementwiseMax(index_type       n,
+                        const real_type* x,
+                        real_type*       y)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int       num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::elementwiseMax<<<num_blocks, block_size>>>(n, x, y);
+    }
+
+    /**
+     * @brief Wrapper that computes the element-wise absolute value of a vector.
+     *
+     * @param[in]      n - size of the vector
+     * @param[in, out] x - Vector values. Changes in place.
+     *
+     * @todo Decide how to allow user to configure grid and block sizes.
+     */
+    void abs(index_type n,
+             real_type* x)
+    {
+      // Define block size and number of blocks
+      const int block_size = 256;
+      int       num_blocks = (n + block_size - 1) / block_size;
+      // Launch the kernel
+      kernels::abs<<<num_blocks, block_size>>>(n, x);
     }
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hykkt/permutation/Permutation.cpp
+++ b/resolve/hykkt/permutation/Permutation.cpp
@@ -247,8 +247,8 @@ namespace ReSolve
                                real_type*      old_val,
                                real_type*      new_val)
     {
-      index_type  length;
-      index_type* apply_perm_;
+      index_type  length{0};
+      index_type* apply_perm_{nullptr};
       switch (permutation)
       {
       case PERM_V:

--- a/resolve/hykkt/ruiz/CMakeLists.txt
+++ b/resolve/hykkt/ruiz/CMakeLists.txt
@@ -18,7 +18,9 @@ set(RUIZ_HEADER_INSTALL
 # Build shared library ReSolve::hykkt
 add_library(resolve_hykkt_ruiz SHARED ${RUIZ_SRC})
 
-target_link_libraries(resolve_hykkt_ruiz PRIVATE resolve_logger resolve_vector resolve_matrix)
+target_link_libraries(
+  resolve_hykkt_ruiz PRIVATE resolve_logger resolve_vector resolve_matrix
+)
 
 # Link to CUDA ReSolve backend if CUDA is support enabled
 if(RESOLVE_USE_CUDA)

--- a/resolve/hykkt/ruiz/CMakeLists.txt
+++ b/resolve/hykkt/ruiz/CMakeLists.txt
@@ -18,7 +18,7 @@ set(RUIZ_HEADER_INSTALL
 # Build shared library ReSolve::hykkt
 add_library(resolve_hykkt_ruiz SHARED ${RUIZ_SRC})
 
-target_link_libraries(resolve_hykkt_ruiz PRIVATE resolve_logger resolve_vector)
+target_link_libraries(resolve_hykkt_ruiz PRIVATE resolve_logger resolve_vector resolve_matrix)
 
 # Link to CUDA ReSolve backend if CUDA is support enabled
 if(RESOLVE_USE_CUDA)

--- a/resolve/hykkt/spgemm/CMakeLists.txt
+++ b/resolve/hykkt/spgemm/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SPGEMM_ROCM_SRC SpGEMMHip.cpp)
 add_library(resolve_hykkt_spgemm SHARED ${SPGEMM_SRC})
 
 target_link_libraries(
-  resolve_hykkt_spgemm PRIVATE resolve_logger ${suitesparse_cholmod}
+  resolve_hykkt_spgemm PRIVATE resolve_logger ${suitesparse_cholmod} resolve_matrix resolve_vector
 )
 target_include_directories(
   resolve_hykkt_spgemm PUBLIC ${SUITESPARSE_INCLUDE_DIR}

--- a/resolve/hykkt/spgemm/CMakeLists.txt
+++ b/resolve/hykkt/spgemm/CMakeLists.txt
@@ -20,7 +20,8 @@ set(SPGEMM_ROCM_SRC SpGEMMHip.cpp)
 add_library(resolve_hykkt_spgemm SHARED ${SPGEMM_SRC})
 
 target_link_libraries(
-  resolve_hykkt_spgemm PRIVATE resolve_logger ${suitesparse_cholmod} resolve_matrix resolve_vector
+  resolve_hykkt_spgemm PRIVATE resolve_logger ${suitesparse_cholmod}
+                               resolve_matrix resolve_vector
 )
 target_include_directories(
   resolve_hykkt_spgemm PUBLIC ${SUITESPARSE_INCLUDE_DIR}

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -371,6 +371,59 @@ namespace ReSolve
   }
 
   /**
+   * @brief Takes the element-wise max between two vectors.
+   *
+   * @param[in] x        - The first vector
+   * @param[in,out] y    - The second vector (result is returned in y)
+   * @param[in] memspace - Device where the operation is computed
+   *
+   * @pre The two vectors must be the same size
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandler::elementwiseMax(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace)
+  {
+    assert(x->getSize() == y->getSize() && "Vectors must be the same size.");
+    assert(x->getData(memspace) != nullptr && "Vector x data is null!\n");
+    assert(y->getData(memspace) != nullptr && "Vector y data is null!\n");
+    using namespace ReSolve::memory;
+    switch (memspace)
+    {
+    case HOST:
+      return cpuImpl_->elementwiseMax(x, y);
+      break;
+    case DEVICE:
+      return devImpl_->elementwiseMax(x, y);
+      break;
+    }
+    return 1;
+  }
+
+  /**
+   * @brief Computes the element-wise absolute value of a vector.
+   *
+   * @param[in,out] x    - Input and output vector
+   * @param[in] memspace - Device where the operation is computed
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandler::abs(vector::Vector* x, memory::MemorySpace memspace)
+  {
+    assert(x->getData(memspace) != nullptr && "Vector data is null!\n");
+    using namespace ReSolve::memory;
+    switch (memspace)
+    {
+    case HOST:
+      return cpuImpl_->abs(x);
+      break;
+    case DEVICE:
+      return devImpl_->abs(x);
+      break;
+    }
+    return 1;
+  }
+
+  /**
    * @brief If CUDA support is enabled in the handler.
    *
    * @return true

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -373,27 +373,30 @@ namespace ReSolve
   /**
    * @brief Takes the element-wise max between two vectors.
    *
-   * @param[in] x        - The first vector
-   * @param[in,out] y    - The second vector (result is returned in y)
-   * @param[in] memspace - Device where the operation is computed
+   * @param[in]  x        - The first vector
+   * @param[in]  y        - The second vector
+   * @param[out] out      - The output vector
+   * @param[in]  memspace - Device where the operation is computed
    *
    * @pre The two vectors must be the same size
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::max(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace)
+  int VectorHandler::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out, memory::MemorySpace memspace)
   {
     assert(x->getSize() == y->getSize() && "Vectors must be the same size.");
-    assert(x->getData(memspace) != nullptr && "Vector x data is null!\n");
-    assert(y->getData(memspace) != nullptr && "Vector y data is null!\n");
+    assert(x->getSize() == out->getSize() && "Vectors must be the same size.");
+    assert(x->getData(memspace) != nullptr && "Vector x data is null!");
+    assert(y->getData(memspace) != nullptr && "Vector y data is null!");
+    assert(out->getData(memspace) != nullptr && "Vector out data is null!");
     using namespace ReSolve::memory;
     switch (memspace)
     {
     case HOST:
-      return cpuImpl_->max(x, y);
+      return cpuImpl_->max(x, y, out);
       break;
     case DEVICE:
-      return devImpl_->max(x, y);
+      return devImpl_->max(x, y, out);
       break;
     }
     return 1;

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -402,22 +402,26 @@ namespace ReSolve
   /**
    * @brief Computes the element-wise absolute value of a vector.
    *
-   * @param[in,out] x    - Input and output vector
-   * @param[in] memspace - Device where the operation is computed
+   * @param[in]  in       - Input vector
+   * @param[out] out      - Output vector
+   * @param[in]  memspace - Device where the operation is computed
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::abs(vector::Vector* x, memory::MemorySpace memspace)
+  int VectorHandler::abs(const vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace)
   {
-    assert(x->getData(memspace) != nullptr && "Vector data is null!\n");
+    assert(in->getData(memspace) != nullptr && "Vector in data is null!");
+    assert(out->getData(memspace) != nullptr && "Vector out data is null!");
+    assert(in->getSize() == out->getSize() && "Vector sizes do not match!");
+
     using namespace ReSolve::memory;
     switch (memspace)
     {
     case HOST:
-      return cpuImpl_->abs(x);
+      return cpuImpl_->abs(in, out);
       break;
     case DEVICE:
-      return devImpl_->abs(x);
+      return devImpl_->abs(in, out);
       break;
     }
     return 1;

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -342,9 +342,9 @@ namespace ReSolve
   }
 
   /**
-   * @brief Divide the elements of a vector by the elements of another vector
+   * @brief Multiplies vector by an inverse of a diagonal matrix.
    *
-   * @param[in] divisor - vector divisor
+   * @param[in]  diag   - diagonal matrix stored in a vector object
    * @param[in,out] vec - vector to be divided
    * @param[in] memspace - Device where the operation is computed
    *
@@ -352,19 +352,19 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::scaleInv(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace)
+  int VectorHandler::diagSolve(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace)
   {
-    assert(divisor->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
-    assert(divisor->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
+    assert(diag->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
+    assert(diag->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
     assert(vec->getData(memspace) != nullptr && "Vector data is null!\n");
     using namespace ReSolve::memory;
     switch (memspace)
     {
     case HOST:
-      return cpuImpl_->scaleInv(divisor, vec);
+      return cpuImpl_->diagSolve(diag, vec);
       break;
     case DEVICE:
-      return devImpl_->scaleInv(divisor, vec);
+      return devImpl_->diagSolve(diag, vec);
       break;
     }
     return 1;

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -352,7 +352,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace)
+  int VectorHandler::scaleInv(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace)
   {
     assert(divisor->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
     assert(divisor->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
@@ -361,10 +361,10 @@ namespace ReSolve
     switch (memspace)
     {
     case HOST:
-      return cpuImpl_->elementwiseDivide(divisor, vec);
+      return cpuImpl_->scaleInv(divisor, vec);
       break;
     case DEVICE:
-      return devImpl_->elementwiseDivide(divisor, vec);
+      return devImpl_->scaleInv(divisor, vec);
       break;
     }
     return 1;
@@ -381,7 +381,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::elementwiseMax(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace)
+  int VectorHandler::max(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace)
   {
     assert(x->getSize() == y->getSize() && "Vectors must be the same size.");
     assert(x->getData(memspace) != nullptr && "Vector x data is null!\n");
@@ -390,10 +390,10 @@ namespace ReSolve
     switch (memspace)
     {
     case HOST:
-      return cpuImpl_->elementwiseMax(x, y);
+      return cpuImpl_->max(x, y);
       break;
     case DEVICE:
-      return devImpl_->elementwiseMax(x, y);
+      return devImpl_->max(x, y);
       break;
     }
     return 1;

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -342,6 +342,35 @@ namespace ReSolve
   }
 
   /**
+   * @brief Divide the elements of a vector by the elements of another vector
+   *
+   * @param[in] divisor - vector divisor
+   * @param[in,out] vec - vector to be divided
+   * @param[in] memspace - Device where the operation is computed
+   *
+   * @pre The two vectors must be the same size
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandler::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace)
+  {
+    assert(divisor->getSize() == vec->getSize() && "Diagonal vector must be of the same size as the vector.");
+    assert(divisor->getData(memspace) != nullptr && "Diagonal vector data is null!\n");
+    assert(vec->getData(memspace) != nullptr && "Vector data is null!\n");
+    using namespace ReSolve::memory;
+    switch (memspace)
+    {
+    case HOST:
+      return cpuImpl_->elementwiseDivide(divisor, vec);
+      break;
+    case DEVICE:
+      return devImpl_->elementwiseDivide(divisor, vec);
+      break;
+    }
+    return 1;
+  }
+
+  /**
    * @brief If CUDA support is enabled in the handler.
    *
    * @return true

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -382,7 +382,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out, memory::MemorySpace memspace)
+  int VectorHandler::max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out, memory::MemorySpace memspace)
   {
     assert(x->getSize() == y->getSize() && "Vectors must be the same size.");
     assert(x->getSize() == out->getSize() && "Vectors must be the same size.");
@@ -411,7 +411,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandler::abs(const vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace)
+  int VectorHandler::abs(/* const */ vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace)
   {
     assert(in->getData(memspace) != nullptr && "Vector in data is null!");
     assert(out->getData(memspace) != nullptr && "Vector out data is null!");

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -70,7 +70,7 @@ namespace ReSolve
     int scaleInv(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace);
     int max(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace);
 
-    int abs(vector::Vector* x, memory::MemorySpace memspace);
+    int abs(const vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace);
 
     // Vector infinity norm
     real_type amax(vector::Vector* x, memory::MemorySpace memspace);

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -68,9 +68,9 @@ namespace ReSolve
               memory::MemorySpace memspace);
 
     int scaleInv(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace);
-    int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out, memory::MemorySpace memspace);
+    int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out, memory::MemorySpace memspace);
 
-    int abs(const vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace);
+    int abs(/* const */ vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace);
 
     // Vector infinity norm
     real_type amax(vector::Vector* x, memory::MemorySpace memspace);

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -68,7 +68,7 @@ namespace ReSolve
               memory::MemorySpace memspace);
 
     int scaleInv(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace);
-    int max(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace);
+    int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out, memory::MemorySpace memspace);
 
     int abs(const vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace);
 

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -67,6 +67,8 @@ namespace ReSolve
               vector::Vector*     x,
               memory::MemorySpace memspace);
 
+    int elementwiseDivide(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace);
+
     // Vector infinity norm
     real_type amax(vector::Vector* x, memory::MemorySpace memspace);
 

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -67,8 +67,8 @@ namespace ReSolve
               vector::Vector*     x,
               memory::MemorySpace memspace);
 
-    int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace);
-    int elementwiseMax(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace);
+    int scaleInv(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace);
+    int max(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace);
 
     int abs(vector::Vector* x, memory::MemorySpace memspace);
 

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -67,7 +67,10 @@ namespace ReSolve
               vector::Vector*     x,
               memory::MemorySpace memspace);
 
-    int elementwiseDivide(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace);
+    int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace);
+    int elementwiseMax(vector::Vector* x, vector::Vector* y, memory::MemorySpace memspace);
+
+    int abs(vector::Vector* x, memory::MemorySpace memspace);
 
     // Vector infinity norm
     real_type amax(vector::Vector* x, memory::MemorySpace memspace);

--- a/resolve/vector/VectorHandler.hpp
+++ b/resolve/vector/VectorHandler.hpp
@@ -67,7 +67,7 @@ namespace ReSolve
               vector::Vector*     x,
               memory::MemorySpace memspace);
 
-    int scaleInv(vector::Vector* divisor, vector::Vector* vec, memory::MemorySpace memspace);
+    int diagSolve(vector::Vector* diag, vector::Vector* vec, memory::MemorySpace memspace);
     int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out, memory::MemorySpace memspace);
 
     int abs(/* const */ vector::Vector* in, vector::Vector* out, memory::MemorySpace memspace);

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -329,8 +329,8 @@ namespace ReSolve
   int VectorHandlerCpu::diagSolve(vector::Vector* diag, vector::Vector* vec)
   {
     real_type* diag_data = diag->getData(memory::HOST);
-    real_type* vec_data     = vec->getData(memory::HOST);
-    index_type n            = vec->getSize();
+    real_type* vec_data  = vec->getData(memory::HOST);
+    index_type n         = vec->getSize();
 
     for (index_type i = 0; i < n; ++i)
     {

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -372,16 +372,17 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::abs(vector::Vector* x)
+  int VectorHandlerCpu::abs(const vector::Vector* in, vector::Vector* out)
   {
-    real_type* x_data = x->getData(memory::HOST);
-    index_type n      = x->getSize();
+    const real_type* in_data  = in->getData(memory::HOST);
+    real_type*       out_data = out->getData(memory::HOST);
+    index_type       n        = in->getSize();
 
     for (index_type i = 0; i < n; ++i)
     {
-      x_data[i] = std::abs(x_data[i]);
+      out_data[i] = std::abs(in_data[i]);
     }
-    x->setDataUpdated(memory::HOST);
+    out->setDataUpdated(memory::HOST);
     return 0;
   }
 

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -326,7 +326,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec)
+  int VectorHandlerCpu::scaleInv(vector::Vector* divisor, vector::Vector* vec)
   {
     real_type* divisor_data = divisor->getData(memory::HOST);
     real_type* vec_data     = vec->getData(memory::HOST);
@@ -351,7 +351,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::elementwiseMax(vector::Vector* x, vector::Vector* y)
+  int VectorHandlerCpu::max(vector::Vector* x, vector::Vector* y)
   {
     real_type* x_data = x->getData(memory::HOST);
     real_type* y_data = y->getData(memory::HOST);

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -317,24 +317,24 @@ namespace ReSolve
   }
 
   /**
-   * @brief Divide the elements of a vector by the elements of another vector
+   * @brief Multiplies vector by an inverse of a diagonal matrix.
    *
-   * @param[in] divisor - vector divisor
+   * @param[in]  diag   - diagonal matrix stored in a vector object
    * @param[in,out] vec - vector to be divided
    *
    * @pre The two vectors must be the same size
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::scaleInv(vector::Vector* divisor, vector::Vector* vec)
+  int VectorHandlerCpu::diagSolve(vector::Vector* diag, vector::Vector* vec)
   {
-    real_type* divisor_data = divisor->getData(memory::HOST);
+    real_type* diag_data = diag->getData(memory::HOST);
     real_type* vec_data     = vec->getData(memory::HOST);
     index_type n            = vec->getSize();
 
     for (index_type i = 0; i < n; ++i)
     {
-      vec_data[i] /= divisor_data[i];
+      vec_data[i] /= diag_data[i];
     }
     vec->setDataUpdated(memory::HOST);
     return 0;

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -352,7 +352,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out)
+  int VectorHandlerCpu::max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out)
   {
     const real_type* x_data   = x->getData(memory::HOST);
     const real_type* y_data   = y->getData(memory::HOST);
@@ -374,7 +374,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::abs(const vector::Vector* in, vector::Vector* out)
+  int VectorHandlerCpu::abs(/* const */ vector::Vector* in, vector::Vector* out)
   {
     const real_type* in_data  = in->getData(memory::HOST);
     real_type*       out_data = out->getData(memory::HOST);

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -316,4 +316,28 @@ namespace ReSolve
     vec->setDataUpdated(memory::HOST);
   }
 
+  /**
+   * @brief Divide the elements of a vector by the elements of another vector
+   *
+   * @param[in] divisor - vector divisor
+   * @param[in,out] vec - vector to be divided
+   *
+   * @pre The two vectors must be the same size
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCpu::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec)
+  {
+    real_type* divisor_data = divisor->getData(memory::HOST);
+    real_type* vec_data     = vec->getData(memory::HOST);
+    index_type n            = vec->getSize();
+
+    for (index_type i = 0; i < n; ++i)
+    {
+      vec_data[i] /= divisor_data[i];
+    }
+    vec->setDataUpdated(memory::HOST);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -344,24 +344,26 @@ namespace ReSolve
    * @brief Take the element-wise max of two vectors.
    * Each element of the output will be the maximum value of the corresponding elements in the input vectors.
    *
-   * @param[in]     x - First vector
-   * @param[in,out] y - Second vector (output)
+   * @param[in]  x   - First input vector
+   * @param[in]  y   - Second input vector
+   * @param[out] out - Output vector
    *
-   * @pre The two vectors must be the same size
+   * @pre The three vectors must be the same size
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCpu::max(vector::Vector* x, vector::Vector* y)
+  int VectorHandlerCpu::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out)
   {
-    real_type* x_data = x->getData(memory::HOST);
-    real_type* y_data = y->getData(memory::HOST);
-    index_type n      = y->getSize();
+    const real_type* x_data   = x->getData(memory::HOST);
+    const real_type* y_data   = y->getData(memory::HOST);
+    real_type*       out_data = out->getData(memory::HOST);
+    index_type       n        = y->getSize();
 
     for (index_type i = 0; i < n; ++i)
     {
-      y_data[i] = std::max(x_data[i], y_data[i]);
+      out_data[i] = std::max(x_data[i], y_data[i]);
     }
-    y->setDataUpdated(memory::HOST);
+    out->setDataUpdated(memory::HOST);
     return 0;
   }
 

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -340,4 +340,49 @@ namespace ReSolve
     return 0;
   }
 
+  /**
+   * @brief Take the element-wise max of two vectors.
+   * Each element of the output will be the maximum value of the corresponding elements in the input vectors.
+   *
+   * @param[in]     x - First vector
+   * @param[in,out] y - Second vector (output)
+   *
+   * @pre The two vectors must be the same size
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCpu::elementwiseMax(vector::Vector* x, vector::Vector* y)
+  {
+    real_type* x_data = x->getData(memory::HOST);
+    real_type* y_data = y->getData(memory::HOST);
+    index_type n      = y->getSize();
+
+    for (index_type i = 0; i < n; ++i)
+    {
+      y_data[i] = std::max(x_data[i], y_data[i]);
+    }
+    y->setDataUpdated(memory::HOST);
+    return 0;
+  }
+
+  /**
+   * @brief Take the element-wise absolute value of a vector.
+   *
+   * @param[in,out] x - Input and output vector
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCpu::abs(vector::Vector* x)
+  {
+    real_type* x_data = x->getData(memory::HOST);
+    index_type n      = x->getSize();
+
+    for (index_type i = 0; i < n; ++i)
+    {
+      x_data[i] = std::abs(x_data[i]);
+    }
+    x->setDataUpdated(memory::HOST);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -59,6 +59,10 @@ namespace ReSolve
 
     virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
 
+    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y);
+
+    virtual int abs(vector::Vector* x);
+
   private:
     LinAlgWorkspaceCpu* workspace_;
   };

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -57,6 +57,8 @@ namespace ReSolve
 
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
+    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
+
   private:
     LinAlgWorkspaceCpu* workspace_;
   };

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -57,9 +57,9 @@ namespace ReSolve
 
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
-    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
+    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
 
-    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y);
+    virtual int max(vector::Vector* x, vector::Vector* y);
 
     virtual int abs(vector::Vector* x);
 

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -57,7 +57,7 @@ namespace ReSolve
 
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
-    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
+    virtual int diagSolve(vector::Vector* diag, vector::Vector* vec);
 
     virtual int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out);
 

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -59,7 +59,7 @@ namespace ReSolve
 
     virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
 
-    virtual int max(vector::Vector* x, vector::Vector* y);
+    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out);
 
     virtual int abs(const vector::Vector* in, vector::Vector* out);
 

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -61,7 +61,7 @@ namespace ReSolve
 
     virtual int max(vector::Vector* x, vector::Vector* y);
 
-    virtual int abs(vector::Vector* x);
+    virtual int abs(const vector::Vector* in, vector::Vector* out);
 
   private:
     LinAlgWorkspaceCpu* workspace_;

--- a/resolve/vector/VectorHandlerCpu.hpp
+++ b/resolve/vector/VectorHandlerCpu.hpp
@@ -59,9 +59,9 @@ namespace ReSolve
 
     virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
 
-    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out);
+    virtual int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out);
 
-    virtual int abs(const vector::Vector* in, vector::Vector* out);
+    virtual int abs(/* const */ vector::Vector* in, vector::Vector* out);
 
   private:
     LinAlgWorkspaceCpu* workspace_;

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -364,20 +364,22 @@ namespace ReSolve
   /**
    * @brief Calculate element-wise maximum between two vectors in CUDA
    *
-   * @param[in]      x - The first vector
-   * @param[in, out] y - The second vector (result is returned in y)
+   * @param[in]  x   - The first vector
+   * @param[in]  y   - The second vector
+   * @param[out] out - The output vector
    *
-   * @pre The two vectors must be the same size
+   * @pre The three vectors must be the same size
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::max(vector::Vector* x, vector::Vector* y)
+  int VectorHandlerCuda::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out)
   {
-    real_type* x_data = x->getData(memory::DEVICE);
-    real_type* y_data = y->getData(memory::DEVICE);
-    index_type n      = y->getSize();
-    cuda::max(n, x_data, y_data);
-    y->setDataUpdated(memory::DEVICE);
+    real_type* x_data   = x->getData(memory::DEVICE);
+    real_type* y_data   = y->getData(memory::DEVICE);
+    real_type* out_data = out->getData(memory::DEVICE);
+    index_type n        = y->getSize();
+    cuda::max(n, x_data, y_data, out_data);
+    out->setDataUpdated(memory::DEVICE);
     return 0;
   }
 

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -354,8 +354,8 @@ namespace ReSolve
   int VectorHandlerCuda::diagSolve(vector::Vector* diag, vector::Vector* vec)
   {
     real_type* diag_data = diag->getData(memory::DEVICE);
-    real_type* vec_data     = vec->getData(memory::DEVICE);
-    index_type n            = vec->getSize();
+    real_type* vec_data  = vec->getData(memory::DEVICE);
+    index_type n         = vec->getSize();
     cuda::diagSolve(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -384,16 +384,18 @@ namespace ReSolve
   /**
    * @brief Calculate element-wise absolute value of a vector in CUDA
    *
-   * @param[in, out] x - The vector (result is returned in x)
+   * @param[in]  in  - The input vector
+   * @param[out] out - The output
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::abs(vector::Vector* x)
+  int VectorHandlerCuda::abs(const vector::Vector* in, vector::Vector* out)
   {
-    real_type* x_data = x->getData(memory::DEVICE);
-    index_type n      = x->getSize();
-    cuda::abs(n, x_data);
-    x->setDataUpdated(memory::DEVICE);
+    const real_type* in_data  = in->getData(memory::DEVICE);
+    real_type*       out_data = out->getData(memory::DEVICE);
+    index_type       n        = in->getSize();
+    cuda::abs(n, in_data, out_data);
+    out->setDataUpdated(memory::DEVICE);
     return 0;
   }
 

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -361,4 +361,40 @@ namespace ReSolve
     return 0;
   }
 
+  /**
+   * @brief Calculate element-wise maximum between two vectors in CUDA
+   *
+   * @param[in]      x - The first vector
+   * @param[in, out] y - The second vector (result is returned in y)
+   *
+   * @pre The two vectors must be the same size
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCuda::elementwiseMax(vector::Vector* x, vector::Vector* y)
+  {
+    real_type* x_data = x->getData(memory::DEVICE);
+    real_type* y_data = y->getData(memory::DEVICE);
+    index_type n      = y->getSize();
+    cuda::elementwiseMax(n, x_data, y_data);
+    y->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
+  /**
+   * @brief Calculate element-wise absolute value of a vector in CUDA
+   *
+   * @param[in, out] x - The vector (result is returned in x)
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCuda::abs(vector::Vector* x)
+  {
+    real_type* x_data = x->getData(memory::DEVICE);
+    index_type n      = x->getSize();
+    cuda::abs(n, x_data);
+    x->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -372,7 +372,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out)
+  int VectorHandlerCuda::max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out)
   {
     real_type* x_data   = x->getData(memory::DEVICE);
     real_type* y_data   = y->getData(memory::DEVICE);
@@ -391,7 +391,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::abs(const vector::Vector* in, vector::Vector* out)
+  int VectorHandlerCuda::abs(/* const */ vector::Vector* in, vector::Vector* out)
   {
     const real_type* in_data  = in->getData(memory::DEVICE);
     real_type*       out_data = out->getData(memory::DEVICE);

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -339,4 +339,26 @@ namespace ReSolve
     vec->setDataUpdated(memory::DEVICE);
   }
 
+  /**
+   * @brief Divide a vector's elements by another vector's elements in CUDA
+   *
+   * @param[in]  divisor  - vector of divisors
+   * @param[in, out]  vec - vector to be divided
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @pre vec is undivided
+   * @post vec is divided
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerCuda::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec)
+  {
+    real_type* divisor_data = divisor->getData(memory::DEVICE);
+    real_type* vec_data     = vec->getData(memory::DEVICE);
+    index_type n            = vec->getSize();
+    cuda::elementwiseDivide(n, divisor_data, vec_data);
+    vec->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -351,12 +351,12 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec)
+  int VectorHandlerCuda::scaleInv(vector::Vector* divisor, vector::Vector* vec)
   {
     real_type* divisor_data = divisor->getData(memory::DEVICE);
     real_type* vec_data     = vec->getData(memory::DEVICE);
     index_type n            = vec->getSize();
-    cuda::elementwiseDivide(n, divisor_data, vec_data);
+    cuda::scaleInv(n, divisor_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }
@@ -371,12 +371,12 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::elementwiseMax(vector::Vector* x, vector::Vector* y)
+  int VectorHandlerCuda::max(vector::Vector* x, vector::Vector* y)
   {
     real_type* x_data = x->getData(memory::DEVICE);
     real_type* y_data = y->getData(memory::DEVICE);
     index_type n      = y->getSize();
-    cuda::elementwiseMax(n, x_data, y_data);
+    cuda::max(n, x_data, y_data);
     y->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -340,9 +340,9 @@ namespace ReSolve
   }
 
   /**
-   * @brief Divide a vector's elements by another vector's elements in CUDA
+   * @brief Multiplies vector by an inverse of a diagonal matrix.
    *
-   * @param[in]  divisor  - vector of divisors
+   * @param[in]  diag   - diagonal matrix stored in a vector object
    * @param[in, out]  vec - vector to be divided
    *
    * @pre The diagonal vector must be of the same size as the vector.
@@ -351,12 +351,12 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerCuda::scaleInv(vector::Vector* divisor, vector::Vector* vec)
+  int VectorHandlerCuda::diagSolve(vector::Vector* diag, vector::Vector* vec)
   {
-    real_type* divisor_data = divisor->getData(memory::DEVICE);
+    real_type* diag_data = diag->getData(memory::DEVICE);
     real_type* vec_data     = vec->getData(memory::DEVICE);
     index_type n            = vec->getSize();
-    cuda::scaleInv(n, divisor_data, vec_data);
+    cuda::diagSolve(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -76,6 +76,25 @@ namespace ReSolve
      */
     virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
 
+    /**
+     * @brief elementwiseMax: calculate the element-wise maximum of two vectors
+     *
+     * @param[in]     x vector of size n x 1
+     * @param[in,out] y vector of size n x 1 (this is where the result is stored)
+     *
+     * @return 0 if successful, 1 otherwise
+     */
+    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y);
+
+    /**
+     * @brief abs: calculate the element-wise absolute value of a vector
+     *
+     * @param[in,out] x vector of size n x 1 (this is where the result is stored)
+     *
+     * @return 0 if successful, 1 otherwise
+     */
+    virtual int abs(vector::Vector* x);
+
   private:
     MemoryHandler        mem_; ///< Device memory manager object
     LinAlgWorkspaceCUDA* workspace_;

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -66,6 +66,16 @@ namespace ReSolve
      */
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
+    /**
+     * @brief elementwiseDivide: divides a vector's elements by another's
+     *
+     * @param[in] divisor vector of size n x 1
+     * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
+     *
+     * @return 0 if successful, 1 otherwise
+     */
+    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
+
   private:
     MemoryHandler        mem_; ///< Device memory manager object
     LinAlgWorkspaceCUDA* workspace_;

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -79,12 +79,13 @@ namespace ReSolve
     /**
      * @brief max: calculate the element-wise maximum of two vectors
      *
-     * @param[in]     x vector of size n x 1
-     * @param[in,out] y vector of size n x 1 (this is where the result is stored)
+     * @param[in]  x   vector of size n x 1
+     * @param[in]  y   vector of size n x 1
+     * @param[out] out output vector of size n x 1
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int max(vector::Vector* x, vector::Vector* y);
+    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out);
 
     /**
      * @brief abs: calculate the element-wise absolute value of a vector

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -85,7 +85,7 @@ namespace ReSolve
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out);
+    virtual int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out);
 
     /**
      * @brief abs: calculate the element-wise absolute value of a vector
@@ -94,7 +94,7 @@ namespace ReSolve
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int abs(const vector::Vector* in, vector::Vector* out);
+    virtual int abs(/* const */ vector::Vector* in, vector::Vector* out);
 
   private:
     MemoryHandler        mem_; ///< Device memory manager object

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -67,14 +67,15 @@ namespace ReSolve
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
     /**
-     * @brief scaleInv: divides a vector's elements by another's
+     * @brief Multiplies vector by an inverse of a diagonal matrix.
      *
-     * @param[in] divisor vector of size n x 1
+     *
+     * @param[in] diag vector of size n x 1
      * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
+    virtual int diagSolve(vector::Vector* diag, vector::Vector* vec);
 
     /**
      * @brief max: calculate the element-wise maximum of two vectors

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -93,7 +93,7 @@ namespace ReSolve
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int abs(vector::Vector* x);
+    virtual int abs(const vector::Vector* in, vector::Vector* out);
 
   private:
     MemoryHandler        mem_; ///< Device memory manager object

--- a/resolve/vector/VectorHandlerCuda.hpp
+++ b/resolve/vector/VectorHandlerCuda.hpp
@@ -67,24 +67,24 @@ namespace ReSolve
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
     /**
-     * @brief elementwiseDivide: divides a vector's elements by another's
+     * @brief scaleInv: divides a vector's elements by another's
      *
      * @param[in] divisor vector of size n x 1
      * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
+    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
 
     /**
-     * @brief elementwiseMax: calculate the element-wise maximum of two vectors
+     * @brief max: calculate the element-wise maximum of two vectors
      *
      * @param[in]     x vector of size n x 1
      * @param[in,out] y vector of size n x 1 (this is where the result is stored)
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y);
+    virtual int max(vector::Vector* x, vector::Vector* y);
 
     /**
      * @brief abs: calculate the element-wise absolute value of a vector

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -358,20 +358,22 @@ namespace ReSolve
   /**
    * @brief Calculate element-wise maximum between two vectors in HIP
    *
-   * @param[in]      x - The first vector
-   * @param[in, out] y - The second vector (result is returned in y)
+   * @param[in]  x   - The first vector
+   * @param[in]  y   - The second vector
+   * @param[out] out - The output vector
    *
-   * @pre The two vectors must be the same size
+   * @pre The three vectors must be the same size
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::max(vector::Vector* x, vector::Vector* y)
+  int VectorHandlerHip::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out)
   {
-    real_type* x_data = x->getData(memory::DEVICE);
-    real_type* y_data = y->getData(memory::DEVICE);
-    index_type n      = y->getSize();
-    hip::max(n, x_data, y_data);
-    y->setDataUpdated(memory::DEVICE);
+    real_type* x_data   = x->getData(memory::DEVICE);
+    real_type* y_data   = y->getData(memory::DEVICE);
+    real_type* out_data = out->getData(memory::DEVICE);
+    index_type n        = y->getSize();
+    hip::max(n, x_data, y_data, out_data);
+    out->setDataUpdated(memory::DEVICE);
     return 0;
   }
 

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -366,7 +366,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out)
+  int VectorHandlerHip::max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out)
   {
     real_type* x_data   = x->getData(memory::DEVICE);
     real_type* y_data   = y->getData(memory::DEVICE);
@@ -385,7 +385,7 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::abs(const vector::Vector* in, vector::Vector* out)
+  int VectorHandlerHip::abs(/* const */ vector::Vector* in, vector::Vector* out)
   {
     const real_type* in_data  = in->getData(memory::DEVICE);
     real_type*       out_data = out->getData(memory::DEVICE);

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -333,4 +333,26 @@ namespace ReSolve
     vec->setDataUpdated(memory::DEVICE);
   }
 
+  /**
+   * @brief Divide a vector's elements by another vector's elements in HIP
+   *
+   * @param[in]  divisor  - vector of divisors
+   * @param[in, out]  vec - vector to be divided
+   *
+   * @pre The diagonal vector must be of the same size as the vector.
+   * @pre vec is undivided
+   * @post vec is divided
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerHip::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec)
+  {
+    real_type* divisor_data = divisor->getData(memory::DEVICE);
+    real_type* vec_data     = vec->getData(memory::DEVICE);
+    index_type n            = vec->getSize();
+    hip::elementwiseDivide(n, divisor_data, vec_data);
+    vec->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -378,16 +378,18 @@ namespace ReSolve
   /**
    * @brief Calculate element-wise absolute value of a vector in HIP
    *
-   * @param[in, out] x - The vector (result is returned in x)
+   * @param[in]  in  - The input vector
+   * @param[out] out - The output
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::abs(vector::Vector* x)
+  int VectorHandlerHip::abs(const vector::Vector* in, vector::Vector* out)
   {
-    real_type* x_data = x->getData(memory::DEVICE);
-    index_type n      = x->getSize();
-    hip::abs(n, x_data);
-    x->setDataUpdated(memory::DEVICE);
+    const real_type* in_data  = in->getData(memory::DEVICE);
+    real_type*       out_data = out->getData(memory::DEVICE);
+    index_type       n        = in->getSize();
+    hip::abs(n, in_data, out_data);
+    out->setDataUpdated(memory::DEVICE);
     return 0;
   }
 

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -345,12 +345,12 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::elementwiseDivide(vector::Vector* divisor, vector::Vector* vec)
+  int VectorHandlerHip::scaleInv(vector::Vector* divisor, vector::Vector* vec)
   {
     real_type* divisor_data = divisor->getData(memory::DEVICE);
     real_type* vec_data     = vec->getData(memory::DEVICE);
     index_type n            = vec->getSize();
-    hip::elementwiseDivide(n, divisor_data, vec_data);
+    hip::scaleInv(n, divisor_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }
@@ -365,12 +365,12 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::elementwiseMax(vector::Vector* x, vector::Vector* y)
+  int VectorHandlerHip::max(vector::Vector* x, vector::Vector* y)
   {
     real_type* x_data = x->getData(memory::DEVICE);
     real_type* y_data = y->getData(memory::DEVICE);
     index_type n      = y->getSize();
-    hip::elementwiseMax(n, x_data, y_data);
+    hip::max(n, x_data, y_data);
     y->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -355,4 +355,40 @@ namespace ReSolve
     return 0;
   }
 
+  /**
+   * @brief Calculate element-wise maximum between two vectors in HIP
+   *
+   * @param[in]      x - The first vector
+   * @param[in, out] y - The second vector (result is returned in y)
+   *
+   * @pre The two vectors must be the same size
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerHip::elementwiseMax(vector::Vector* x, vector::Vector* y)
+  {
+    real_type* x_data = x->getData(memory::DEVICE);
+    real_type* y_data = y->getData(memory::DEVICE);
+    index_type n      = y->getSize();
+    hip::elementwiseMax(n, x_data, y_data);
+    y->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
+  /**
+   * @brief Calculate element-wise absolute value of a vector in HIP
+   *
+   * @param[in, out] x - The vector (result is returned in x)
+   *
+   * @return 0 if successful, 1 otherwise
+   */
+  int VectorHandlerHip::abs(vector::Vector* x)
+  {
+    real_type* x_data = x->getData(memory::DEVICE);
+    index_type n      = x->getSize();
+    hip::abs(n, x_data);
+    x->setDataUpdated(memory::DEVICE);
+    return 0;
+  }
+
 } // namespace ReSolve

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -334,9 +334,9 @@ namespace ReSolve
   }
 
   /**
-   * @brief Divide a vector's elements by another vector's elements in HIP
+   * @brief Multiplies vector by an inverse of a diagonal matrix.
    *
-   * @param[in]  divisor  - vector of divisors
+   * @param[in]  diag   - diagonal matrix stored in a vector object
    * @param[in, out]  vec - vector to be divided
    *
    * @pre The diagonal vector must be of the same size as the vector.
@@ -345,12 +345,12 @@ namespace ReSolve
    *
    * @return 0 if successful, 1 otherwise
    */
-  int VectorHandlerHip::scaleInv(vector::Vector* divisor, vector::Vector* vec)
+  int VectorHandlerHip::diagSolve(vector::Vector* diag, vector::Vector* vec)
   {
-    real_type* divisor_data = divisor->getData(memory::DEVICE);
-    real_type* vec_data     = vec->getData(memory::DEVICE);
-    index_type n            = vec->getSize();
-    hip::scaleInv(n, divisor_data, vec_data);
+    real_type* diag_data = diag->getData(memory::DEVICE);
+    real_type* vec_data  = vec->getData(memory::DEVICE);
+    index_type n         = vec->getSize();
+    hip::diagSolve(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
     return 0;
   }

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -93,7 +93,7 @@ namespace ReSolve
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int abs(vector::Vector* x);
+    virtual int abs(const vector::Vector* in, vector::Vector* out);
 
   private:
     LinAlgWorkspaceHIP* workspace_;

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -85,7 +85,7 @@ namespace ReSolve
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out);
+    virtual int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out);
 
     /**
      * @brief abs: calculate the element-wise absolute value of a vector
@@ -94,7 +94,7 @@ namespace ReSolve
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int abs(const vector::Vector* in, vector::Vector* out);
+    virtual int abs(/* const */ vector::Vector* in, vector::Vector* out);
 
   private:
     LinAlgWorkspaceHIP* workspace_;

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -79,12 +79,13 @@ namespace ReSolve
     /**
      * @brief max: calculate the element-wise maximum of two vectors
      *
-     * @param[in]     x vector of size n x 1
-     * @param[in,out] y vector of size n x 1 (this is where the result is stored)
+     * @param[in]  x   vector of size n x 1
+     * @param[in]  y   vector of size n x 1
+     * @param[out] out output vector of size n x 1
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int max(vector::Vector* x, vector::Vector* y);
+    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out);
 
     /**
      * @brief abs: calculate the element-wise absolute value of a vector

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -76,6 +76,25 @@ namespace ReSolve
      */
     virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
 
+    /**
+     * @brief elementwiseMax: calculate the element-wise maximum of two vectors
+     *
+     * @param[in]     x vector of size n x 1
+     * @param[in,out] y vector of size n x 1 (this is where the result is stored)
+     *
+     * @return 0 if successful, 1 otherwise
+     */
+    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y);
+
+    /**
+     * @brief abs: calculate the element-wise absolute value of a vector
+     *
+     * @param[in,out] x vector of size n x 1 (this is where the result is stored)
+     *
+     * @return 0 if successful, 1 otherwise
+     */
+    virtual int abs(vector::Vector* x);
+
   private:
     LinAlgWorkspaceHIP* workspace_;
     MemoryHandler       mem_; ///< Device memory manager object

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -67,14 +67,14 @@ namespace ReSolve
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
     /**
-     * @brief scaleInv: divides a vector's elements by another's
+     * @brief Multiplies vector by an inverse of a diagonal matrix.
      *
-     * @param[in] divisor vector of size n x 1
+     * @param[in] diag vector of size n x 1
      * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
+    virtual int diagSolve(vector::Vector* diag, vector::Vector* vec);
 
     /**
      * @brief max: calculate the element-wise maximum of two vectors

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -66,6 +66,16 @@ namespace ReSolve
      */
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
+    /**
+     * @brief elementwiseDivide: divides a vector's elements by another's
+     *
+     * @param[in] divisor vector of size n x 1
+     * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
+     *
+     * @return 0 if successful, 1 otherwise
+     */
+    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
+
   private:
     LinAlgWorkspaceHIP* workspace_;
     MemoryHandler       mem_; ///< Device memory manager object

--- a/resolve/vector/VectorHandlerHip.hpp
+++ b/resolve/vector/VectorHandlerHip.hpp
@@ -67,24 +67,24 @@ namespace ReSolve
     virtual void scal(vector::Vector* diag, vector::Vector* vec);
 
     /**
-     * @brief elementwiseDivide: divides a vector's elements by another's
+     * @brief scaleInv: divides a vector's elements by another's
      *
      * @param[in] divisor vector of size n x 1
      * @param[in,out] vec vector of size n x 1 (this is where the result is stored)
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec);
+    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec);
 
     /**
-     * @brief elementwiseMax: calculate the element-wise maximum of two vectors
+     * @brief max: calculate the element-wise maximum of two vectors
      *
      * @param[in]     x vector of size n x 1
      * @param[in,out] y vector of size n x 1 (this is where the result is stored)
      *
      * @return 0 if successful, 1 otherwise
      */
-    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y);
+    virtual int max(vector::Vector* x, vector::Vector* y);
 
     /**
      * @brief abs: calculate the element-wise absolute value of a vector

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -45,6 +45,9 @@ namespace ReSolve
     // Scale a vector by a diagonal matrix
     virtual void scal(vector::Vector* diag, vector::Vector* vec) = 0;
 
+    // Divide the elements of a vector by the elements of another vector
+    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec) = 0;
+
     /** gemv:
      * if `transpose = N` (no), `x = beta*x +  alpha*V*y`,
      * where `x` is `[n x 1]`, `V` is `[n x k]` and `y` is `[k x 1]`.

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -49,10 +49,10 @@ namespace ReSolve
     virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec) = 0;
 
     // Compute element-wise max of two vectors
-    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out) = 0;
+    virtual int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out) = 0;
 
     // Compute element-wise absolute value of a vector
-    virtual int abs(const vector::Vector* in, vector::Vector* out) = 0;
+    virtual int abs(/* const */ vector::Vector* in, vector::Vector* out) = 0;
 
     /** gemv:
      * if `transpose = N` (no), `x = beta*x +  alpha*V*y`,

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -52,7 +52,7 @@ namespace ReSolve
     virtual int max(vector::Vector* x, vector::Vector* y) = 0;
 
     // Compute element-wise absolute value of a vector
-    virtual int abs(vector::Vector* x) = 0;
+    virtual int abs(const vector::Vector* in, vector::Vector* out) = 0;
 
     /** gemv:
      * if `transpose = N` (no), `x = beta*x +  alpha*V*y`,

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -46,7 +46,7 @@ namespace ReSolve
     virtual void scal(vector::Vector* diag, vector::Vector* vec) = 0;
 
     // Divide the elements of a vector by the elements of another vector
-    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec) = 0;
+    virtual int diagSolve(vector::Vector* diag, vector::Vector* vec) = 0;
 
     // Compute element-wise max of two vectors
     virtual int max(/* const */ vector::Vector* x, /* const */ vector::Vector* y, vector::Vector* out) = 0;

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -46,10 +46,10 @@ namespace ReSolve
     virtual void scal(vector::Vector* diag, vector::Vector* vec) = 0;
 
     // Divide the elements of a vector by the elements of another vector
-    virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec) = 0;
+    virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec) = 0;
 
     // Compute element-wise max of two vectors
-    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y) = 0;
+    virtual int max(vector::Vector* x, vector::Vector* y) = 0;
 
     // Compute element-wise absolute value of a vector
     virtual int abs(vector::Vector* x) = 0;

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -48,6 +48,12 @@ namespace ReSolve
     // Divide the elements of a vector by the elements of another vector
     virtual int elementwiseDivide(vector::Vector* divisor, vector::Vector* vec) = 0;
 
+    // Compute element-wise max of two vectors
+    virtual int elementwiseMax(vector::Vector* x, vector::Vector* y) = 0;
+
+    // Compute element-wise absolute value of a vector
+    virtual int abs(vector::Vector* x) = 0;
+
     /** gemv:
      * if `transpose = N` (no), `x = beta*x +  alpha*V*y`,
      * where `x` is `[n x 1]`, `V` is `[n x k]` and `y` is `[k x 1]`.

--- a/resolve/vector/VectorHandlerImpl.hpp
+++ b/resolve/vector/VectorHandlerImpl.hpp
@@ -49,7 +49,7 @@ namespace ReSolve
     virtual int scaleInv(vector::Vector* divisor, vector::Vector* vec) = 0;
 
     // Compute element-wise max of two vectors
-    virtual int max(vector::Vector* x, vector::Vector* y) = 0;
+    virtual int max(const vector::Vector* x, const vector::Vector* y, vector::Vector* out) = 0;
 
     // Compute element-wise absolute value of a vector
     virtual int abs(const vector::Vector* in, vector::Vector* out) = 0;

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -299,7 +299,7 @@ namespace ReSolve
         {
           divisor_data[i] = (real_type) (i + 1);
         }
-        divisor.copyDataFrom(divisor_data.get(), memory::HOST, memspace_);
+        divisor.copyFromExternal(divisor_data.get(), memory::HOST, memspace_);
 
         handler_.elementwiseDivide(&divisor, &vec, memspace_);
 
@@ -347,8 +347,8 @@ namespace ReSolve
             y_data[i] = (real_type) (i + 1);
           }
         }
-        x.copyDataFrom(x_data.get(), memory::HOST, memspace_);
-        y.copyDataFrom(y_data.get(), memory::HOST, memspace_);
+        x.copyFromExternal(x_data.get(), memory::HOST, memspace_);
+        y.copyFromExternal(y_data.get(), memory::HOST, memspace_);
 
         handler_.elementwiseMax(&x, &y, memspace_);
 
@@ -391,7 +391,7 @@ namespace ReSolve
             x_data[i] = (real_type) i;
           }
         }
-        x.copyDataFrom(x_data.get(), memory::HOST, memspace_);
+        x.copyFromExternal(x_data.get(), memory::HOST, memspace_);
 
         handler_.abs(&x, memspace_);
 

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -280,28 +280,28 @@ namespace ReSolve
         return status.report(__func__);
       }
 
-      TestOutcome scaleInv(index_type N)
+      TestOutcome diagSolve(index_type N)
       {
         TestStatus status;
 
-        vector::Vector divisor(N);
+        vector::Vector diag(N);
         vector::Vector vec(N);
 
-        // divisor[i] = i + 1, vec[i] = 3.0
+        // diag[i] = i + 1, vec[i] = 3.0
         // expected result vec[i] = 3.0 / (i + 1)
-        divisor.allocate(memspace_);
+        diag.allocate(memspace_);
         vec.allocate(memspace_);
 
         vec.setToConst(3.0, memspace_);
 
-        auto divisor_data = std::unique_ptr<real_type[]>(new real_type[N]);
+        auto diag_data = std::unique_ptr<real_type[]>(new real_type[N]);
         for (size_t i = 0; i < static_cast<size_t>(N); ++i)
         {
-          divisor_data[i] = (real_type) (i + 1);
+          diag_data[i] = (real_type) (i + 1);
         }
-        divisor.copyFromExternal(divisor_data.get(), memory::HOST, memspace_);
+        diag.copyFromExternal(diag_data.get(), memory::HOST, memspace_);
 
-        handler_.scaleInv(&divisor, &vec, memspace_);
+        handler_.diagSolve(&diag, &vec, memspace_);
 
         if (memspace_ == memory::DEVICE)
         {

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -280,7 +280,7 @@ namespace ReSolve
         return status.report(__func__);
       }
 
-      TestOutcome elementwiseDivide(index_type N)
+      TestOutcome scaleInv(index_type N)
       {
         TestStatus status;
 
@@ -301,7 +301,7 @@ namespace ReSolve
         }
         divisor.copyFromExternal(divisor_data.get(), memory::HOST, memspace_);
 
-        handler_.elementwiseDivide(&divisor, &vec, memspace_);
+        handler_.scaleInv(&divisor, &vec, memspace_);
 
         if (memspace_ == memory::DEVICE)
         {
@@ -322,7 +322,7 @@ namespace ReSolve
         return status.report(__func__);
       }
 
-      TestOutcome elementwiseMax(index_type N)
+      TestOutcome max(index_type N)
       {
         TestStatus status;
 
@@ -350,7 +350,7 @@ namespace ReSolve
         x.copyFromExternal(x_data.get(), memory::HOST, memspace_);
         y.copyFromExternal(y_data.get(), memory::HOST, memspace_);
 
-        handler_.elementwiseMax(&x, &y, memspace_);
+        handler_.max(&x, &y, memspace_);
 
         if (memspace_ == memory::DEVICE)
         {

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -287,8 +287,8 @@ namespace ReSolve
         vector::Vector divisor(N);
         vector::Vector vec(N);
 
-        // divisor[i] = i, vec[i] = 3.0
-        // expected result vec[i] = i * 3.0
+        // divisor[i] = i + 1, vec[i] = 3.0
+        // expected result vec[i] = 3.0 / (i + 1)
         divisor.allocate(memspace_);
         vec.allocate(memspace_);
 
@@ -314,6 +314,98 @@ namespace ReSolve
           {
             std::cout << "Solution vector element vec[" << i << "] = " << vec.getData(memory::HOST)[i]
                       << ", expected: " << (real_type) 3.0 / (i + 1) << "\n";
+            status *= false;
+            break;
+          }
+        }
+
+        return status.report(__func__);
+      }
+
+      TestOutcome elementwiseMax(index_type N)
+      {
+        TestStatus status;
+
+        vector::Vector x(N);
+        vector::Vector y(N);
+
+        x.allocate(memspace_);
+        y.allocate(memspace_);
+
+        auto x_data = std::unique_ptr<real_type[]>(new real_type[N]);
+        auto y_data = std::unique_ptr<real_type[]>(new real_type[N]);
+        for (size_t i = 0; i < static_cast<size_t>(N); ++i)
+        {
+          if (i % 3 == 0)
+          {
+            x_data[i] = (real_type) (i + 1);
+            y_data[i] = (real_type) i * .5;
+          }
+          else
+          {
+            x_data[i] = -(real_type) (i + 1);
+            y_data[i] = (real_type) (i + 1);
+          }
+        }
+        x.copyDataFrom(x_data.get(), memory::HOST, memspace_);
+        y.copyDataFrom(y_data.get(), memory::HOST, memspace_);
+
+        handler_.elementwiseMax(&x, &y, memspace_);
+
+        if (memspace_ == memory::DEVICE)
+        {
+          y.syncData(memory::HOST);
+        }
+
+        for (index_type i = 0; i < N; ++i)
+        {
+          if (!isEqual(y.getData(memory::HOST)[i], (real_type) (i + 1)))
+          {
+            std::cout << "Solution vector element y[" << i << "] = " << y.getData(memory::HOST)[i]
+                      << ", expected: " << (real_type) (i + 1) << "\n";
+            status *= false;
+            break;
+          }
+        }
+
+        return status.report(__func__);
+      }
+
+      TestOutcome abs(index_type N)
+      {
+        TestStatus status;
+
+        vector::Vector x(N);
+
+        x.allocate(memspace_);
+
+        auto x_data = std::unique_ptr<real_type[]>(new real_type[N]);
+        for (size_t i = 0; i < static_cast<size_t>(N); ++i)
+        {
+          if (i % 3 == 0)
+          {
+            x_data[i] = -(real_type) i;
+          }
+          else
+          {
+            x_data[i] = (real_type) i;
+          }
+        }
+        x.copyDataFrom(x_data.get(), memory::HOST, memspace_);
+
+        handler_.abs(&x, memspace_);
+
+        if (memspace_ == memory::DEVICE)
+        {
+          x.syncData(memory::HOST);
+        }
+
+        for (index_type i = 0; i < N; ++i)
+        {
+          if (!isEqual(x.getData(memory::HOST)[i], (real_type) i))
+          {
+            std::cout << "Solution vector element y[" << i << "] = " << x.getData(memory::HOST)[i]
+                      << ", expected: " << (real_type) i << "\n";
             status *= false;
             break;
           }

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -280,6 +280,48 @@ namespace ReSolve
         return status.report(__func__);
       }
 
+      TestOutcome elementwiseDivide(index_type N)
+      {
+        TestStatus status;
+
+        vector::Vector divisor(N);
+        vector::Vector vec(N);
+
+        // divisor[i] = i, vec[i] = 3.0
+        // expected result vec[i] = i * 3.0
+        divisor.allocate(memspace_);
+        vec.allocate(memspace_);
+
+        vec.setToConst(3.0, memspace_);
+
+        auto divisor_data = std::unique_ptr<real_type[]>(new real_type[N]);
+        for (size_t i = 0; i < static_cast<size_t>(N); ++i)
+        {
+          divisor_data[i] = (real_type) (i + 1);
+        }
+        divisor.copyDataFrom(divisor_data.get(), memory::HOST, memspace_);
+
+        handler_.elementwiseDivide(&divisor, &vec, memspace_);
+
+        if (memspace_ == memory::DEVICE)
+        {
+          vec.syncData(memory::HOST);
+        }
+
+        for (index_type i = 0; i < N; ++i)
+        {
+          if (!isEqual(vec.getData(memory::HOST)[i], (real_type) 3.0 / (i + 1)))
+          {
+            std::cout << "Solution vector element vec[" << i << "] = " << vec.getData(memory::HOST)[i]
+                      << ", expected: " << (real_type) 3.0 / (i + 1) << "\n";
+            status *= false;
+            break;
+          }
+        }
+
+        return status.report(__func__);
+      }
+
     private:
       ReSolve::VectorHandler&      handler_;
       ReSolve::memory::MemorySpace memspace_{memory::HOST};

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -341,7 +341,7 @@ namespace ReSolve
           if (i % 3 == 0)
           {
             x_data[i] = (real_type) (i + 1);
-            y_data[i] = (real_type) i * .5;
+            y_data[i] = (real_type) i * 0.5;
           }
           else
           {

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -376,8 +376,10 @@ namespace ReSolve
         TestStatus status;
 
         vector::Vector x(N);
+        vector::Vector y(N);
 
         x.allocate(memspace_);
+        y.allocate(memspace_);
 
         auto x_data = std::unique_ptr<real_type[]>(new real_type[N]);
         for (size_t i = 0; i < static_cast<size_t>(N); ++i)
@@ -393,18 +395,28 @@ namespace ReSolve
         }
         x.copyFromExternal(x_data.get(), memory::HOST, memspace_);
 
-        handler_.abs(&x, memspace_);
+        handler_.abs(&x, &y, memspace_);
+        handler_.abs(&x, &x, memspace_);
 
         if (memspace_ == memory::DEVICE)
         {
           x.syncData(memory::HOST);
+          y.syncData(memory::HOST);
         }
 
         for (index_type i = 0; i < N; ++i)
         {
           if (!isEqual(x.getData(memory::HOST)[i], (real_type) i))
           {
-            std::cout << "Solution vector element y[" << i << "] = " << x.getData(memory::HOST)[i]
+            std::cout << "Solution vector element x[" << i << "] = " << x.getData(memory::HOST)[i]
+                      << ", expected: " << (real_type) i << "\n";
+            status *= false;
+            break;
+          }
+
+          if (!isEqual(y.getData(memory::HOST)[i], (real_type) i))
+          {
+            std::cout << "Solution vector element y[" << i << "] = " << y.getData(memory::HOST)[i]
                       << ", expected: " << (real_type) i << "\n";
             status *= false;
             break;

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -328,9 +328,11 @@ namespace ReSolve
 
         vector::Vector x(N);
         vector::Vector y(N);
+        vector::Vector z(N);
 
         x.allocate(memspace_);
         y.allocate(memspace_);
+        z.allocate(memspace_);
 
         auto x_data = std::unique_ptr<real_type[]>(new real_type[N]);
         auto y_data = std::unique_ptr<real_type[]>(new real_type[N]);
@@ -350,7 +352,8 @@ namespace ReSolve
         x.copyFromExternal(x_data.get(), memory::HOST, memspace_);
         y.copyFromExternal(y_data.get(), memory::HOST, memspace_);
 
-        handler_.max(&x, &y, memspace_);
+        handler_.max(&x, &y, &z, memspace_);
+        handler_.max(&x, &y, &y, memspace_);
 
         if (memspace_ == memory::DEVICE)
         {
@@ -362,6 +365,14 @@ namespace ReSolve
           if (!isEqual(y.getData(memory::HOST)[i], (real_type) (i + 1)))
           {
             std::cout << "Solution vector element y[" << i << "] = " << y.getData(memory::HOST)[i]
+                      << ", expected: " << (real_type) (i + 1) << "\n";
+            status *= false;
+            break;
+          }
+
+          if (!isEqual(z.getData(memory::HOST)[i], (real_type) (i + 1)))
+          {
+            std::cout << "Solution vector element z[" << i << "] = " << z.getData(memory::HOST)[i]
                       << ", expected: " << (real_type) (i + 1) << "\n";
             status *= false;
             break;

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -25,7 +25,7 @@ int main(int, char**)
     result += test.axpyMulti(100, 10);
     result += test.massDot(100, 10);
     result += test.scale(100);
-    result += test.scaleInv(100);
+    result += test.diagSolve(100);
     result += test.max(100);
     result += test.abs(100);
 
@@ -51,7 +51,7 @@ int main(int, char**)
     result += test.massDot(1000, 30);
     result += test.amax(1000);
     result += test.scale(1000);
-    result += test.scaleInv(1000);
+    result += test.diagSolve(1000);
     result += test.max(1000);
     result += test.abs(1000);
 
@@ -78,7 +78,7 @@ int main(int, char**)
     result += test.massDot(1000, 30);
     result += test.amax(1000);
     result += test.scale(1000);
-    result += test.scaleInv(1000);
+    result += test.diagSolve(1000);
     result += test.max(1000);
     result += test.abs(1000);
 

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -25,6 +25,7 @@ int main(int, char**)
     result += test.axpyMulti(100, 10);
     result += test.massDot(100, 10);
     result += test.scale(100);
+    result += test.elementwiseDivide(100);
 
     std::cout << "\n";
   }

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -25,8 +25,8 @@ int main(int, char**)
     result += test.axpyMulti(100, 10);
     result += test.massDot(100, 10);
     result += test.scale(100);
-    result += test.elementwiseDivide(100);
-    result += test.elementwiseMax(100);
+    result += test.scaleInv(100);
+    result += test.max(100);
     result += test.abs(100);
 
     std::cout << "\n";
@@ -51,8 +51,8 @@ int main(int, char**)
     result += test.massDot(1000, 30);
     result += test.amax(1000);
     result += test.scale(1000);
-    result += test.elementwiseDivide(1000);
-    result += test.elementwiseMax(1000);
+    result += test.scaleInv(1000);
+    result += test.max(1000);
     result += test.abs(1000);
 
     std::cout << "\n";
@@ -78,8 +78,8 @@ int main(int, char**)
     result += test.massDot(1000, 30);
     result += test.amax(1000);
     result += test.scale(1000);
-    result += test.elementwiseDivide(1000);
-    result += test.elementwiseMax(1000);
+    result += test.scaleInv(1000);
+    result += test.max(1000);
     result += test.abs(1000);
 
     std::cout << "\n";

--- a/tests/unit/vector/runVectorHandlerTests.cpp
+++ b/tests/unit/vector/runVectorHandlerTests.cpp
@@ -26,6 +26,8 @@ int main(int, char**)
     result += test.massDot(100, 10);
     result += test.scale(100);
     result += test.elementwiseDivide(100);
+    result += test.elementwiseMax(100);
+    result += test.abs(100);
 
     std::cout << "\n";
   }
@@ -49,6 +51,9 @@ int main(int, char**)
     result += test.massDot(1000, 30);
     result += test.amax(1000);
     result += test.scale(1000);
+    result += test.elementwiseDivide(1000);
+    result += test.elementwiseMax(1000);
+    result += test.abs(1000);
 
     std::cout << "\n";
   }
@@ -73,6 +78,9 @@ int main(int, char**)
     result += test.massDot(1000, 30);
     result += test.amax(1000);
     result += test.scale(1000);
+    result += test.elementwiseDivide(1000);
+    result += test.elementwiseMax(1000);
+    result += test.abs(1000);
 
     std::cout << "\n";
   }


### PR DESCRIPTION
## Description
 
Add a new vector operations:
- `scaleInv` which performs like `scale`, but scales by the inverse of a diagonal matrix.
- `max` which computes a vector whose elements are the maximum of the corresponding elements in the two input vectors.
- `abs` which computes a vector whose elements are the absolute values of the corresponding element in the input vector.
 
Supplants #409 and is based on top of #411

 ## Proposed changes
 
N/A
 
 ## Checklist

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run:
`./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
N/A