### PR TITLE
Removed unnecessary syncs and handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Added `cons` counterparts to `Vector::getData` methods.
 
-- Made Vector::copyDataTo able to copy from device to host and vice versa
+- Made Vector::copyToExternal able to copy from device to host and vice versa
 
 - Added `diagSolve`, `max`, and `abs` vector operations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,15 @@
 
 - Added `cons` counterparts to `Vector::getData` methods.
 
-- Made Vector::copyToExternal able to copy from device to host and vice versa
+- Made Vector::copyToExternal able to copy from device to host and vice versa.
 
 - Added `diagSolve`, `max`, and `abs` vector operations.
 
 - Improved coding guidelines for developers on floating point conventions.
+
+- Removed unnecessary device synchronization.
+
+- Changed variable and function names to be more explanatory.
 
 ## Changes to Re::Solve in release 0.99.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Removed unnecessary device synchronization and added where needed (HIP only calls).
 
 - Changed variable and function names to be more explanatory.
+
 - Added Developer Guide documentation for vector and matrix classes and handlers.
 
 ## Changes to Re::Solve in release 0.99.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - Improved coding guidelines for developers on floating point conventions.
 
-- Removed unnecessary device synchronization.
+- Removed unnecessary device synchronization and added where needed (HIP only calls).
 
 - Changed variable and function names to be more explanatory.
 - Added Developer Guide documentation for vector and matrix classes and handlers.

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -187,26 +187,21 @@ namespace ReSolve
       vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_, memspace_);
       // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
       vector_handler_->gemv('N', i + 1, ONE, MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_);
-      mem_.deviceSynchronize();
 
       // copy H_col to aux, we will need it later
       vec_Hcolumn_->setDataUpdated(memspace_);
       vec_Hcolumn_->resize(i + 1);
       vec_Hcolumn_->copyToExternal(h_aux_, 0, memory::HOST, memory::HOST);
-      mem_.deviceSynchronize();
 
       // Hcol = V(:,1:i)^T*V(:,i+1);
       vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_, memspace_);
-      mem_.deviceSynchronize();
 
       // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
       vector_handler_->gemv('N', i + 1, ONE, MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_);
-      mem_.deviceSynchronize();
 
       // copy H_col to H
       vec_Hcolumn_->setDataUpdated(memspace_);
       vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
-      mem_.deviceSynchronize();
 
       // add both pieces together (unstable otherwise, careful here!!)
       t = 0.0;
@@ -381,13 +376,11 @@ namespace ReSolve
       vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_, memspace_);
       // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
       vector_handler_->gemv('N', i + 1, ONE, MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_);
-      mem_.deviceSynchronize();
 
       // copy H_col to H
       vec_Hcolumn_->setDataUpdated(memspace_);
       vec_Hcolumn_->resize(i + 1);
       vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
-      mem_.deviceSynchronize();
 
       t = vector_handler_->dot(vec_v_, vec_v_, memspace_);
       // set the last entry in Hessenberg matrix

--- a/resolve/GramSchmidt.hpp
+++ b/resolve/GramSchmidt.hpp
@@ -53,7 +53,6 @@ namespace ReSolve
     vector_type* vec_w_{nullptr}; // aux variable
     vector_type* vec_x_{nullptr}; // aux variable
 
-    MemoryHandler       mem_; ///< Device memory manager object
     memory::MemorySpace memspace_;
   };
 

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -125,7 +125,6 @@ namespace ReSolve
                                                d_Q_,
                                                handle_cusolverrf_);
     error_sum += status_cusolverrf_;
-    mem_.deviceSynchronize();
     status_cusolverrf_ = cusolverRfAnalyze(handle_cusolverrf_);
     error_sum += status_cusolverrf_;
     const cusolverRfFactorization_t fact_alg =
@@ -194,7 +193,6 @@ namespace ReSolve
                                                handle_cusolverrf_);
     error_sum += status_cusolverrf_;
 
-    mem_.deviceSynchronize();
     status_cusolverrf_ = cusolverRfRefactor(handle_cusolverrf_);
     error_sum += status_cusolverrf_;
 

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -92,7 +92,6 @@ namespace ReSolve
     mem_.copyArrayHostToDevice(d_P_, P, n);
     mem_.copyArrayHostToDevice(d_Q_, Q, n);
 
-    mem_.deviceSynchronize();
     status_rocblas_ = rocsolver_dcsrrf_analysis(workspace_->getRocblasHandle(),
                                                 n,
                                                 1,
@@ -125,7 +124,6 @@ namespace ReSolve
   {
     RESOLVE_RANGE_PUSH(__FUNCTION__);
     int error_sum = 0;
-    mem_.deviceSynchronize();
     status_rocblas_ = rocsolver_dcsrrf_refactlu(workspace_->getRocblasHandle(),
                                                 A_->getNumRows(),
                                                 A_->getNnz(),
@@ -156,7 +154,6 @@ namespace ReSolve
   {
     RESOLVE_RANGE_PUSH(__FUNCTION__);
     int error_sum = 0;
-    mem_.deviceSynchronize();
     status_rocblas_ = rocsolver_dcsrrf_solve(workspace_->getRocblasHandle(),
                                              A_->getNumRows(),
                                              1,
@@ -188,7 +185,6 @@ namespace ReSolve
     x->copyFromExternal(rhs->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::DEVICE);
     x->setDataUpdated(ReSolve::memory::DEVICE);
     int error_sum = 0;
-    mem_.deviceSynchronize();
     status_rocblas_ = rocsolver_dcsrrf_solve(workspace_->getRocblasHandle(),
                                              A_->getNumRows(),
                                              1,

--- a/resolve/LinSolverDirectRocSolverRf.cpp
+++ b/resolve/LinSolverDirectRocSolverRf.cpp
@@ -123,7 +123,7 @@ namespace ReSolve
   int LinSolverDirectRocSolverRf::refactorize()
   {
     RESOLVE_RANGE_PUSH(__FUNCTION__);
-    int error_sum = 0;
+    int error_sum   = 0;
     status_rocblas_ = rocsolver_dcsrrf_refactlu(workspace_->getRocblasHandle(),
                                                 A_->getNumRows(),
                                                 A_->getNnz(),
@@ -153,7 +153,7 @@ namespace ReSolve
   int LinSolverDirectRocSolverRf::solve(vector_type* rhs)
   {
     RESOLVE_RANGE_PUSH(__FUNCTION__);
-    int error_sum = 0;
+    int error_sum   = 0;
     status_rocblas_ = rocsolver_dcsrrf_solve(workspace_->getRocblasHandle(),
                                              A_->getNumRows(),
                                              1,
@@ -184,7 +184,7 @@ namespace ReSolve
     RESOLVE_RANGE_PUSH(__FUNCTION__);
     x->copyFromExternal(rhs->getData(ReSolve::memory::DEVICE), ReSolve::memory::DEVICE, ReSolve::memory::DEVICE);
     x->setDataUpdated(ReSolve::memory::DEVICE);
-    int error_sum = 0;
+    int error_sum   = 0;
     status_rocblas_ = rocsolver_dcsrrf_solve(workspace_->getRocblasHandle(),
                                              A_->getNumRows(),
                                              1,

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -198,7 +198,6 @@ namespace ReSolve
           vec_z.setData(vec_Z_->getData(0, memspace_), memspace_);
         }
         this->precV(&vec_v, &vec_z);
-        mem_.deviceSynchronize();
 
         // V_{i+1}=A*Z_i
 

--- a/resolve/LinSolverIterativeFGMRES.hpp
+++ b/resolve/LinSolverIterativeFGMRES.hpp
@@ -107,6 +107,5 @@ namespace ReSolve
     index_type   n_{0};
     bool         is_solver_set_{false};
 
-    MemoryHandler mem_; ///< Device memory manager object
   };
 } // namespace ReSolve

--- a/resolve/LinSolverIterativeFGMRES.hpp
+++ b/resolve/LinSolverIterativeFGMRES.hpp
@@ -106,6 +106,5 @@ namespace ReSolve
     GramSchmidt* GS_{nullptr};
     index_type   n_{0};
     bool         is_solver_set_{false};
-
   };
 } // namespace ReSolve

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -171,7 +171,6 @@ namespace ReSolve
     {
       vector_handler_->scal(one_over_k_, &vec_s, memspace_);
     }
-    mem_.deviceSynchronize();
 
     rnorm = 0.0;
     bnorm = vector_handler_->dot(rhs, rhs, memspace_);
@@ -222,7 +221,6 @@ namespace ReSolve
       vector_handler_->scal(t, vec_V_, memspace_);
       vector_handler_->scal(t, vec_S_, memspace_);
 
-      mem_.deviceSynchronize();
 
       // initialize norm history
       h_rs_[0] = rnorm;
@@ -246,7 +244,6 @@ namespace ReSolve
         }
         this->precV(&vec_v, &vec_z);
 
-        mem_.deviceSynchronize();
 
         // V_{i+1}=A*Z_i
         vec_v.setData(vec_V_->getData(i + 1, memspace_), memspace_);
@@ -261,7 +258,7 @@ namespace ReSolve
         {
           vector_handler_->scal(one_over_k_, &vec_s, memspace_);
         }
-        mem_.deviceSynchronize();
+
         GS_->orthogonalize(k_rand_, vec_S_, h_H_, i);
 
         // now post-process
@@ -273,7 +270,6 @@ namespace ReSolve
 
         t = 1.0 / h_H_[i * (restart_ + 1) + i + 1];
         vector_handler_->scal(t, &vec_v, memspace_);
-        mem_.deviceSynchronize();
         vec_s.setData(vec_S_->getData(i + 1, memspace_), memspace_);
 
         if (i != 0)
@@ -384,7 +380,7 @@ namespace ReSolve
         {
           vector_handler_->scal(one_over_k_, &vec_s, memspace_);
         }
-        mem_.deviceSynchronize();
+
         rnorm = vector_handler_->dot(vec_S_, vec_S_, memspace_);
         // rnorm = ||S_0||
         rnorm = std::sqrt(rnorm);

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -221,7 +221,6 @@ namespace ReSolve
       vector_handler_->scal(t, vec_V_, memspace_);
       vector_handler_->scal(t, vec_S_, memspace_);
 
-
       // initialize norm history
       h_rs_[0] = rnorm;
       i        = -1;
@@ -243,7 +242,6 @@ namespace ReSolve
           vec_z.setData(vec_Z_->getData(0, memspace_), memspace_);
         }
         this->precV(&vec_v, &vec_z);
-
 
         // V_{i+1}=A*Z_i
         vec_v.setData(vec_V_->getData(i + 1, memspace_), memspace_);

--- a/resolve/LinSolverIterativeRandFGMRES.hpp
+++ b/resolve/LinSolverIterativeRandFGMRES.hpp
@@ -128,7 +128,6 @@ namespace ReSolve
     real_type    one_over_k_{1.0};
 
     index_type         k_rand_{0}; ///< size of sketch space. We need to know it so we can allocate S!
-    MemoryHandler      mem_;       ///< Device memory manager object
     SketchingHandler*  sketching_handler_{nullptr};
     SketchingMethod    sketching_method_;
     memory::DeviceType device_type_{memory::NONE};

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -370,10 +370,10 @@ namespace ReSolve
      * @todo Decide how to allow user to configure grid and block sizes.
      */
     void matrixRowSums(index_type        n,
-                         index_type        nnz,
-                         const index_type* a_ia,
-                         const real_type*  a_val,
-                         real_type*        result)
+                       index_type        nnz,
+                       const index_type* a_ia,
+                       const real_type*  a_val,
+                       real_type*        result)
     {
       kernels::matrixInfNormPart1<<<1000, 1024>>>(n, nnz, a_ia, a_val, result);
     }

--- a/resolve/cuda/cudaKernels.cu
+++ b/resolve/cuda/cudaKernels.cu
@@ -369,7 +369,7 @@ namespace ReSolve
      *
      * @todo Decide how to allow user to configure grid and block sizes.
      */
-    void matrix_row_sums(index_type        n,
+    void matrixRowSums(index_type        n,
                          index_type        nnz,
                          const index_type* a_ia,
                          const real_type*  a_val,

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -37,10 +37,10 @@ namespace ReSolve
 
     // needed for matrix inf nrm
     void matrixRowSums(index_type        n,
-                         index_type        nnz,
-                         const index_type* a_ia,
-                         const real_type*  a_val,
-                         real_type*        result);
+                       index_type        nnz,
+                       const index_type* a_ia,
+                       const real_type*  a_val,
+                       real_type*        result);
 
   } // namespace cuda
 } // namespace ReSolve

--- a/resolve/cuda/cudaKernels.h
+++ b/resolve/cuda/cudaKernels.h
@@ -36,7 +36,7 @@ namespace ReSolve
                     const real_type*  diag);
 
     // needed for matrix inf nrm
-    void matrix_row_sums(index_type        n,
+    void matrixRowSums(index_type        n,
                          index_type        nnz,
                          const index_type* a_ia,
                          const real_type*  a_val,

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -37,10 +37,10 @@ namespace ReSolve
 
     // needed for matrix inf nrm
     void matrixRowSums(index_type  n,
-                         index_type  nnz,
-                         index_type* a_ia,
-                         real_type*  a_val,
-                         real_type*  result);
+                       index_type  nnz,
+                       index_type* a_ia,
+                       real_type*  a_val,
+                       real_type*  result);
 
     // needed for triangular solve
 
@@ -55,8 +55,8 @@ namespace ReSolve
                         real_type*  vec_out);
 
     void vectorInfNorm(index_type n,
-                         real_type* input,
-                         real_type* buffer,
-                         real_type* result);
+                       real_type* input,
+                       real_type* buffer,
+                       real_type* result);
   } // namespace hip
 } // namespace ReSolve

--- a/resolve/hip/hipKernels.h
+++ b/resolve/hip/hipKernels.h
@@ -36,7 +36,7 @@ namespace ReSolve
                     const real_type*  diag);
 
     // needed for matrix inf nrm
-    void matrix_row_sums(index_type  n,
+    void matrixRowSums(index_type  n,
                          index_type  nnz,
                          index_type* a_ia,
                          real_type*  a_val,
@@ -54,7 +54,7 @@ namespace ReSolve
                         real_type*  vec_in,
                         real_type*  vec_out);
 
-    void vector_inf_norm(index_type n,
+    void vectorInfNorm(index_type n,
                          real_type* input,
                          real_type* buffer,
                          real_type* result);

--- a/resolve/hip/hipKernels.hip
+++ b/resolve/hip/hipKernels.hip
@@ -442,7 +442,7 @@ namespace ReSolve {
     *
     * @todo Decide how to allow user to configure grid and block sizes.
     */
-    void matrix_row_sums(index_type n,
+    void matrixRowSums(index_type n,
                         index_type nnz,
                         index_type* a_ia,
                         real_type* a_val,
@@ -461,7 +461,7 @@ namespace ReSolve {
     *
     * @todo Decide how to allow user to configure grid and block sizes.
     */
-    void vector_inf_norm(index_type n,
+    void vectorInfNorm(index_type n,
                         real_type* input,
                         real_type* buffer,
                         real_type* result)

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -117,7 +117,6 @@ namespace ReSolve
                                        CUSPARSE_SPMV_CSR_ALG2,
                                        &bufferSize);
       error_sum += status;
-      mem_.deviceSynchronize();
       mem_.allocateBufferOnDevice(&buffer_spmv, bufferSize);
       workspace_->setSpmvMatrixDescriptor(matA);
       workspace_->setSpmvBuffer(buffer_spmv);
@@ -136,7 +135,6 @@ namespace ReSolve
                           CUSPARSE_SPMV_CSR_ALG2,
                           buffer_spmv);
     error_sum += status;
-    mem_.deviceSynchronize();
     if (status)
       out::error() << "Matvec status: " << status << ". "
                    << "Last error code: " << mem_.getLastDeviceError() << ".\n";
@@ -185,7 +183,7 @@ namespace ReSolve
       workspace_->setDr(d_r);
     }
 
-    cuda::matrix_row_sums(A->getNumRows(),
+    cuda::matrixRowSums(A->getNumRows(),
                           A->getNnz(),
                           A->getRowData(memory::DEVICE),
                           A->getValues(memory::DEVICE),

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -184,10 +184,10 @@ namespace ReSolve
     }
 
     cuda::matrixRowSums(A->getNumRows(),
-                          A->getNnz(),
-                          A->getRowData(memory::DEVICE),
-                          A->getValues(memory::DEVICE),
-                          d_r);
+                        A->getNnz(),
+                        A->getRowData(memory::DEVICE),
+                        A->getValues(memory::DEVICE),
+                        d_r);
 
     int status = cusolverSpDnrminf(workspace_->getCusolverSpHandle(),
                                    A->getNumRows(),

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -177,16 +177,16 @@ namespace ReSolve
 
     mem_.deviceSynchronize();
     hip::matrixRowSums(A->getNumRows(),
-                         A->getNnz(),
-                         A->getRowData(memory::DEVICE),
-                         A->getValues(memory::DEVICE),
-                         d_r);
+                       A->getNnz(),
+                       A->getRowData(memory::DEVICE),
+                       A->getValues(memory::DEVICE),
+                       d_r);
     mem_.deviceSynchronize();
 
     hip::vectorInfNorm(A->getNumRows(),
-                         d_r,
-                         workspace_->getNormBuffer(),
-                         norm);
+                       d_r,
+                       workspace_->getNormBuffer(),
+                       norm);
     return 0;
   }
 

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -176,14 +176,14 @@ namespace ReSolve
     }
 
     mem_.deviceSynchronize();
-    hip::matrix_row_sums(A->getNumRows(),
+    hip::matrixRowSums(A->getNumRows(),
                          A->getNnz(),
                          A->getRowData(memory::DEVICE),
                          A->getValues(memory::DEVICE),
                          d_r);
     mem_.deviceSynchronize();
 
-    hip::vector_inf_norm(A->getNumRows(),
+    hip::vectorInfNorm(A->getNumRows(),
                          d_r,
                          workspace_->getNormBuffer(),
                          norm);

--- a/resolve/random/RandomSketchingCountCuda.cpp
+++ b/resolve/random/RandomSketchingCountCuda.cpp
@@ -47,14 +47,12 @@ namespace ReSolve
    */
   int RandomSketchingCountCuda::Theta(vector_type* input, vector_type* output)
   {
-    mem_.deviceSynchronize();
     cuda::count_sketch_theta(n_,
                              k_rand_,
                              d_labels_,
                              d_flip_,
                              input->getData(memory::DEVICE),
                              output->getData(memory::DEVICE));
-    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -107,7 +105,6 @@ namespace ReSolve
     // then copy
     mem_.copyArrayHostToDevice(d_labels_, h_labels_, n_);
     mem_.copyArrayHostToDevice(d_flip_, h_flip_, n_);
-    mem_.deviceSynchronize();
 
     return 0;
   }
@@ -148,7 +145,6 @@ namespace ReSolve
 
     mem_.copyArrayHostToDevice(d_labels_, h_labels_, n_);
     mem_.copyArrayHostToDevice(d_flip_, h_flip_, n_);
-    mem_.deviceSynchronize();
 
     return 0;
   }

--- a/resolve/random/RandomSketchingCountHip.cpp
+++ b/resolve/random/RandomSketchingCountHip.cpp
@@ -47,7 +47,6 @@ namespace ReSolve
    */
   int RandomSketchingCountHip::Theta(vector_type* input, vector_type* output)
   {
-    mem_.deviceSynchronize();
     hip::count_sketch_theta(n_,
                             k_rand_,
                             d_labels_,

--- a/resolve/random/RandomSketchingFWHTCuda.cpp
+++ b/resolve/random/RandomSketchingFWHTCuda.cpp
@@ -66,15 +66,12 @@ namespace ReSolve
                         input->getData(memory::DEVICE),
                         d_aux_);
 
-    mem_.deviceSynchronize();
     cuda::FWHT(1, log2N_, d_aux_);
 
-    mem_.deviceSynchronize();
     cuda::FWHT_select(k_rand_,
                       d_perm_,
                       d_aux_,
                       output->getData(memory::DEVICE));
-    mem_.deviceSynchronize();
     return 0;
   }
 
@@ -210,7 +207,6 @@ namespace ReSolve
 
     mem_.copyArrayHostToDevice(d_perm_, h_perm_, k_rand_);
     mem_.copyArrayHostToDevice(d_D_, h_D_, n_);
-    mem_.deviceSynchronize();
 
     return 0;
   }

--- a/resolve/vector/VectorHandlerCpu.cpp
+++ b/resolve/vector/VectorHandlerCpu.cpp
@@ -184,7 +184,7 @@ namespace ReSolve
         x_data[i] = sum;
       }
       break;
-    default:
+    case 'N':
       assert((V->getSize() == x->getSize())
              && "gemv: Size mismatch! Size of V does not match size of x.");
       for (i = 0; i < n; ++i)
@@ -201,14 +201,13 @@ namespace ReSolve
         }
         x_data[i] = sum;
       }
-      if (transpose != 'N')
-      {
-        out::warning() << "Unrecognized transpose option " << transpose
-                       << " in gemv. Using non-transposed multivector.\n";
-      }
       break;
+    default:
+      out::error() << "Unrecognized transpose option " << transpose
+                   << " in gemv. Valid options are 'N' (not transposed) and 'T' (transposed).\n";
     } // switch
     x->setDataUpdated(memory::HOST);
+    return;
   }
 
   /**

--- a/resolve/vector/VectorHandlerCuda.cpp
+++ b/resolve/vector/VectorHandlerCuda.cpp
@@ -194,7 +194,7 @@ namespace ReSolve
                   x->getData(memory::DEVICE),
                   1);
       return;
-    default:
+    case 'N':
       assert((V->getSize() == x->getSize())
              && "gemv: Size mismatch! Size of V does not match size of x.");
       cublasDgemv(handle_cublas,
@@ -209,11 +209,11 @@ namespace ReSolve
                   &beta,
                   x->getData(memory::DEVICE),
                   1);
-      if (transpose != 'N')
-      {
-        out::warning() << "Unrecognized transpose option " << transpose
-                       << " in gemv. Using non-transposed multivector.\n";
-      }
+      break;
+    default:
+      out::error() << "Unrecognized transpose option " << transpose
+                   << " in gemv. Valid options are 'N' (not transposed) and 'T' (transposed).\n";
+      break;
     }
     x->setDataUpdated(memory::DEVICE);
   }

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -212,6 +212,7 @@ namespace ReSolve
       }
     }
     x->setDataUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
   }
 
   /**

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -88,6 +88,7 @@ namespace ReSolve
       out::error() << "scal returned error code " << st << "\n";
     }
     x->setDataUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
   }
 
   /**
@@ -109,7 +110,7 @@ namespace ReSolve
       workspace_->setNormBufferState(true);
     }
     real_type norm{0.0};
-    hip::vector_inf_norm(x->getSize(),
+    hip::vectorInfNorm(x->getSize(),
                          x->getData(memory::DEVICE),
                          workspace_->getNormBuffer(),
                          &norm);
@@ -135,6 +136,7 @@ namespace ReSolve
                   y->getData(memory::DEVICE),
                   1);
     y->setDataUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
   }
 
   /**
@@ -257,6 +259,7 @@ namespace ReSolve
                     size);                      // ldc
     }
     y->setDataUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
   }
 
   /**
@@ -309,6 +312,7 @@ namespace ReSolve
                     k);                           // ldc
     }
     res->setDataUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
   }
 
   /**
@@ -330,7 +334,8 @@ namespace ReSolve
     real_type* vec_data  = vec->getData(memory::DEVICE);
     index_type n         = vec->getSize();
     hip::scale(n, diag_data, vec_data);
-    vec->setDataUpdated(memory::DEVICE);
+    vec->setDataUpdated(memory::DEVICE);   
+    mem_.deviceSynchronize();
   }
 
   /**
@@ -352,6 +357,7 @@ namespace ReSolve
     index_type n         = vec->getSize();
     hip::diagSolve(n, diag_data, vec_data);
     vec->setDataUpdated(memory::DEVICE);
+    mem_.deviceSynchronize();
     return 0;
   }
 

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -190,7 +190,7 @@ namespace ReSolve
                     x->getData(memory::DEVICE),
                     1);
       return;
-    default:
+    case 'N':
       assert((V->getSize() == x->getSize())
              && "gemv: Size mismatch! Size of V does not match size of x.");
       rocblas_dgemv(handle_rocblas,
@@ -205,14 +205,15 @@ namespace ReSolve
                     &beta,
                     x->getData(memory::DEVICE),
                     1);
-      if (transpose != 'N')
-      {
-        out::warning() << "Unrecognized transpose option " << transpose
-                       << " in gemv. Using non-transposed multivector.\n";
-      }
+      break;
+    default:
+      out::error() << "Unrecognized transpose option " << transpose
+                   << " in gemv. Valid options are 'N' (not transposed) and 'T' (transposed).\n";
+      break;
     }
     x->setDataUpdated(memory::DEVICE);
     mem_.deviceSynchronize();
+    return;
   }
 
   /**

--- a/resolve/vector/VectorHandlerHip.cpp
+++ b/resolve/vector/VectorHandlerHip.cpp
@@ -111,9 +111,9 @@ namespace ReSolve
     }
     real_type norm{0.0};
     hip::vectorInfNorm(x->getSize(),
-                         x->getData(memory::DEVICE),
-                         workspace_->getNormBuffer(),
-                         &norm);
+                       x->getData(memory::DEVICE),
+                       workspace_->getNormBuffer(),
+                       &norm);
     return norm;
   }
 
@@ -334,7 +334,7 @@ namespace ReSolve
     real_type* vec_data  = vec->getData(memory::DEVICE);
     index_type n         = vec->getSize();
     hip::scale(n, diag_data, vec_data);
-    vec->setDataUpdated(memory::DEVICE);   
+    vec->setDataUpdated(memory::DEVICE);
     mem_.deviceSynchronize();
   }
 


### PR DESCRIPTION
The code was synchronizing unnecessarily in GramSchmidt and FGMRES, no matter the backend. This should be handled on the HIP backend (which it now is). Removed double synching and all syncing from generic and CUDA code. Established a convention that syncing is always post operation (so there is no need to sync pre, because the device is synced from the post of the last operation).

 ## Proposed changes
 
Removed unnecessary syncs. Updates changelogs.
 
 ## Checklist
 
 <!-- Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code. -->
 

- [ ] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [ ] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [x] The new code is documented.
- [ ] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.

