### PR TITLE
Make Vector::copyDataTo able to copy from device to host and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Added `cons` counterparts to `Vector::getData` methods.
 
+- Made Vector::copyDataTo able to copy from device to host and vice versa
+
 ## Changes to Re::Solve in release 0.99.2
 
 ### Major Features

--- a/examples/ExampleHelper.hpp
+++ b/examples/ExampleHelper.hpp
@@ -140,7 +140,7 @@ namespace ReSolve
           }
         }
 
-        res_->copyDataFrom(r_, memspace_, memspace_);
+        res_->copyFromExternal(r_, memspace_, memspace_);
         real_type norm  = computeResidualNorm(*A_, *x_, *res_, memspace_);
         real_type rnorm = norm2(*r_, memspace_);
 
@@ -220,7 +220,7 @@ namespace ReSolve
         int error_sum = 0;
 
         // Compute residual norm to get updated vector res_
-        res_->copyDataFrom(r_, memspace_, memspace_);
+        res_->copyFromExternal(r_, memspace_, memspace_);
         norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
         // Compute norm of scaled residuals
@@ -261,7 +261,7 @@ namespace ReSolve
         int error_sum = 0;
 
         // Compute residual norm
-        res_->copyDataFrom(r_, memspace_, memspace_);
+        res_->copyFromExternal(r_, memspace_, memspace_);
         norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
         real_type error = std::abs(norm_rhs_ * rrn_system - norm_res_) / norm_res_;
@@ -292,7 +292,7 @@ namespace ReSolve
         int error_sum = 0;
 
         // Compute residual norm
-        res_->copyDataFrom(r_, memspace_, memspace_);
+        res_->copyFromExternal(r_, memspace_, memspace_);
         norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
         real_type error = std::abs(rn_system - norm_res_) / norm_res_;
@@ -312,7 +312,7 @@ namespace ReSolve
       void computeNorms()
       {
         // Compute rhs and residual norms
-        res_->copyDataFrom(r_, memspace_, memspace_);
+        res_->copyFromExternal(r_, memspace_, memspace_);
         norm_rhs_ = norm2(*r_, memspace_);
         norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 

--- a/examples/experimental/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/experimental/r_KLU_GLU_matrix_values_update.cpp
@@ -133,11 +133,11 @@ int main(int argc, char* argv[])
     // Update host and device data.
     if (i < 1)
     {
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     }
     else
     {
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -173,7 +173,7 @@ int main(int argc, char* argv[])
       status = GLU->solve(vec_rhs, vec_x);
       std::cout << "CUSOLVER GLU solve status: " << status << std::endl;
     }
-    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);

--- a/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
@@ -129,11 +129,11 @@ int main(int argc, char* argv[])
     // Update host and device data.
     if (i < 2)
     {
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     }
     else
     {
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
     }
 
     // Make sure vec_r is properly initialized before using it.
-    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 
@@ -211,8 +211,8 @@ int main(int argc, char* argv[])
       status = KLU->solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
 
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 

--- a/examples/experimental/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/experimental/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -126,14 +126,14 @@ int main(int argc, char* argv[])
     // Update host and device data.
     if (i < 2)
     {
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
       vec_rhs->setDataUpdated(ReSolve::memory::HOST);
     }
     else
     {
       A->setUpdated(ReSolve::memory::HOST);
       A->syncData(ReSolve::memory::DEVICE);
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -150,7 +150,7 @@ int main(int argc, char* argv[])
       std::cout << "KLU factorization status: " << status << std::endl;
       status = KLU->solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
-      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
       matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
         status = Rf->refactorize();
         std::cout << "CUSOLVER RF, using REAL refactorization, refactorization status: "
                   << status << std::endl;
-        vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+        vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         status = Rf->solve(vec_rhs, vec_x);
         ReSolve::PreconditionerLU precond_lu(Rf);
         FGMRES->setPreconditioner(&precond_lu);
@@ -196,8 +196,8 @@ int main(int argc, char* argv[])
                 << sqrt(norm_x) << "\n";
       std::cout << "CUSOLVER RF solve status: " << status << std::endl;
 
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-      vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
 
@@ -213,7 +213,7 @@ int main(int argc, char* argv[])
                 << std::scientific << std::setprecision(16)
                 << norm_b << "\n";
 
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       FGMRES->solve(vec_rhs, vec_x);
 
       std::cout << "FGMRES: init nrm: "

--- a/examples/experimental/r_KLU_rocsolverrf_asym6x6.cpp
+++ b/examples/experimental/r_KLU_rocsolverrf_asym6x6.cpp
@@ -96,7 +96,7 @@ int main()
   // Create CSR matrix
   ReSolve::matrix::Csr* A = new ReSolve::matrix::Csr(n, n, nnz, false, false);
   A->allocateMatrixData(ReSolve::memory::HOST);
-  A->copyDataFrom(csr_row_ptr.data(), csr_col_ind.data(), csr_values.data(), ReSolve::memory::HOST, ReSolve::memory::HOST);
+  A->copyFromExternal(csr_row_ptr.data(), csr_col_ind.data(), csr_values.data(), ReSolve::memory::HOST, ReSolve::memory::HOST);
   A->allocateMatrixData(ReSolve::memory::DEVICE);
   A->syncData(ReSolve::memory::DEVICE);
 
@@ -121,7 +121,7 @@ int main()
       0.04939382906591484,
       -1.0,
       0.1118034015563139};
-  vec_rhs->copyDataFrom(rhs_data.data(), ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyFromExternal(rhs_data.data(), ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->syncData(ReSolve::memory::DEVICE);
 
   std::cout << "Right-hand side vector set\n";

--- a/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -118,11 +118,11 @@ int main(int argc, char* argv[])
     // Update host and device data.
     if (i < 2)
     {
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
     }
     else
     {
-      vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     }
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
         ReSolve::matrix::Csr* U = (ReSolve::matrix::Csr*) KLU->getUFactor();
         index_type*           P = KLU->getPOrdering();
         index_type*           Q = KLU->getQOrdering();
-        vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+        vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         Rf->setup(A, L, U, P, Q, vec_rhs);
         Rf->refactorize();
       }
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
     }
 
     // Check accuracy of the solution
-    vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+    vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
     res_nrm = sqrt(vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE));
@@ -181,8 +181,8 @@ int main(int argc, char* argv[])
         status = KLU->solve(vec_rhs, vec_x);
         std::cout << "KLU solve status: " << status << std::endl;
 
-        vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-        vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+        vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+        vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
         matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
 

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -259,7 +259,7 @@ namespace ReSolve
         H[idxmap(i, j, num_vecs_ + 1)] -= s;
       } // for j
       vec_Hcolumn_->resize(i + 1);
-      vec_Hcolumn_->copyDataFrom(&H[idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
+      vec_Hcolumn_->copyFromExternal(&H[idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
       vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V, vec_w_, memspace_);
 
       // normalize (second synch)
@@ -349,7 +349,7 @@ namespace ReSolve
       }
 
       vec_Hcolumn_->resize(i + 1);
-      vec_Hcolumn_->copyDataFrom(&H[idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
+      vec_Hcolumn_->copyFromExternal(&H[idxmap(i, 0, num_vecs_ + 1)], memory::HOST, memspace_);
 
       vector_handler_->massAxpy(n, vec_Hcolumn_, i + 1, V, vec_w_, memspace_);
       // normalize (second synch)

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -187,7 +187,7 @@ namespace ReSolve
       // copy H_col to aux, we will need it later
       vec_Hcolumn_->setDataUpdated(memspace_);
       vec_Hcolumn_->resize(i + 1);
-      vec_Hcolumn_->copyDataTo(h_aux_, 0, memory::HOST);
+      vec_Hcolumn_->copyToExternal(h_aux_, 0, memory::HOST);
       mem_.deviceSynchronize();
 
       // Hcol = V(:,1:i)^T*V(:,i+1);
@@ -200,7 +200,7 @@ namespace ReSolve
 
       // copy H_col to H
       vec_Hcolumn_->setDataUpdated(memspace_);
-      vec_Hcolumn_->copyDataTo(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
       mem_.deviceSynchronize();
 
       // add both pieces together (unstable otherwise, careful here!!)
@@ -240,7 +240,7 @@ namespace ReSolve
         vec_rv_->syncData(memory::HOST);
       }
 
-      vec_rv_->copyDataTo(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_rv_->copyToExternal(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
       h_rv = vec_rv_->getData(1, memory::HOST);
 
       for (int j = 0; j <= i; ++j)
@@ -297,7 +297,7 @@ namespace ReSolve
         vec_rv_->syncData(memory::HOST);
       }
 
-      vec_rv_->copyDataTo(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_rv_->copyToExternal(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
       h_rv = vec_rv_->getData(1, memory::HOST);
 
       for (int j = 0; j <= i; ++j)
@@ -381,7 +381,7 @@ namespace ReSolve
       // copy H_col to H
       vec_Hcolumn_->setDataUpdated(memspace_);
       vec_Hcolumn_->resize(i + 1);
-      vec_Hcolumn_->copyDataTo(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
       mem_.deviceSynchronize();
 
       t = vector_handler_->dot(vec_v_, vec_v_, memspace_);

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -187,7 +187,7 @@ namespace ReSolve
       // copy H_col to aux, we will need it later
       vec_Hcolumn_->setDataUpdated(memspace_);
       vec_Hcolumn_->resize(i + 1);
-      vec_Hcolumn_->copyToExternal(h_aux_, 0, memory::HOST);
+      vec_Hcolumn_->copyToExternal(h_aux_, 0, memory::HOST, memory::HOST);
       mem_.deviceSynchronize();
 
       // Hcol = V(:,1:i)^T*V(:,i+1);
@@ -200,7 +200,7 @@ namespace ReSolve
 
       // copy H_col to H
       vec_Hcolumn_->setDataUpdated(memspace_);
-      vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
       mem_.deviceSynchronize();
 
       // add both pieces together (unstable otherwise, careful here!!)
@@ -240,7 +240,7 @@ namespace ReSolve
         vec_rv_->syncData(memory::HOST);
       }
 
-      vec_rv_->copyToExternal(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_rv_->copyToExternal(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
       h_rv = vec_rv_->getData(1, memory::HOST);
 
       for (int j = 0; j <= i; ++j)
@@ -297,7 +297,7 @@ namespace ReSolve
         vec_rv_->syncData(memory::HOST);
       }
 
-      vec_rv_->copyToExternal(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_rv_->copyToExternal(&h_L_[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
       h_rv = vec_rv_->getData(1, memory::HOST);
 
       for (int j = 0; j <= i; ++j)
@@ -381,7 +381,7 @@ namespace ReSolve
       // copy H_col to H
       vec_Hcolumn_->setDataUpdated(memspace_);
       vec_Hcolumn_->resize(i + 1);
-      vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST);
+      vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
       mem_.deviceSynchronize();
 
       t = vector_handler_->dot(vec_v_, vec_v_, memspace_);

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -237,7 +237,7 @@ namespace ReSolve
    */
   int LinSolverDirectCuSolverRf::solve(vector_type* rhs, vector_type* x)
   {
-    x->copyDataFrom(rhs->getData(memory::DEVICE), memory::DEVICE, memory::DEVICE);
+    x->copyFromExternal(rhs->getData(memory::DEVICE), memory::DEVICE, memory::DEVICE);
     x->setDataUpdated(memory::DEVICE);
     status_cusolverrf_ = cusolverRfSolve(handle_cusolverrf_,
                                          d_P_,

--- a/resolve/LinSolverDirectKLU.cpp
+++ b/resolve/LinSolverDirectKLU.cpp
@@ -227,7 +227,7 @@ namespace ReSolve
   int LinSolverDirectKLU::solve(vector_type* rhs, vector_type* x)
   {
     // copy the vector
-    x->copyDataFrom(rhs->getData(memory::HOST), memory::HOST, memory::HOST);
+    x->copyFromExternal(rhs->getData(memory::HOST), memory::HOST, memory::HOST);
     x->setDataUpdated(memory::HOST);
     int kluStatus = 1;
     // check sparsity format of A

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include "LinSolverDirectRocSolverRf.hpp"
 
 #include <resolve/hip/hipKernels.h>

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -185,7 +185,7 @@ namespace ReSolve
   int LinSolverDirectRocSolverRf::solve(vector_type* rhs, vector_type* x)
   {
     RESOLVE_RANGE_PUSH(__FUNCTION__);
-    x->copyDataFrom(rhs->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::DEVICE);
+    x->copyFromExternal(rhs->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::DEVICE);
     x->setDataUpdated(ReSolve::memory::DEVICE);
     int error_sum = 0;
     mem_.deviceSynchronize();

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -1,5 +1,6 @@
-#include <cassert>
 #include "LinSolverDirectRocSolverRf.hpp"
+
+#include <cassert>
 
 #include <resolve/hip/hipKernels.h>
 

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -128,7 +128,7 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
+    rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_, memspace_);
     matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
@@ -300,7 +300,7 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
+      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_, memspace_);
       matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
       rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
       // rnorm = ||V_1||

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -128,7 +128,7 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+    rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
     matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
@@ -300,7 +300,7 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
       matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
       rnorm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
       // rnorm = ||V_1||

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -159,7 +159,7 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
+    rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_, memspace_);
     matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
 
     vec_v.setData(vec_V_->getData(0, memspace_), memspace_);
@@ -366,7 +366,7 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
+      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_, memspace_);
       matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
       if (outer_flag)
       {

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -159,7 +159,7 @@ namespace ReSolve
     vec_Z_->setToZero(memspace_);
     vec_V_->setToZero(memspace_);
 
-    rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+    rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
     matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
 
     vec_v.setData(vec_V_->getData(0, memspace_), memspace_);
@@ -366,7 +366,7 @@ namespace ReSolve
         outer_flag = 0;
       }
 
-      rhs->copyDataTo(vec_V_->getData(memspace_), 0, memspace_);
+      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_);
       matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
       if (outer_flag)
       {

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -266,7 +266,7 @@ namespace ReSolve
 
         // now post-process
         vec_aux_->resize(i + 1);
-        vec_aux_->copyDataFrom(&h_H_[i * (restart_ + 1)], memory::HOST, memspace_);
+        vec_aux_->copyFromExternal(&h_H_[i * (restart_ + 1)], memory::HOST, memspace_);
 
         // V(:, i+1) = w - V(:, 1:i)*d_H_col = V(:, i+1) - d_H_col*V(:,1:i);
         vector_handler_->gemv('N', n_, i + 1, &MINUS_ONE, &ONE, vec_V_, vec_aux_, &vec_v, memspace_);

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -812,7 +812,7 @@ namespace ReSolve
     memory::MemorySpace ms      = memory::HOST;
     if (memspace_ == "cpu")
     {
-      resVector_->copyDataFrom(rhs, memory::HOST, memory::HOST);
+      resVector_->copyFromExternal(rhs, memory::HOST, memory::HOST);
       norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::HOST));
 #if defined(RESOLVE_USE_HIP) || defined(RESOLVE_USE_CUDA)
     }
@@ -820,12 +820,12 @@ namespace ReSolve
     {
       if (is_solve_on_device_)
       {
-        resVector_->copyDataFrom(rhs, memory::DEVICE, memory::DEVICE);
+        resVector_->copyFromExternal(rhs, memory::DEVICE, memory::DEVICE);
         norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::DEVICE));
       }
       else
       {
-        resVector_->copyDataFrom(rhs, memory::HOST, memory::DEVICE);
+        resVector_->copyFromExternal(rhs, memory::HOST, memory::DEVICE);
         norm_b = std::sqrt(vectorHandler_->dot(resVector_, resVector_, memory::HOST));
         // ms = memory::HOST;
       }
@@ -853,18 +853,18 @@ namespace ReSolve
     memory::MemorySpace ms      = memory::HOST;
     if (memspace_ == "cpu")
     {
-      resVector_->copyDataFrom(rhs, memory::HOST, memory::HOST);
+      resVector_->copyFromExternal(rhs, memory::HOST, memory::HOST);
 #if defined(RESOLVE_USE_HIP) || defined(RESOLVE_USE_CUDA)
     }
     else if (memspace_ == "cuda" || memspace_ == "hip")
     {
       if (is_solve_on_device_)
       {
-        resVector_->copyDataFrom(rhs, memory::DEVICE, memory::DEVICE);
+        resVector_->copyFromExternal(rhs, memory::DEVICE, memory::DEVICE);
       }
       else
       {
-        resVector_->copyDataFrom(rhs, memory::HOST, memory::DEVICE);
+        resVector_->copyFromExternal(rhs, memory::HOST, memory::DEVICE);
       }
       ms = memory::DEVICE;
 #endif

--- a/resolve/hykkt/cholesky/CholeskySolverCpu.cpp
+++ b/resolve/hykkt/cholesky/CholeskySolverCpu.cpp
@@ -95,7 +95,7 @@ namespace ReSolve
       {
         out::error() << "Cholesky solve failed with status: " << Common_.status << "\n";
       }
-      x->copyDataFrom(static_cast<real_type*>(x_chol->x), memory::HOST, memory::HOST);
+      x->copyFromExternal(static_cast<real_type*>(x_chol->x), memory::HOST, memory::HOST);
     }
 
     /**

--- a/resolve/hykkt/cholesky/CholeskySolverHip.cpp
+++ b/resolve/hykkt/cholesky/CholeskySolverHip.cpp
@@ -170,8 +170,8 @@ namespace ReSolve
     void CholeskySolverHip::solve(vector::Vector* x, vector::Vector* b)
     {
       x->copyFromExternal(b, memory::DEVICE, memory::DEVICE);
-      // TODO: currently, this returns status rocblas_status_invalid_pointer
-      // but we have verified that none of the inputs are null and need to be non-null
+// TODO: currently, this returns status rocblas_status_invalid_pointer
+// but we have verified that none of the inputs are null and need to be non-null.
       rocblas_status status = rocsolver_dcsrrf_solve(handle_,
                                                      L_->getNumRows(),
                                                      1,

--- a/resolve/hykkt/cholesky/CholeskySolverHip.cpp
+++ b/resolve/hykkt/cholesky/CholeskySolverHip.cpp
@@ -99,7 +99,7 @@ namespace ReSolve
         cholmod_sparse* L_chol_tr = cholmod_transpose(L_chol, 1, &Common_);
         L_                        = new matrix::Csr((index_type) L_chol->nrow, (index_type) L_chol->ncol, (index_type) L_chol->nzmax);
         L_->allocateMatrixData(memory::DEVICE);
-        L_->copyDataFrom(static_cast<index_type*>(L_chol_tr->p),
+        L_->copyFromExternal(static_cast<index_type*>(L_chol_tr->p),
                          static_cast<index_type*>(L_chol_tr->i),
                          static_cast<real_type*>(L_chol_tr->x),
                          memory::HOST,
@@ -169,7 +169,7 @@ namespace ReSolve
      */
     void CholeskySolverHip::solve(vector::Vector* x, vector::Vector* b)
     {
-      x->copyDataFrom(b, memory::DEVICE, memory::DEVICE);
+      x->copyFromExternal(b, memory::DEVICE, memory::DEVICE);
       // TODO: currently, this returns status rocblas_status_invalid_pointer
       // but we have verified that none of the inputs are null and need to be non-null
       rocblas_status status = rocsolver_dcsrrf_solve(handle_,

--- a/resolve/hykkt/cholesky/CholeskySolverHip.cpp
+++ b/resolve/hykkt/cholesky/CholeskySolverHip.cpp
@@ -170,8 +170,8 @@ namespace ReSolve
     void CholeskySolverHip::solve(vector::Vector* x, vector::Vector* b)
     {
       x->copyFromExternal(b, memory::DEVICE, memory::DEVICE);
-// TODO: currently, this returns status rocblas_status_invalid_pointer
-// but we have verified that none of the inputs are null and need to be non-null.
+      // TODO: currently, this returns status rocblas_status_invalid_pointer
+      // but we have verified that none of the inputs are null and need to be non-null.
       rocblas_status status = rocsolver_dcsrrf_solve(handle_,
                                                      L_->getNumRows(),
                                                      1,

--- a/resolve/hykkt/cholesky/CholeskySolverHip.cpp
+++ b/resolve/hykkt/cholesky/CholeskySolverHip.cpp
@@ -100,10 +100,10 @@ namespace ReSolve
         L_                        = new matrix::Csr((index_type) L_chol->nrow, (index_type) L_chol->ncol, (index_type) L_chol->nzmax);
         L_->allocateMatrixData(memory::DEVICE);
         L_->copyFromExternal(static_cast<index_type*>(L_chol_tr->p),
-                         static_cast<index_type*>(L_chol_tr->i),
-                         static_cast<real_type*>(L_chol_tr->x),
-                         memory::HOST,
-                         memory::DEVICE);
+                             static_cast<index_type*>(L_chol_tr->i),
+                             static_cast<real_type*>(L_chol_tr->x),
+                             memory::HOST,
+                             memory::DEVICE);
         // Store fill-in reducing permutation.
         // Within HyKKT, this will be the identity permutation because the Permutation class will permute the matrix.
         mem_.allocateArrayOnDevice(&Q_, A_->getNumRows());

--- a/resolve/hykkt/spgemm/SpGEMMCpu.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.cpp
@@ -95,8 +95,8 @@ namespace ReSolve
         (*E_ptr_)->destroyMatrixData(memory::HOST);
       }
 
-// Previous data must be de-allocated and new data copied.
-// Cholmod does not allow for reuse of arrays.
+      // Previous data must be de-allocated and new data copied.
+      // Cholmod does not allow for reuse of arrays.
       (*E_ptr_)->copyFromExternal(static_cast<index_type*>(E_chol->p),
                                   static_cast<index_type*>(E_chol->i),
                                   static_cast<real_type*>(E_chol->x),

--- a/resolve/hykkt/spgemm/SpGEMMCpu.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.cpp
@@ -57,8 +57,8 @@ namespace ReSolve
       {
         B_ = allocateCholmodType(B);
       }
-      copyDataToCholmodType(A, A_);
-      copyDataToCholmodType(B, B_);
+      copyDataCholmodType(A, A_);
+      copyDataCholmodType(B, B_);
     }
 
     void SpGEMMCpu::loadSumMatrix(matrix::Csr* D)
@@ -67,7 +67,7 @@ namespace ReSolve
       {
         D_ = allocateCholmodType(D);
       }
-      copyDataToCholmodType(D, D_);
+      copyDataCholmodType(D, D_);
     }
 
     void SpGEMMCpu::loadResultMatrix(matrix::Csr** E_ptr)
@@ -126,7 +126,7 @@ namespace ReSolve
      * @param A[in] - Pointer to CSR matrix
      * @param A_chol[in] - Pointer to CHOLMOD sparse matrix
      */
-    void SpGEMMCpu::copyDataToCholmodType(matrix::Csr* A, cholmod_sparse* A_chol)
+    void SpGEMMCpu::copyDataCholmodType(matrix::Csr* A, cholmod_sparse* A_chol)
     {
       mem_.copyArrayHostToHost(
           static_cast<int*>(A_chol->p), A->getRowData(memory::HOST), A->getNumRows() + 1);

--- a/resolve/hykkt/spgemm/SpGEMMCpu.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.cpp
@@ -95,8 +95,8 @@ namespace ReSolve
         (*E_ptr_)->destroyMatrixData(memory::HOST);
       }
 
-      // Previous data must be de-allocated and new data copied
-      // Cholmod does not allow for reuse of arrays
+// Previous data must be de-allocated and new data copied.
+// Cholmod does not allow for reuse of arrays.
       (*E_ptr_)->copyFromExternal(static_cast<index_type*>(E_chol->p),
                                   static_cast<index_type*>(E_chol->i),
                                   static_cast<real_type*>(E_chol->x),

--- a/resolve/hykkt/spgemm/SpGEMMCpu.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.cpp
@@ -97,7 +97,7 @@ namespace ReSolve
 
       // Previous data must be de-allocated and new data copied
       // Cholmod does not allow for reuse of arrays
-      (*E_ptr_)->copyDataFrom(static_cast<index_type*>(E_chol->p),
+      (*E_ptr_)->copyFromExternal(static_cast<index_type*>(E_chol->p),
                               static_cast<index_type*>(E_chol->i),
                               static_cast<real_type*>(E_chol->x),
                               memory::HOST,

--- a/resolve/hykkt/spgemm/SpGEMMCpu.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.cpp
@@ -98,10 +98,10 @@ namespace ReSolve
       // Previous data must be de-allocated and new data copied
       // Cholmod does not allow for reuse of arrays
       (*E_ptr_)->copyFromExternal(static_cast<index_type*>(E_chol->p),
-                              static_cast<index_type*>(E_chol->i),
-                              static_cast<real_type*>(E_chol->x),
-                              memory::HOST,
-                              memory::HOST);
+                                  static_cast<index_type*>(E_chol->i),
+                                  static_cast<real_type*>(E_chol->x),
+                                  memory::HOST,
+                                  memory::HOST);
     }
 
     /**

--- a/resolve/hykkt/spgemm/SpGEMMCpu.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.hpp
@@ -37,7 +37,7 @@ namespace ReSolve
       matrix::Csr** E_ptr_;
 
       cholmod_sparse* allocateCholmodType(matrix::Csr* X);
-      void            copyDataToCholmodType(matrix::Csr* X, cholmod_sparse* X_chol);
+      void            copyDataCholmodType(matrix::Csr* X, cholmod_sparse* X_chol);
     };
   } // namespace hykkt
 } // namespace ReSolve

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -191,7 +191,7 @@ namespace ReSolve
     }
   }
 
-  int matrix::Coo::copyDataFrom(const index_type*   row_data,
+  int matrix::Coo::copyFromExternal(const index_type*   row_data,
                                 const index_type*   col_data,
                                 const real_type*    val_data,
                                 memory::MemorySpace memspaceIn,
@@ -222,7 +222,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST)
     {
       // check if cpu data allocated
-      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) && "In Coo::copyDataFrom one of host row or column data is null!\n");
+      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) && "In Coo::copyFromExternal one of host row or column data is null!\n");
 
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr))
       {
@@ -240,7 +240,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE)
     {
       // check if cuda data allocated
-      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) && "In Coo::copyDataFrom one of device row or column data is null!\n");
+      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) && "In Coo::copyFromExternal one of device row or column data is null!\n");
 
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr))
       {
@@ -287,7 +287,7 @@ namespace ReSolve
     return 0;
   }
 
-  int matrix::Coo::copyDataFrom(const index_type*   row_data,
+  int matrix::Coo::copyFromExternal(const index_type*   row_data,
                                 const index_type*   col_data,
                                 const real_type*    val_data,
                                 index_type          new_nnz,
@@ -296,7 +296,7 @@ namespace ReSolve
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return copyDataFrom(row_data, col_data, val_data, memspaceIn, memspaceOut);
+    return copyFromExternal(row_data, col_data, val_data, memspaceIn, memspaceOut);
   }
 
   int matrix::Coo::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -192,10 +192,10 @@ namespace ReSolve
   }
 
   int matrix::Coo::copyFromExternal(const index_type*   row_data,
-                                const index_type*   col_data,
-                                const real_type*    val_data,
-                                memory::MemorySpace memspaceIn,
-                                memory::MemorySpace memspaceOut)
+                                    const index_type*   col_data,
+                                    const real_type*    val_data,
+                                    memory::MemorySpace memspaceIn,
+                                    memory::MemorySpace memspaceOut)
   {
 
     // four cases (for now)
@@ -288,11 +288,11 @@ namespace ReSolve
   }
 
   int matrix::Coo::copyFromExternal(const index_type*   row_data,
-                                const index_type*   col_data,
-                                const real_type*    val_data,
-                                index_type          new_nnz,
-                                memory::MemorySpace memspaceIn,
-                                memory::MemorySpace memspaceOut)
+                                    const index_type*   col_data,
+                                    const real_type*    val_data,
+                                    index_type          new_nnz,
+                                    memory::MemorySpace memspaceIn,
+                                    memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;

--- a/resolve/matrix/Coo.cpp
+++ b/resolve/matrix/Coo.cpp
@@ -239,7 +239,7 @@ namespace ReSolve
 
     if (memspaceOut == memory::DEVICE)
     {
-      // check if cuda data allocated
+      // Check if Cuda data is allocated.
       assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) && "In Coo::copyFromExternal one of device row or column data is null!\n");
 
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr))

--- a/resolve/matrix/Coo.hpp
+++ b/resolve/matrix/Coo.hpp
@@ -32,12 +32,12 @@ namespace ReSolve
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues(memory::MemorySpace memspace);
 
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                memory::MemorySpace memspaceIn,
                                memory::MemorySpace memspaceOut);
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                index_type          new_nnz,

--- a/resolve/matrix/Coo.hpp
+++ b/resolve/matrix/Coo.hpp
@@ -33,16 +33,16 @@ namespace ReSolve
       virtual real_type*  getValues(memory::MemorySpace memspace);
 
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut);
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut);
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               index_type          new_nnz,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut);
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   index_type          new_nnz,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -81,10 +81,10 @@ namespace ReSolve
   }
 
   int matrix::Csc::copyFromExternal(const index_type*   row_data,
-                                const index_type*   col_data,
-                                const real_type*    val_data,
-                                memory::MemorySpace memspaceIn,
-                                memory::MemorySpace memspaceOut)
+                                    const index_type*   col_data,
+                                    const real_type*    val_data,
+                                    memory::MemorySpace memspaceIn,
+                                    memory::MemorySpace memspaceOut)
   {
     index_type nnz_current = nnz_;
 
@@ -177,11 +177,11 @@ namespace ReSolve
   }
 
   int matrix::Csc::copyFromExternal(const index_type*   row_data,
-                                const index_type*   col_data,
-                                const real_type*    val_data,
-                                index_type          new_nnz,
-                                memory::MemorySpace memspaceIn,
-                                memory::MemorySpace memspaceOut)
+                                    const index_type*   col_data,
+                                    const real_type*    val_data,
+                                    index_type          new_nnz,
+                                    memory::MemorySpace memspaceIn,
+                                    memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;

--- a/resolve/matrix/Csc.cpp
+++ b/resolve/matrix/Csc.cpp
@@ -80,7 +80,7 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csc::copyDataFrom(const index_type*   row_data,
+  int matrix::Csc::copyFromExternal(const index_type*   row_data,
                                 const index_type*   col_data,
                                 const real_type*    val_data,
                                 memory::MemorySpace memspaceIn,
@@ -111,7 +111,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST)
     {
       // check if cpu data allocated
-      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) && "In Csc::copyDataFrom one of host row or column data is null!\n");
+      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) && "In Csc::copyFromExternal one of host row or column data is null!\n");
 
       if ((h_col_data_ == nullptr) && (h_row_data_ == nullptr))
       {
@@ -129,7 +129,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE)
     {
       // check if cuda data allocated
-      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) && "In Csc::copyDataFrom one of device row or column data is null!\n");
+      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) && "In Csc::copyFromExternal one of device row or column data is null!\n");
 
       if ((d_col_data_ == nullptr) && (d_row_data_ == nullptr))
       {
@@ -176,7 +176,7 @@ namespace ReSolve
     return 0;
   }
 
-  int matrix::Csc::copyDataFrom(const index_type*   row_data,
+  int matrix::Csc::copyFromExternal(const index_type*   row_data,
                                 const index_type*   col_data,
                                 const real_type*    val_data,
                                 index_type          new_nnz,
@@ -185,7 +185,7 @@ namespace ReSolve
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return copyDataFrom(col_data, row_data, val_data, memspaceIn, memspaceOut);
+    return copyFromExternal(col_data, row_data, val_data, memspaceIn, memspaceOut);
   }
 
   int matrix::Csc::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csc.hpp
+++ b/resolve/matrix/Csc.hpp
@@ -22,12 +22,12 @@ namespace ReSolve
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues(memory::MemorySpace memspace);
 
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                memory::MemorySpace memspaceIn,
                                memory::MemorySpace memspaceOut);
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                index_type          new_nnz,

--- a/resolve/matrix/Csc.hpp
+++ b/resolve/matrix/Csc.hpp
@@ -23,16 +23,16 @@ namespace ReSolve
       virtual real_type*  getValues(memory::MemorySpace memspace);
 
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut);
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut);
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               index_type          new_nnz,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut);
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   index_type          new_nnz,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -217,10 +217,10 @@ namespace ReSolve
   }
 
   int matrix::Csr::copyFromExternal(const index_type*   row_data,
-                                const index_type*   col_data,
-                                const real_type*    val_data,
-                                memory::MemorySpace memspaceIn,
-                                memory::MemorySpace memspaceOut)
+                                    const index_type*   col_data,
+                                    const real_type*    val_data,
+                                    memory::MemorySpace memspaceIn,
+                                    memory::MemorySpace memspaceOut)
   {
     // four cases (for now)
     index_type nnz_current = nnz_;
@@ -313,11 +313,11 @@ namespace ReSolve
   }
 
   int matrix::Csr::copyFromExternal(const index_type*   row_data,
-                                const index_type*   col_data,
-                                const real_type*    val_data,
-                                index_type          new_nnz,
-                                memory::MemorySpace memspaceIn,
-                                memory::MemorySpace memspaceOut)
+                                    const index_type*   col_data,
+                                    const real_type*    val_data,
+                                    index_type          new_nnz,
+                                    memory::MemorySpace memspaceIn,
+                                    memory::MemorySpace memspaceOut)
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;

--- a/resolve/matrix/Csr.cpp
+++ b/resolve/matrix/Csr.cpp
@@ -216,7 +216,7 @@ namespace ReSolve
     }
   }
 
-  int matrix::Csr::copyDataFrom(const index_type*   row_data,
+  int matrix::Csr::copyFromExternal(const index_type*   row_data,
                                 const index_type*   col_data,
                                 const real_type*    val_data,
                                 memory::MemorySpace memspaceIn,
@@ -246,7 +246,7 @@ namespace ReSolve
     if (memspaceOut == memory::HOST)
     {
       // check if cpu data allocated
-      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) && "In Csr::copyDataFrom one of host row or column data is null!\n");
+      assert(((h_row_data_ == nullptr) == (h_col_data_ == nullptr)) && "In Csr::copyFromExternal one of host row or column data is null!\n");
 
       if ((h_row_data_ == nullptr) && (h_col_data_ == nullptr))
       {
@@ -264,7 +264,7 @@ namespace ReSolve
     if (memspaceOut == memory::DEVICE)
     {
       // check if cuda data allocated
-      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) && "In Csr::copyDataFrom one of device row or column data is null!\n");
+      assert(((d_row_data_ == nullptr) == (d_col_data_ == nullptr)) && "In Csr::copyFromExternal one of device row or column data is null!\n");
 
       if ((d_row_data_ == nullptr) && (d_col_data_ == nullptr))
       {
@@ -312,7 +312,7 @@ namespace ReSolve
     return 0;
   }
 
-  int matrix::Csr::copyDataFrom(const index_type*   row_data,
+  int matrix::Csr::copyFromExternal(const index_type*   row_data,
                                 const index_type*   col_data,
                                 const real_type*    val_data,
                                 index_type          new_nnz,
@@ -321,7 +321,7 @@ namespace ReSolve
   {
     destroyMatrixData(memspaceOut);
     nnz_ = new_nnz;
-    return copyDataFrom(row_data, col_data, val_data, memspaceIn, memspaceOut);
+    return copyFromExternal(row_data, col_data, val_data, memspaceIn, memspaceOut);
   }
 
   int matrix::Csr::allocateMatrixData(memory::MemorySpace memspace)

--- a/resolve/matrix/Csr.hpp
+++ b/resolve/matrix/Csr.hpp
@@ -39,12 +39,12 @@ namespace ReSolve
       virtual index_type* getColData(memory::MemorySpace memspace);
       virtual real_type*  getValues(memory::MemorySpace memspace);
 
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                memory::MemorySpace memspaceIn,
                                memory::MemorySpace memspaceOut);
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                index_type          new_nnz,

--- a/resolve/matrix/Csr.hpp
+++ b/resolve/matrix/Csr.hpp
@@ -40,16 +40,16 @@ namespace ReSolve
       virtual real_type*  getValues(memory::MemorySpace memspace);
 
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut);
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut);
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               index_type          new_nnz,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut);
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   index_type          new_nnz,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut);
 
       virtual int allocateMatrixData(memory::MemorySpace memspace);
 

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -1,6 +1,7 @@
 #include "MatrixHandlerHip.hpp"
 
 #include <algorithm>
+#include <cassert>
 
 #include <resolve/hip/hipKernels.h>
 #include <resolve/hip/hipVectorKernels.h>

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -65,12 +65,12 @@ namespace ReSolve
       virtual index_type* getColData(memory::MemorySpace memspace) = 0;
       virtual real_type*  getValues(memory::MemorySpace memspace)  = 0;
 
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                memory::MemorySpace memspaceIn,
                                memory::MemorySpace memspaceOut) = 0;
-      virtual int copyDataFrom(const index_type*   row_data,
+      virtual int copyFromExternal(const index_type*   row_data,
                                const index_type*   col_data,
                                const real_type*    val_data,
                                index_type          new_nnz,

--- a/resolve/matrix/Sparse.hpp
+++ b/resolve/matrix/Sparse.hpp
@@ -66,16 +66,16 @@ namespace ReSolve
       virtual real_type*  getValues(memory::MemorySpace memspace)  = 0;
 
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut) = 0;
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut) = 0;
       virtual int copyFromExternal(const index_type*   row_data,
-                               const index_type*   col_data,
-                               const real_type*    val_data,
-                               index_type          new_nnz,
-                               memory::MemorySpace memspaceIn,
-                               memory::MemorySpace memspaceOut) = 0;
+                                   const index_type*   col_data,
+                                   const real_type*    val_data,
+                                   index_type          new_nnz,
+                                   memory::MemorySpace memspaceIn,
+                                   memory::MemorySpace memspaceOut) = 0;
 
       virtual int allocateMatrixData(memory::MemorySpace memspace) = 0;
       int         setDataPointers(index_type*         row_data,

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -211,10 +211,10 @@ namespace ReSolve
      *
      * @pre   size of _v_ is equal or larger than the current vector size.
      */
-    int Vector::copyDataFrom(Vector* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+    int Vector::copyFromExternal(Vector* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
     {
       real_type* source_data = source->getData(memspaceIn);
-      return copyDataFrom(source_data, memspaceIn, memspaceOut);
+      return copyFromExternal(source_data, memspaceIn, memspaceOut);
     }
 
     /**
@@ -228,7 +228,7 @@ namespace ReSolve
      *
      * @return 0 if successful, -1 otherwise.
      */
-    int Vector::copyDataFrom(const real_type* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
+    int Vector::copyFromExternal(const real_type* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut)
     {
       int control = -1;
       if ((memspaceIn == memory::HOST) && (memspaceOut == memory::HOST))
@@ -862,7 +862,7 @@ namespace ReSolve
     int Vector::copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst)
     {
       using namespace ReSolve::memory;
-      real_type* data = this->getData(i, memspaceSrc);
+      real_type* data = getData(i, memspaceSrc);
       // Check that the source data is not null and up to date
       if (data == nullptr)
       {

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -805,6 +805,84 @@ namespace ReSolve
       }
       return 0;
     }
+    /**
+     * @brief copy HOST or DEVICE data of a specified vector in a multivector to _dest_.
+     * 
+     * This function allows to copy data between different memory spaces in one call.
+     * For example, you can copy data of vector _i_ from HOST to DEVICE, or from DEVICE to HOST.
+     * 
+     * @param[out] dest      - Pointer to the memory to which data is copied
+     * @param[in] i          - Index of a vector in a multivector
+     * @param[in] memspaceInSrc   - Memory space (HOST or DEVICE) of the data to be copied
+     * @param[in] memspaceOutDst  - Memory space (HOST or DEVICE) to which data is copied
+     * 
+     * @return 0 if successful, -1 otherwise.
+     * 
+     * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in multivector.
+     * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (length of a single vector in the multivector).
+     * @pre _dest_ is allocated in memspaceOutDst memory space.
+     * @post All elements of the vector _i_ are copied to the array _dest_.
+     */
+    int Vector::copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst)
+    {
+      using namespace ReSolve::memory;
+      real_type* data = this->getData(i, memspaceSrc);
+      // Check that the source data is not null and up to date
+      if (data == nullptr)
+      {
+        out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not allocated in the source memory space!\n";
+        return -1;
+      }
+      // Check that the destination memory space is allocated
+      if (dest == nullptr)
+      {
+        out::error() << "Trying to copy data for vector " << i << " in multivector but the destination pointer is not allocated!\n";
+        return -1;
+      }
+      if (i > this->k_)
+      {
+        return -1;
+      }
+      else
+      {
+        switch (memspaceSrc)
+        {
+        case HOST:
+          if (!cpu_updated_[i])
+          {
+            out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
+            return -1;
+          }
+          switch (memspaceDst)
+          {
+          case HOST:
+            mem_.copyArrayHostToHost(dest, data, n_size_);
+            break;
+          case DEVICE:
+            mem_.copyArrayHostToDevice(dest, data, n_size_);
+            break;
+          }
+          break;
+        case DEVICE:
+          if (!gpu_updated_[i])        {
+            out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
+            return -1;
+          }
+          switch (memspaceDst)
+          {
+          case HOST:
+            mem_.copyArrayDeviceToHost(dest, data, n_size_);
+            break;
+          case DEVICE:
+            mem_.copyArrayDeviceToDevice(dest, data, n_size_);
+            break;
+          }
+          break;
+        }
+      }
+      return 0;
+    }
+
 
     //
     // Private methods

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -840,19 +840,20 @@ namespace ReSolve
         return 0;
       }
     }
+
     /**
      * @brief copy HOST or DEVICE data of a specified vector in a multivector to _dest_.
-     * 
+     *
      * This function allows to copy data between different memory spaces in one call.
      * For example, you can copy data of vector _i_ from HOST to DEVICE, or from DEVICE to HOST.
-     * 
+     *
      * @param[out] dest      - Pointer to the memory to which data is copied
      * @param[in] i          - Index of a vector in a multivector
      * @param[in] memspaceInSrc   - Memory space (HOST or DEVICE) of the data to be copied
      * @param[in] memspaceOutDst  - Memory space (HOST or DEVICE) to which data is copied
-     * 
+     *
      * @return 0 if successful, -1 otherwise.
-     * 
+     *
      * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in multivector.
      * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (length of a single vector in the multivector).
      * @pre _dest_ is allocated in memspaceOutDst memory space.
@@ -899,7 +900,8 @@ namespace ReSolve
           }
           break;
         case DEVICE:
-          if (!gpu_updated_[i])        {
+          if (!gpu_updated_[i])
+          {
             out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
             return -1;
           }
@@ -920,16 +922,16 @@ namespace ReSolve
 
     /**
      * @brief copy HOST or DEVICE data of multivector to _dest_.
-     * 
+     *
      * This function allows to copy data between different memory spaces in one call.
      * For example, you can copy data of multivector from HOST to DEVICE, or from DEVICE to HOST.
-     * 
+     *
      * @param[out] dest      - Pointer to the memory to which data is copied
      * @param[in] memspaceSrc   - Memory space (HOST or DEVICE) of the data to be copied
      * @param[in] memspaceDst  - Memory space (HOST or DEVICE) to which data is copied
-     * 
+     *
      * @return 0 if successful, -1 otherwise.
-     * 
+     *
      * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ * _k_ (total length of all vectors in the multivector).
      * @pre _dest_ is allocated in memspaceOutDst memory space.
      * @post All elements of all vectors in multivector are copied to the array _dest_.
@@ -953,7 +955,8 @@ namespace ReSolve
       switch (memspaceSrc)
       {
       case HOST:
-        if (!cpu_updated_[0])        {
+        if (!cpu_updated_[0])
+        {
           out::error() << "Trying to copy data for multivector but the data is not up to date in the source memory space!\n";
           return -1;
         }
@@ -968,7 +971,8 @@ namespace ReSolve
         }
         break;
       case DEVICE:
-        if (!gpu_updated_[0])        {
+        if (!gpu_updated_[0])
+        {
           out::error() << "Trying to copy data for multivector but the data is not up to date in the source memory space!\n";
           return -1;
         }
@@ -985,7 +989,6 @@ namespace ReSolve
       }
       return 0;
     }
-
 
     //
     // Private methods

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -735,153 +735,83 @@ namespace ReSolve
         return 0;
       }
     }
-
     /**
-     * @brief copy HOST or DEVICE data of a specified vector in a multivector
-     * to _dest_.
-     *
+     * @brief copy HOST or DEVICE data of a specified vector in a multivector to _dest_.
+     * 
+     * This function allows to copy data between different memory spaces in one call.
+     * For example, you can copy data of vector _i_ from HOST to DEVICE, or from DEVICE to HOST.
+     * 
      * @param[out] dest      - Pointer to the memory to which data is copied
      * @param[in] i          - Index of a vector in a multivector
-     * @param[in] memspace   - Memory space (HOST or DEVICE) to copy from and to
-     *
+     * @param[in] memspaceInSrc   - Memory space (HOST or DEVICE) of the data to be copied
+     * @param[in] memspaceOutDst  - Memory space (HOST or DEVICE) to which data is copied
+     * 
      * @return 0 if successful, -1 otherwise.
-     *
-     * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in
-     * multivector.
-     * @pre _dest_ is allocated, and the size of _dest_ is at least _n_
-     * (length of a single vector in the multivector).
-     * @pre _dest_ is allocated in memspaceInOut memory space.
+     * 
+     * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in multivector.
+     * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (length of a single vector in the multivector).
+     * @pre _dest_ is allocated in memspaceOutDst memory space.
      * @post All elements of the vector _i_ are copied to the array _dest_.
      */
-    int Vector::copyToExternal(real_type*          dest,
-                           index_type          i,
-                           memory::MemorySpace memspaceInOut)
+    int Vector::copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst)
     {
       using namespace ReSolve::memory;
+      real_type* data = this->getData(i, memspaceSrc);
+      // Check that the source data is not null and up to date
+      if (data == nullptr)
+      {
+        out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not allocated in the source memory space!\n";
+        return -1;
+      }
+      // Check that the destination memory space is allocated
+      if (dest == nullptr)
+      {
+        out::error() << "Trying to copy data for vector " << i << " in multivector but the destination pointer is not allocated!\n";
+        return -1;
+      }
       if (i > this->k_)
       {
         return -1;
       }
       else
       {
-        real_type* data = this->getData(i, memspaceInOut);
-        switch (memspaceInOut)
+        switch (memspaceSrc)
         {
         case HOST:
-          mem_.copyArrayHostToHost(dest, data, n_size_);
+          if (!cpu_updated_[i])
+          {
+            out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
+            return -1;
+          }
+          switch (memspaceDst)
+          {
+          case HOST:
+            mem_.copyArrayHostToHost(dest, data, n_size_);
+            break;
+          case DEVICE:
+            mem_.copyArrayHostToDevice(dest, data, n_size_);
+            break;
+          }
           break;
         case DEVICE:
-          mem_.copyArrayDeviceToDevice(dest, data, n_size_);
+          if (!gpu_updated_[i])        {
+            out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
+            return -1;
+          }
+          switch (memspaceDst)
+          {
+          case HOST:
+            mem_.copyArrayDeviceToHost(dest, data, n_size_);
+            break;
+          case DEVICE:
+            mem_.copyArrayDeviceToDevice(dest, data, n_size_);
+            break;
+          }
           break;
         }
-        return 0;
-      }
-    }
-
-    /**
-     * @brief copy HOST or DEVICE vector data to _dest_.
-     *
-     * In case of multivector, all data (size _k_ * _n_) is copied.
-     *
-     * @param[out] dest      - Pointer to the memory to which data is copied
-     * @param[in] memspace   - Memory space (HOST or DEVICE) to copy from
-     *
-     * @return 0 if successful, -1 otherwise.
-     *
-     * @pre _dest_ is allocated, and the size of _dest_ is at least _k_ * _n_ .
-     */
-    int Vector::copyToExternal(real_type* dest, memory::MemorySpace memspaceInOut)
-    {
-      using namespace ReSolve::memory;
-      real_type* data = this->getData(memspaceInOut);
-      switch (memspaceInOut)
-      {
-      case HOST:
-        mem_.copyArrayHostToHost(dest, data, n_size_ * k_);
-        break;
-      case DEVICE:
-        mem_.copyArrayDeviceToDevice(dest, data, n_size_ * k_);
-        break;
       }
       return 0;
     }
-    // /**
-    //  * @brief copy HOST or DEVICE data of a specified vector in a multivector to _dest_.
-    //  * 
-    //  * This function allows to copy data between different memory spaces in one call.
-    //  * For example, you can copy data of vector _i_ from HOST to DEVICE, or from DEVICE to HOST.
-    //  * 
-    //  * @param[out] dest      - Pointer to the memory to which data is copied
-    //  * @param[in] i          - Index of a vector in a multivector
-    //  * @param[in] memspaceInSrc   - Memory space (HOST or DEVICE) of the data to be copied
-    //  * @param[in] memspaceOutDst  - Memory space (HOST or DEVICE) to which data is copied
-    //  * 
-    //  * @return 0 if successful, -1 otherwise.
-    //  * 
-    //  * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in multivector.
-    //  * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (length of a single vector in the multivector).
-    //  * @pre _dest_ is allocated in memspaceOutDst memory space.
-    //  * @post All elements of the vector _i_ are copied to the array _dest_.
-    //  */
-    // int Vector::copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst)
-    // {
-    //   using namespace ReSolve::memory;
-    //   real_type* data = this->getData(i, memspaceSrc);
-    //   // Check that the source data is not null and up to date
-    //   if (data == nullptr)
-    //   {
-    //     out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not allocated in the source memory space!\n";
-    //     return -1;
-    //   }
-    //   // Check that the destination memory space is allocated
-    //   if (dest == nullptr)
-    //   {
-    //     out::error() << "Trying to copy data for vector " << i << " in multivector but the destination pointer is not allocated!\n";
-    //     return -1;
-    //   }
-    //   if (i > this->k_)
-    //   {
-    //     return -1;
-    //   }
-    //   else
-    //   {
-    //     switch (memspaceSrc)
-    //     {
-    //     case HOST:
-    //       if (!cpu_updated_[i])
-    //       {
-    //         out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
-    //         return -1;
-    //       }
-    //       switch (memspaceDst)
-    //       {
-    //       case HOST:
-    //         mem_.copyArrayHostToHost(dest, data, n_size_);
-    //         break;
-    //       case DEVICE:
-    //         mem_.copyArrayHostToDevice(dest, data, n_size_);
-    //         break;
-    //       }
-    //       break;
-    //     case DEVICE:
-    //       if (!gpu_updated_[i])        {
-    //         out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
-    //         return -1;
-    //       }
-    //       switch (memspaceDst)
-    //       {
-    //       case HOST:
-    //         mem_.copyArrayDeviceToHost(dest, data, n_size_);
-    //         break;
-    //       case DEVICE:
-    //         mem_.copyArrayDeviceToDevice(dest, data, n_size_);
-    //         break;
-    //       }
-    //       break;
-    //     }
-    //   }
-    //   return 0;
-    // }
 
     /**
      * @brief copy HOST or DEVICE data of multivector to _dest_.

--- a/resolve/vector/Vector.cpp
+++ b/resolve/vector/Vector.cpp
@@ -753,7 +753,7 @@ namespace ReSolve
      * @pre _dest_ is allocated in memspaceInOut memory space.
      * @post All elements of the vector _i_ are copied to the array _dest_.
      */
-    int Vector::copyDataTo(real_type*          dest,
+    int Vector::copyToExternal(real_type*          dest,
                            index_type          i,
                            memory::MemorySpace memspaceInOut)
     {
@@ -790,7 +790,7 @@ namespace ReSolve
      *
      * @pre _dest_ is allocated, and the size of _dest_ is at least _k_ * _n_ .
      */
-    int Vector::copyDataTo(real_type* dest, memory::MemorySpace memspaceInOut)
+    int Vector::copyToExternal(real_type* dest, memory::MemorySpace memspaceInOut)
     {
       using namespace ReSolve::memory;
       real_type* data = this->getData(memspaceInOut);
@@ -805,80 +805,148 @@ namespace ReSolve
       }
       return 0;
     }
+    // /**
+    //  * @brief copy HOST or DEVICE data of a specified vector in a multivector to _dest_.
+    //  * 
+    //  * This function allows to copy data between different memory spaces in one call.
+    //  * For example, you can copy data of vector _i_ from HOST to DEVICE, or from DEVICE to HOST.
+    //  * 
+    //  * @param[out] dest      - Pointer to the memory to which data is copied
+    //  * @param[in] i          - Index of a vector in a multivector
+    //  * @param[in] memspaceInSrc   - Memory space (HOST or DEVICE) of the data to be copied
+    //  * @param[in] memspaceOutDst  - Memory space (HOST or DEVICE) to which data is copied
+    //  * 
+    //  * @return 0 if successful, -1 otherwise.
+    //  * 
+    //  * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in multivector.
+    //  * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (length of a single vector in the multivector).
+    //  * @pre _dest_ is allocated in memspaceOutDst memory space.
+    //  * @post All elements of the vector _i_ are copied to the array _dest_.
+    //  */
+    // int Vector::copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst)
+    // {
+    //   using namespace ReSolve::memory;
+    //   real_type* data = this->getData(i, memspaceSrc);
+    //   // Check that the source data is not null and up to date
+    //   if (data == nullptr)
+    //   {
+    //     out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not allocated in the source memory space!\n";
+    //     return -1;
+    //   }
+    //   // Check that the destination memory space is allocated
+    //   if (dest == nullptr)
+    //   {
+    //     out::error() << "Trying to copy data for vector " << i << " in multivector but the destination pointer is not allocated!\n";
+    //     return -1;
+    //   }
+    //   if (i > this->k_)
+    //   {
+    //     return -1;
+    //   }
+    //   else
+    //   {
+    //     switch (memspaceSrc)
+    //     {
+    //     case HOST:
+    //       if (!cpu_updated_[i])
+    //       {
+    //         out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
+    //         return -1;
+    //       }
+    //       switch (memspaceDst)
+    //       {
+    //       case HOST:
+    //         mem_.copyArrayHostToHost(dest, data, n_size_);
+    //         break;
+    //       case DEVICE:
+    //         mem_.copyArrayHostToDevice(dest, data, n_size_);
+    //         break;
+    //       }
+    //       break;
+    //     case DEVICE:
+    //       if (!gpu_updated_[i])        {
+    //         out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
+    //         return -1;
+    //       }
+    //       switch (memspaceDst)
+    //       {
+    //       case HOST:
+    //         mem_.copyArrayDeviceToHost(dest, data, n_size_);
+    //         break;
+    //       case DEVICE:
+    //         mem_.copyArrayDeviceToDevice(dest, data, n_size_);
+    //         break;
+    //       }
+    //       break;
+    //     }
+    //   }
+    //   return 0;
+    // }
+
     /**
-     * @brief copy HOST or DEVICE data of a specified vector in a multivector to _dest_.
+     * @brief copy HOST or DEVICE data of multivector to _dest_.
      * 
      * This function allows to copy data between different memory spaces in one call.
-     * For example, you can copy data of vector _i_ from HOST to DEVICE, or from DEVICE to HOST.
+     * For example, you can copy data of multivector from HOST to DEVICE, or from DEVICE to HOST.
      * 
      * @param[out] dest      - Pointer to the memory to which data is copied
-     * @param[in] i          - Index of a vector in a multivector
-     * @param[in] memspaceInSrc   - Memory space (HOST or DEVICE) of the data to be copied
-     * @param[in] memspaceOutDst  - Memory space (HOST or DEVICE) to which data is copied
+     * @param[in] memspaceSrc   - Memory space (HOST or DEVICE) of the data to be copied
+     * @param[in] memspaceDst  - Memory space (HOST or DEVICE) to which data is copied
      * 
      * @return 0 if successful, -1 otherwise.
      * 
-     * @pre _i_ < _k_ i.e,, _i_ is smaller than the total number of vectors in multivector.
-     * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ (length of a single vector in the multivector).
+     * @pre _dest_ is allocated, and the size of _dest_ is at least _n_ * _k_ (total length of all vectors in the multivector).
      * @pre _dest_ is allocated in memspaceOutDst memory space.
-     * @post All elements of the vector _i_ are copied to the array _dest_.
+     * @post All elements of all vectors in multivector are copied to the array _dest_.
      */
-    int Vector::copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst)
+    int Vector::copyToExternal(real_type* dest, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst)
     {
       using namespace ReSolve::memory;
-      real_type* data = this->getData(i, memspaceSrc);
+      real_type* data = this->getData(memspaceSrc);
       // Check that the source data is not null and up to date
       if (data == nullptr)
       {
-        out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not allocated in the source memory space!\n";
+        out::error() << "Trying to copy data for multivector but the data is not allocated in the source memory space!\n";
         return -1;
       }
       // Check that the destination memory space is allocated
       if (dest == nullptr)
       {
-        out::error() << "Trying to copy data for vector " << i << " in multivector but the destination pointer is not allocated!\n";
+        out::error() << "Trying to copy data for multivector but the destination pointer is not allocated!\n";
         return -1;
       }
-      if (i > this->k_)
+      switch (memspaceSrc)
       {
-        return -1;
-      }
-      else
-      {
-        switch (memspaceSrc)
+      case HOST:
+        if (!cpu_updated_[0])        {
+          out::error() << "Trying to copy data for multivector but the data is not up to date in the source memory space!\n";
+          return -1;
+        }
+        switch (memspaceDst)
         {
         case HOST:
-          if (!cpu_updated_[i])
-          {
-            out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
-            return -1;
-          }
-          switch (memspaceDst)
-          {
-          case HOST:
-            mem_.copyArrayHostToHost(dest, data, n_size_);
-            break;
-          case DEVICE:
-            mem_.copyArrayHostToDevice(dest, data, n_size_);
-            break;
-          }
+          mem_.copyArrayHostToHost(dest, data, n_size_ * k_);
           break;
         case DEVICE:
-          if (!gpu_updated_[i])        {
-            out::error() << "Trying to copy data for vector " << i << " in multivector but the data is not up to date in the source memory space!\n";
-            return -1;
-          }
-          switch (memspaceDst)
-          {
-          case HOST:
-            mem_.copyArrayDeviceToHost(dest, data, n_size_);
-            break;
-          case DEVICE:
-            mem_.copyArrayDeviceToDevice(dest, data, n_size_);
-            break;
-          }
+          mem_.copyArrayHostToDevice(dest, data, n_size_ * k_);
           break;
         }
+        break;
+      case DEVICE:
+        if (!gpu_updated_[0])        {
+          out::error() << "Trying to copy data for multivector but the data is not up to date in the source memory space!\n";
+          return -1;
+        }
+        switch (memspaceDst)
+        {
+        case HOST:
+          mem_.copyArrayDeviceToHost(dest, data, n_size_ * k_);
+          break;
+        case DEVICE:
+          mem_.copyArrayDeviceToDevice(dest, data, n_size_ * k_);
+          break;
+        }
+        break;
       }
       return 0;
     }

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -55,10 +55,10 @@ namespace ReSolve
       int syncData(memory::MemorySpace memspaceOut);
       int syncData(index_type j, memory::MemorySpace memspaceOut);
       int resize(index_type new_n_current);
-      int copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspace);
-      int copyDataTo(real_type* dest, memory::MemorySpace memspace);
-      int copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
-      int copyDataTo(real_type* dest, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
+      // int copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspace);
+      // int copyToExternal(real_type* dest, memory::MemorySpace memspace);
+      int copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
+      int copyToExternal(real_type* dest, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
 
     private:
       void setHostUpdated(bool is_updated);

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -57,6 +57,8 @@ namespace ReSolve
       int resize(index_type new_n_current);
       int copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspace);
       int copyDataTo(real_type* dest, memory::MemorySpace memspace);
+      int copyDataTo(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
+      int copyDataTo(real_type* dest, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
 
     private:
       void setHostUpdated(bool is_updated);

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -55,8 +55,6 @@ namespace ReSolve
       int syncData(memory::MemorySpace memspaceOut);
       int syncData(index_type j, memory::MemorySpace memspaceOut);
       int resize(index_type new_n_current);
-      // int copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspace);
-      // int copyToExternal(real_type* dest, memory::MemorySpace memspace);
       int copyToExternal(real_type* dest, index_type i, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
       int copyToExternal(real_type* dest, memory::MemorySpace memspaceSrc, memory::MemorySpace memspaceDst);
 

--- a/resolve/vector/Vector.hpp
+++ b/resolve/vector/Vector.hpp
@@ -35,8 +35,8 @@ namespace ReSolve
       Vector(index_type n, index_type k);
       ~Vector();
 
-      int              copyDataFrom(const real_type* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
-      int              copyDataFrom(Vector* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
+      int              copyFromExternal(const real_type* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
+      int              copyFromExternal(Vector* source, memory::MemorySpace memspaceIn, memory::MemorySpace memspaceOut);
       real_type*       getData(memory::MemorySpace memspace);
       real_type*       getData(index_type i, memory::MemorySpace memspace);
       const real_type* getData(memory::MemorySpace memspace) const;

--- a/tests/functionality/TestHelper.hpp
+++ b/tests/functionality/TestHelper.hpp
@@ -299,7 +299,7 @@ public:
     int error_sum = 0;
 
     // Compute residual norm to get updated vector res_
-    res_->copyDataFrom(r_, memspace_, memspace_);
+    res_->copyFromExternal(r_, memspace_, memspace_);
     norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
     // Compute norm of scaled residuals
@@ -340,7 +340,7 @@ public:
     int error_sum = 0;
 
     // Compute residual norm
-    res_->copyDataFrom(r_, memspace_, memspace_);
+    res_->copyFromExternal(r_, memspace_, memspace_);
     norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
     real_type error = std::abs(norm_rhs_ * rrn_system - norm_res_) / norm_res_;
@@ -371,7 +371,7 @@ public:
     int error_sum = 0;
 
     // Compute residual norm
-    res_->copyDataFrom(r_, memspace_, memspace_);
+    res_->copyFromExternal(r_, memspace_, memspace_);
     norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
     real_type error = std::abs(rn_system - norm_res_) / norm_res_;
@@ -396,12 +396,12 @@ private:
     }
 
     // Compute rhs and residual norms
-    res_->copyDataFrom(r_, memspace_, memspace_);
+    res_->copyFromExternal(r_, memspace_, memspace_);
     norm_rhs_ = norm2(*r_, memspace_);
     norm_res_ = computeResidualNorm(*A_, *x_, *res_, memspace_);
 
     // Compute residual norm w.r.t. true solution
-    res_->copyDataFrom(r_, memspace_, memspace_);
+    res_->copyFromExternal(r_, memspace_, memspace_);
     norm_res_true_ = computeResidualNorm(*A_, *x_true_, *res_, memspace_);
 
     // Compute residual norm on CPU
@@ -410,12 +410,12 @@ private:
       // A_->syncData(ReSolve::memory::HOST);
       // r_->syncData(ReSolve::memory::HOST);
       // x_->syncData(ReSolve::memory::HOST);
-      res_->copyDataFrom(r_, memspace_, ReSolve::memory::HOST);
+      res_->copyFromExternal(r_, memspace_, ReSolve::memory::HOST);
       norm_res_cpu_ = computeResidualNorm(*A_, *x_, *res_, ReSolve::memory::HOST);
     }
 
     // Compute vector difference norm
-    res_->copyDataFrom(x_, memspace_, memspace_);
+    res_->copyFromExternal(x_, memspace_, memspace_);
     norm_diff_ = computeDiffNorm(*x_true_, *res_, memspace_);
   }
 

--- a/tests/functionality/testKlu.cpp
+++ b/tests/functionality/testKlu.cpp
@@ -122,7 +122,7 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   }
   real_type*  rhs = ReSolve::io::createArrayFromFile(rhs1_file);
   vector_type vec_rhs(A->getNumRows());
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   rhs1_file.close();
 
   // Allocate the solution vector
@@ -189,7 +189,7 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   }
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   status = KLU.refactorize();
   error_sum += status;

--- a/tests/functionality/testLUSOL.cpp
+++ b/tests/functionality/testLUSOL.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
   vector_type vec_x(A->getNumRows());
   vector_type vec_r(A->getNumRows());
 
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs.setDataUpdated(ReSolve::memory::HOST);
   vec_x.allocate(ReSolve::memory::HOST);
 
@@ -106,9 +106,9 @@ int main(int argc, char* argv[])
   real_type* x_data = new real_type[A->getNumRows()];
   std::fill_n(x_data, A->getNumRows(), 1.0);
 
-  vec_test.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_diff.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_test.copyFromExternal(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_diff.copyFromExternal(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   // Matrix-vector product does not support COO format so we need to convert to CSR
   ReSolve::matrix::Csr A_csr(A->getNumRows(), A->getNumColumns(), A->getNnz(), A->symmetric(), A->expanded());
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
   real_type normDiffMatrix = sqrt(vector_handler.dot(&vec_diff, &vec_diff, ReSolve::memory::HOST));
 
   // Compute residual r := A*x - r using exact solution x
-  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   error_sum += matrix_handler.matvec(&A_csr,
                                      &vec_test,
                                      &vec_r,
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
 
   x = new real_type[A->getNumRows()];
 
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs.setDataUpdated(ReSolve::memory::HOST);
   vec_x.allocate(ReSolve::memory::HOST);
 
@@ -210,9 +210,9 @@ int main(int argc, char* argv[])
   x_data = new real_type[A->getNumRows()];
   std::fill_n(x_data, A->getNumRows(), 1.0);
 
-  vec_test.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_diff.copyDataFrom(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_test.copyFromExternal(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_diff.copyFromExternal(x_data, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   // Matrix-vector product does not support COO format so we need to convert to CSR
   error_sum += coo2csr(A.get(), &A_csr, ReSolve::memory::HOST);
@@ -239,7 +239,7 @@ int main(int argc, char* argv[])
   normDiffMatrix = sqrt(vector_handler.dot(&vec_diff, &vec_diff, ReSolve::memory::HOST));
 
   // compute the residual using exact solution
-  vec_r.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_r.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   // Compute residual r := A*x - r using exact solution x
   error_sum += matrix_handler.matvec(&A_csr,
                                      &vec_test,
@@ -326,7 +326,7 @@ int coo2csr(ReSolve::matrix::Coo* A_coo, ReSolve::matrix::Csr* A_csr, ReSolve::m
     }
   }
   row_csr[n] = nnz;
-  A_csr->copyDataFrom(row_csr, cols_coo, vals_coo, ReSolve::memory::HOST, memspace);
+  A_csr->copyFromExternal(row_csr, cols_coo, vals_coo, ReSolve::memory::HOST, memspace);
 
   delete[] row_csr;
 

--- a/tests/functionality/testRefactor.cpp
+++ b/tests/functionality/testRefactor.cpp
@@ -147,7 +147,7 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   }
   real_type*  rhs = ReSolve::io::createArrayFromFile(rhs1_file);
   vector_type vec_rhs(A->getNumRows());
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs.syncData(ReSolve::memory::DEVICE);
   rhs1_file.close();
 
@@ -231,7 +231,7 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   }
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // Refactorize second matrix
   status = Rf.refactorize();

--- a/tests/functionality/testSysGLU.cpp
+++ b/tests/functionality/testSysGLU.cpp
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
   vec_x->allocate(ReSolve::memory::DEVICE);
 
   // Set RHS vector on CPU
-  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   vec_rhs->setDataUpdated(ReSolve::memory::HOST);
 
   // Set system matrix
@@ -130,13 +130,13 @@ int main(int argc, char* argv[])
   std::cout << "GLU setup status: " << status << std::endl;
 
   // Move rhs vector data to GPU
-  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = solver.solve(vec_rhs, vec_x);
   error_sum += status;
   std::cout << "GLU solve status: " << status << std::endl;
 
   // Compute residual on device
-  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
@@ -180,23 +180,23 @@ int main(int argc, char* argv[])
   {
     x_data_ref[i] = 1.0;
   }
-  vec_test->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::HOST);
-  vec_test->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_test->copyFromExternal(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_test->copyFromExternal(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // compute ||x_diff|| = ||x - x_true|| norm
-  vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyFromExternal(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler.axpy(&MINUS_ONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix1 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   // Compute residual norm ON THE GPU using REFERENCE solution
-  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type exactSol_normRmatrix1 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));
 
   // Compute residual norm ON THE CPU using COMPUTED solution
-  vec_x->copyDataFrom(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
-  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_x->copyFromExternal(vec_x->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::HOST);
+  vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::HOST);
   error_sum += status;
   real_type normRmatrix1CPU = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::HOST));
@@ -245,7 +245,7 @@ int main(int argc, char* argv[])
   rhs2_file.close();
 
   // Update system values
-  vec_rhs->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // Refactorize and solve
   status = solver.refactorize();
@@ -256,7 +256,7 @@ int main(int argc, char* argv[])
   error_sum += status;
 
   // Compute residual norm for the second system
-  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   matrix_handler.setValuesChanged(true, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
@@ -287,12 +287,12 @@ int main(int argc, char* argv[])
   }
 
   // compute ||x_diff|| = ||x - x_true|| norm
-  vec_diff->copyDataFrom(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_diff->copyFromExternal(x_data_ref, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   vector_handler.axpy(&MINUS_ONE, vec_x, vec_diff, ReSolve::memory::DEVICE);
   real_type normDiffMatrix2 = sqrt(vector_handler.dot(vec_diff, vec_diff, ReSolve::memory::DEVICE));
 
   // compute the residual using exact solution
-  vec_r->copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
+  vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
   status = matrix_handler.matvec(A, vec_test, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
   error_sum += status;
   real_type exactSol_normRmatrix2 = sqrt(vector_handler.dot(vec_r, vec_r, ReSolve::memory::DEVICE));

--- a/tests/functionality/testSysRefactor.cpp
+++ b/tests/functionality/testSysRefactor.cpp
@@ -175,7 +175,7 @@ static int runTest(int argc, char* argv[], std::string backend)
 
   // Create and set residual vector
   vector_type vec_rhs = (A->getNumRows());
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
 
   // Create and allocate solution vector
   vector_type vec_x(A->getNumRows());
@@ -243,7 +243,7 @@ static int runTest(int argc, char* argv[], std::string backend)
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
 
-  vec_rhs.copyDataFrom(rhs, ReSolve::memory::HOST, memspace);
+  vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, memspace);
 
   // Refactorize matrix
   status = solver.refactorize();

--- a/tests/unit/hykkt/HykktCholeskyTests.hpp
+++ b/tests/unit/hykkt/HykktCholeskyTests.hpp
@@ -52,7 +52,7 @@ namespace ReSolve
         index_type   A_row_data[4] = {0, 3, 6, 9};
         index_type   A_col_data[9] = {0, 1, 2, 0, 1, 2, 0, 1, 2};
         real_type    A_values[9]   = {4.0, 12.0, -16.0, 12.0, 37.0, -43.0, -16.0, -43.0, 98.0};
-        A->copyDataFrom(A_row_data, A_col_data, A_values, memory::HOST, memory::HOST);
+        A->copyFromExternal(A_row_data, A_col_data, A_values, memory::HOST, memory::HOST);
         if (memspace_ == memory::DEVICE)
         {
           A->syncData(memory::DEVICE);
@@ -67,7 +67,7 @@ namespace ReSolve
         x->allocate(memspace_);
         vector::Vector* b         = new vector::Vector(3);
         real_type       b_data[3] = {-6.0, -17.25, 30.0};
-        b->copyDataFrom(b_data, memory::HOST, memspace_);
+        b->copyFromExternal(b_data, memory::HOST, memspace_);
         solver.solve(x, b);
 
         if (memspace_ == memory::DEVICE)
@@ -109,7 +109,7 @@ namespace ReSolve
         matrix::Csr* A = new matrix::Csr((index_type) L_times_L_tr->nrow,
                                          (index_type) L_times_L_tr->ncol,
                                          (index_type) L_times_L_tr->nzmax);
-        A->copyDataFrom(
+        A->copyFromExternal(
             static_cast<int*>(L_times_L_tr->p),
             static_cast<int*>(L_times_L_tr->i),
             static_cast<double*>(L_times_L_tr->x),
@@ -185,7 +185,7 @@ namespace ReSolve
         cholmod_sparse* A_chol = cholmod_ssmult(L, L_tr, 0, 1, 0, &Common);
 
         matrix::Csr* A = new matrix::Csr((index_type) A_chol->nrow, (index_type) A_chol->ncol, (index_type) A_chol->nzmax);
-        A->copyDataFrom(
+        A->copyFromExternal(
             static_cast<int*>(A_chol->p), static_cast<int*>(A_chol->i), static_cast<double*>(A_chol->x), memory::HOST, memspace_);
 
         if (memspace_ == memory::DEVICE)

--- a/tests/unit/hykkt/HykktPermutationTests.hpp
+++ b/tests/unit/hykkt/HykktPermutationTests.hpp
@@ -220,9 +220,9 @@ namespace ReSolve
         int    jac_tr_j[4] = {0, 1, 0, 1};
         double jac_tr_v[4] = {0, 1, 2, 3};
 
-        hes->copyDataFrom(hes_i, hes_j, hes_v, memory::HOST, memory::HOST);
-        jac->copyDataFrom(jac_i, jac_j, jac_v, memory::HOST, memory::HOST);
-        jac_tr->copyDataFrom(jac_tr_i, jac_tr_j, jac_tr_v, memory::HOST, memory::HOST);
+        hes->copyFromExternal(hes_i, hes_j, hes_v, memory::HOST, memory::HOST);
+        jac->copyFromExternal(jac_i, jac_j, jac_v, memory::HOST, memory::HOST);
+        jac_tr->copyFromExternal(jac_tr_i, jac_tr_j, jac_tr_v, memory::HOST, memory::HOST);
       }
 
       bool verifyResults(const int* expected, const int* actual, int size)

--- a/tests/unit/hykkt/HykktRuizScalingTests.hpp
+++ b/tests/unit/hykkt/HykktRuizScalingTests.hpp
@@ -148,7 +148,7 @@ namespace ReSolve
         H_val_data[3 * n - 3] = n;
         H_col_data[3 * n - 3] = n - 1;
 
-        H->copyDataFrom(H_row_data, H_col_data, H_val_data, memory::HOST, memspace_);
+        H->copyFromExternal(H_row_data, H_col_data, H_val_data, memory::HOST, memspace_);
 
         // Define J
         index_type* J_row_data = new index_type[n];
@@ -167,7 +167,7 @@ namespace ReSolve
         }
         J_row_data[n - 1] = 2 * n - 2;
 
-        J->copyDataFrom(J_row_data, J_col_data, J_val_data, memory::HOST, memspace_);
+        J->copyFromExternal(J_row_data, J_col_data, J_val_data, memory::HOST, memspace_);
 
         // Define rhs vectors
         real_type* rhs_data = new real_type[n];
@@ -176,9 +176,9 @@ namespace ReSolve
           rhs_data[i] = 1.0;
         }
 
-        rhs_top->copyDataFrom(rhs_data, memory::HOST, memspace_);
+        rhs_top->copyFromExternal(rhs_data, memory::HOST, memspace_);
 
-        rhs_bottom->copyDataFrom(rhs_data, memory::HOST, memspace_);
+        rhs_bottom->copyFromExternal(rhs_data, memory::HOST, memspace_);
 
         delete[] H_row_data;
         delete[] H_col_data;

--- a/tests/unit/hykkt/HykktSpGEMMTests.hpp
+++ b/tests/unit/hykkt/HykktSpGEMMTests.hpp
@@ -165,9 +165,9 @@ namespace ReSolve
         matrix::Csr* B = new matrix::Csr(n, n, nnz);
         matrix::Csr* D = new matrix::Csr(n, n, n - 2);
 
-        A->copyDataFrom(A_row_ptr, A_col_ind, A_values, memory::HOST, memspace_);
-        B->copyDataFrom(B_row_ptr, B_col_ind, B_values, memory::HOST, memspace_);
-        D->copyDataFrom(D_row_ptr, D_col_ind, D_values, memory::HOST, memspace_);
+        A->copyFromExternal(A_row_ptr, A_col_ind, A_values, memory::HOST, memspace_);
+        B->copyFromExternal(B_row_ptr, B_col_ind, B_values, memory::HOST, memspace_);
+        D->copyFromExternal(D_row_ptr, D_col_ind, D_values, memory::HOST, memspace_);
 
         matrix::Csr* E = nullptr;
 
@@ -341,9 +341,9 @@ namespace ReSolve
         *B = new matrix::Csr(3, 3, 5);
         *D = new matrix::Csr(3, 3, 6);
 
-        (*A)->copyDataFrom(A_row_ptr, A_col_ind, A_values, memory::HOST, memspace_);
-        (*B)->copyDataFrom(B_row_ptr, B_col_ind, B_values, memory::HOST, memspace_);
-        (*D)->copyDataFrom(D_row_ptr, D_col_ind, D_values, memory::HOST, memspace_);
+        (*A)->copyFromExternal(A_row_ptr, A_col_ind, A_values, memory::HOST, memspace_);
+        (*B)->copyFromExternal(B_row_ptr, B_col_ind, B_values, memory::HOST, memspace_);
+        (*D)->copyFromExternal(D_row_ptr, D_col_ind, D_values, memory::HOST, memspace_);
 
         delete[] A_row_ptr;
         delete[] A_col_ind;

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -200,10 +200,10 @@ namespace ReSolve
         index_type   size = static_cast<index_type>(valsA_.size());
         matrix::Coo* A    = new matrix::Coo(9, 9, size, true, true);
         A->copyFromExternal(rowsA_.data(),
-                        colsA_.data(),
-                        valsA_.data(),
-                        memory::HOST,
-                        memory::HOST);
+                            colsA_.data(),
+                            valsA_.data(),
+                            memory::HOST,
+                            memory::HOST);
 
         return A;
       }

--- a/tests/unit/matrix/LUSOLTests.hpp
+++ b/tests/unit/matrix/LUSOLTests.hpp
@@ -199,7 +199,7 @@ namespace ReSolve
         // NOTE: these are hardcoded for now
         index_type   size = static_cast<index_type>(valsA_.size());
         matrix::Coo* A    = new matrix::Coo(9, 9, size, true, true);
-        A->copyDataFrom(rowsA_.data(),
+        A->copyFromExternal(rowsA_.data(),
                         colsA_.data(),
                         valsA_.data(),
                         memory::HOST,

--- a/tests/unit/matrix/MatrixFactorizationTests.hpp
+++ b/tests/unit/matrix/MatrixFactorizationTests.hpp
@@ -161,7 +161,7 @@ namespace ReSolve
         // Allocate NxN CSR matrix with NNZ nonzeros
         matrix::Csr* A = new matrix::Csr(N, N, NNZ);
         A->allocateMatrixData(memory::HOST);
-        A->copyDataFrom(&rowsA_[0], &colsA_[0], &valsA_[0], memory::HOST, memory::HOST);
+        A->copyFromExternal(&rowsA_[0], &colsA_[0], &valsA_[0], memory::HOST, memory::HOST);
 
         // A->print();
 

--- a/tests/unit/vector/GramSchmidtTests.hpp
+++ b/tests/unit/vector/GramSchmidtTests.hpp
@@ -154,8 +154,8 @@ namespace ReSolve
         {
           for (index_type j = 0; j < K; ++j)
           {
-            a.copyDataFrom(x.getData(i, memspace_), memspace_, memory::HOST);
-            b.copyDataFrom(x.getData(j, memspace_), memspace_, memory::HOST);
+            a.copyFromExternal(x.getData(i, memspace_), memspace_, memory::HOST);
+            b.copyFromExternal(x.getData(j, memspace_), memspace_, memory::HOST);
             ip = handler_.dot(&a, &b, memory::HOST);
             if ((i != j) && !isEqual(ip, 0.0))
             {

--- a/tests/unit/vector/VectorHandlerTests.hpp
+++ b/tests/unit/vector/VectorHandlerTests.hpp
@@ -61,7 +61,7 @@ namespace ReSolve
         {
           data[i] = 0.1 * (real_type) i;
         }
-        x.copyDataFrom(data, memory::HOST, memspace_);
+        x.copyFromExternal(data, memory::HOST, memspace_);
 
         real_type result = handler_.infNorm(&x, memspace_);
         real_type answer = static_cast<real_type>(N - 1) * 0.1;
@@ -257,7 +257,7 @@ namespace ReSolve
         {
           diag_data[i] = (real_type) (i + 1);
         }
-        diag.copyDataFrom(diag_data.get(), memory::HOST, memspace_);
+        diag.copyFromExternal(diag_data.get(), memory::HOST, memspace_);
 
         handler_.scale(&diag, &vec, memspace_);
 

--- a/tests/unit/vector/VectorTests.hpp
+++ b/tests/unit/vector/VectorTests.hpp
@@ -238,8 +238,8 @@ namespace ReSolve
 
         // Copy data to an array on current memspace
         real_type* dest = new real_type[N];
-        // second argument is in/out
-        x.copyToExternal(dest, memspace_);
+        // second argument is source, third is destination
+        x.copyToExternal(dest, memspace_, memspace_);
 
         // Copy to host to verify
         real_type* dest_h = new real_type[N];

--- a/tests/unit/vector/VectorTests.hpp
+++ b/tests/unit/vector/VectorTests.hpp
@@ -223,7 +223,7 @@ namespace ReSolve
        * @param[in] N Number of elements in the vector.
        * @return TestOutcome indicating success or failure of the test.
        */
-      TestOutcome copyDataTo(index_type N)
+      TestOutcome copyToExternal(index_type N)
       {
         TestStatus status = true;
 
@@ -239,7 +239,7 @@ namespace ReSolve
         // Copy data to an array on current memspace
         real_type* dest = new real_type[N];
         // second argument is in/out
-        x.copyDataTo(dest, memspace_);
+        x.copyToExternal(dest, memspace_);
 
         // Copy to host to verify
         real_type* dest_h = new real_type[N];

--- a/tests/unit/vector/VectorTests.hpp
+++ b/tests/unit/vector/VectorTests.hpp
@@ -164,7 +164,7 @@ namespace ReSolve
        * @param[in] N Number of elements in the vector.
        * @return TestOutcome indicating success or failure of the test.
        */
-      TestOutcome copyDataFrom(index_type N)
+      TestOutcome copyFromExternal(index_type N)
       {
         TestStatus status;
         status = true;
@@ -177,15 +177,15 @@ namespace ReSolve
         }
 
         // array -> memspace
-        x.copyDataFrom(data, memory::HOST, memspace_);
+        x.copyFromExternal(data, memory::HOST, memspace_);
 
         // memspace -> memspace
         vector::Vector y(N);
-        y.copyDataFrom(&x, memspace_, memspace_);
+        y.copyFromExternal(&x, memspace_, memspace_);
 
         // memspace -> host
         vector::Vector z(N);
-        z.copyDataFrom(&y, memspace_, memory::HOST);
+        z.copyFromExternal(&y, memspace_, memory::HOST);
 
         const real_type* z_data = z.getData(memory::HOST);
 
@@ -234,7 +234,7 @@ namespace ReSolve
           data[i] = 0.1 * (real_type) i;
         }
 
-        x.copyDataFrom(data, memory::HOST, memspace_);
+        x.copyFromExternal(data, memory::HOST, memspace_);
 
         // Copy data to an array on current memspace
         real_type* dest = new real_type[N];

--- a/tests/unit/vector/runVectorTests.cpp
+++ b/tests/unit/vector/runVectorTests.cpp
@@ -18,7 +18,7 @@ int main(int, char**)
     result += test.setData(50);
 
     result += test.copyDataFrom(50);
-    // result += test.copyDataTo(50);
+    // result += test.copyToExternal(50);
 
     result += test.resize(100, 50);
 
@@ -37,7 +37,7 @@ int main(int, char**)
     result += test.setData(50);
 
     result += test.copyDataFrom(50);
-    // result += test.copyDataTo(50);
+    // result += test.copyToExternal(50);
 
     result += test.resize(100, 50);
 

--- a/tests/unit/vector/runVectorTests.cpp
+++ b/tests/unit/vector/runVectorTests.cpp
@@ -17,7 +17,7 @@ int main(int, char**)
 
     result += test.setData(50);
 
-    result += test.copyDataFrom(50);
+    result += test.copyFromExternal(50);
     // result += test.copyToExternal(50);
 
     result += test.resize(100, 50);
@@ -36,7 +36,7 @@ int main(int, char**)
 
     result += test.setData(50);
 
-    result += test.copyDataFrom(50);
+    result += test.copyFromExternal(50);
     // result += test.copyToExternal(50);
 
     result += test.resize(100, 50);


### PR DESCRIPTION
## Description
 
Current implementation of `Vector::copyDataTo` methods allows for copying from host-to-host and device-to-device only. If one needs to copy from host to device one needs an additional copy operation. Need to modify `Vector::copyDataTo` so it can copy data from any memory space to any memory space, similar as `Vector::copyDataFrom` methods.
 
 <!-- Closes #414  --> 

 ## Proposed changes
 
My changes allow the source and memory space to be different. I also addressed naming issues and syncing issues.
 
 ## Checklist

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run:
`./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
I noticed some issues that I left to not explode the scope of the PR. We should follow up on these.

1. `copyDataFrom` has similar naming and potentially syncing issues
2. GramSchmidt is littered with `deviceSynchronize()` seemingly arbitrarily
3. Vector tests have some commented tests.