### PR TITLE
Add initial guess support for iterative solvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Added `diagSolve`, `max`, and `abs` vector operations.
 
+- Added initial guess support for FGMRES and randomized FGMRES iterative solvers.
+
 - Improved coding guidelines for developers on floating point conventions.
 
 - Made spack builds more robust.

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -153,13 +153,25 @@ namespace ReSolve
     int k1         = 0;
 
     real_type   t             = 0.0;
-    real_type   res_norm      = 0.0; // Residual norm used used for convergence
+    real_type   res_norm      = 0.0; // Residual norm used for convergence
     real_type   rhs_norm      = 0.0; // Right-hand side norm used for convergence
     real_type   true_res_norm = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
     real_type   true_rhs_norm = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
+    real_type   initial_rnorm = 0.0;
+    real_type   final_rnorm   = 0.0;
+    real_type   xnorm         = 0.0;
     real_type   tolrel;
     vector_type vec_v(n_);
     vector_type vec_z(n_);
+    vector_type x_initial(x->getSize());
+
+    x_initial.allocate(memspace_);
+    x_initial.copyFromExternal(x, memspace_, memspace_);
+
+    xnorm = vector_handler_->dot(&x_initial, &x_initial, memspace_);
+    xnorm = std::sqrt(xnorm);
+
+    bool check_initial_guess = (xnorm > MACHINE_EPSILON);
 
     // Compute initial residual norm.
     // V[0] = ||b - A*x0||         for right preconditioning
@@ -181,6 +193,29 @@ namespace ReSolve
     // True right-hand side norm ||b||
     true_rhs_norm = vector_handler_->dot(rhs, rhs, memspace_);
     true_rhs_norm = std::sqrt(true_rhs_norm);
+
+    initial_rnorm = true_res_norm;
+
+    if (check_initial_guess && initial_rnorm > true_rhs_norm)
+    {
+      out::warning() << "Initial guess has a larger residual than the zero vector. Ignoring initial guess.\n";
+
+      x->setToZero(memspace_);
+      x_initial.copyFromExternal(x, memspace_, memspace_);
+      check_initial_guess = false;
+
+      vec_Z_->setToZero(memspace_);
+      vec_V_->setToZero(memspace_);
+
+      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_, memspace_);
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
+
+      vec_v.setData(vec_V_->getData(0, memspace_), memspace_);
+
+      true_res_norm = vector_handler_->dot(&vec_v, &vec_v, memspace_);
+      true_res_norm = std::sqrt(true_res_norm);
+      initial_rnorm = true_res_norm;
+    }
 
     switch (preconditioner_->getSide())
     {
@@ -427,6 +462,16 @@ namespace ReSolve
 
       if (!outer_flag)
       {
+        final_rnorm = true_res_norm;
+
+        if (check_initial_guess && final_rnorm > initial_rnorm)
+        {
+          out::warning() << "Iterative solver did not improve the initial guess. Returning the initial guess.\n";
+          x->copyFromExternal(&x_initial, memspace_, memspace_);
+          final_rnorm   = initial_rnorm;
+          true_res_norm = final_rnorm;
+        }
+
         // Report the true relative residual norm
         final_residual_norm_ = true_res_norm / true_rhs_norm;
         total_iters_         = it;

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -160,7 +160,7 @@ namespace ReSolve
     real_type   initial_r_norm = 0.0;
     real_type   final_r_norm   = 0.0;
     real_type   x_norm         = 0.0;
-    real_type   tolrel;
+    real_type   tol_rel;
     vector_type vec_v(n_);
     vector_type vec_z(n_);
     vector_type x_initial(x->getSize());
@@ -253,10 +253,10 @@ namespace ReSolve
     {
       if (it == 0)
       {
-        tolrel = tol_ * res_norm;
-        if (std::abs(tolrel) < MACHINE_EPSILON)
+        tol_rel = tol_ * res_norm;
+        if (std::abs(tol_rel) < MACHINE_EPSILON)
         {
-          tolrel = MACHINE_EPSILON;
+          tol_rel = MACHINE_EPSILON;
         }
       }
 
@@ -370,7 +370,7 @@ namespace ReSolve
                            << std::scientific << std::setprecision(16)
                            << res_norm << "\n";
         // check convergence
-        if (i + 1 >= restart_ || res_norm <= tolrel || it >= maxit_)
+        if (i + 1 >= restart_ || res_norm <= tol_rel || it >= maxit_)
         {
           notconv = 0;
         }
@@ -436,7 +436,7 @@ namespace ReSolve
 
       /* test solution */
 
-      if (res_norm <= tolrel || it >= maxit_)
+      if (res_norm <= tol_rel || it >= maxit_)
       {
         // res_norm_aux = res_norm;
         outer_flag = 0;

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -157,9 +157,9 @@ namespace ReSolve
     real_type   rhs_norm      = 0.0; // Right-hand side norm used for convergence
     real_type   true_res_norm = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
     real_type   true_rhs_norm = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
-    real_type   initial_rnorm = 0.0;
-    real_type   final_rnorm   = 0.0;
-    real_type   xnorm         = 0.0;
+    real_type   initial_r_norm = 0.0;
+    real_type   final_r_norm   = 0.0;
+    real_type   x_norm         = 0.0;
     real_type   tolrel;
     vector_type vec_v(n_);
     vector_type vec_z(n_);
@@ -168,10 +168,10 @@ namespace ReSolve
     x_initial.allocate(memspace_);
     x_initial.copyFromExternal(x, memspace_, memspace_);
 
-    xnorm = vector_handler_->dot(&x_initial, &x_initial, memspace_);
-    xnorm = std::sqrt(xnorm);
+    x_norm = vector_handler_->dot(&x_initial, &x_initial, memspace_);
+    x_norm = std::sqrt(x_norm);
 
-    bool check_initial_guess = (xnorm > MACHINE_EPSILON);
+    bool check_initial_guess = (x_norm > MACHINE_EPSILON);
 
     // Compute initial residual norm.
     // V[0] = ||b - A*x0||         for right preconditioning
@@ -194,9 +194,9 @@ namespace ReSolve
     true_rhs_norm = vector_handler_->dot(rhs, rhs, memspace_);
     true_rhs_norm = std::sqrt(true_rhs_norm);
 
-    initial_rnorm = true_res_norm;
+    initial_r_norm = true_res_norm;
 
-    if (check_initial_guess && initial_rnorm > true_rhs_norm)
+    if (check_initial_guess && initial_r_norm > true_rhs_norm)
     {
       out::warning() << "Initial guess has a larger residual than the zero vector. Ignoring initial guess.\n";
 
@@ -214,7 +214,7 @@ namespace ReSolve
 
       true_res_norm = vector_handler_->dot(&vec_v, &vec_v, memspace_);
       true_res_norm = std::sqrt(true_res_norm);
-      initial_rnorm = true_res_norm;
+      initial_r_norm = true_res_norm;
     }
 
     switch (preconditioner_->getSide())
@@ -462,14 +462,14 @@ namespace ReSolve
 
       if (!outer_flag)
       {
-        final_rnorm = true_res_norm;
+        final_r_norm = true_res_norm;
 
-        if (check_initial_guess && final_rnorm > initial_rnorm)
+        if (check_initial_guess && final_r_norm > initial_r_norm)
         {
           out::warning() << "Iterative solver did not improve the initial guess. Returning the initial guess.\n";
           x->copyFromExternal(&x_initial, memspace_, memspace_);
-          final_rnorm   = initial_rnorm;
-          true_res_norm = final_rnorm;
+          final_r_norm   = initial_r_norm;
+          true_res_norm = final_r_norm;
         }
 
         // Report the true relative residual norm

--- a/resolve/LinSolverIterativeFGMRES.cpp
+++ b/resolve/LinSolverIterativeFGMRES.cpp
@@ -152,11 +152,11 @@ namespace ReSolve
     int k          = 0;
     int k1         = 0;
 
-    real_type   t             = 0.0;
-    real_type   res_norm      = 0.0; // Residual norm used for convergence
-    real_type   rhs_norm      = 0.0; // Right-hand side norm used for convergence
-    real_type   true_res_norm = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
-    real_type   true_rhs_norm = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
+    real_type   t              = 0.0;
+    real_type   res_norm       = 0.0; // Residual norm used for convergence
+    real_type   rhs_norm       = 0.0; // Right-hand side norm used for convergence
+    real_type   true_res_norm  = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
+    real_type   true_rhs_norm  = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
     real_type   initial_r_norm = 0.0;
     real_type   final_r_norm   = 0.0;
     real_type   x_norm         = 0.0;
@@ -212,8 +212,8 @@ namespace ReSolve
 
       vec_v.setData(vec_V_->getData(0, memspace_), memspace_);
 
-      true_res_norm = vector_handler_->dot(&vec_v, &vec_v, memspace_);
-      true_res_norm = std::sqrt(true_res_norm);
+      true_res_norm  = vector_handler_->dot(&vec_v, &vec_v, memspace_);
+      true_res_norm  = std::sqrt(true_res_norm);
       initial_r_norm = true_res_norm;
     }
 
@@ -468,7 +468,7 @@ namespace ReSolve
         {
           out::warning() << "Iterative solver did not improve the initial guess. Returning the initial guess.\n";
           x->copyFromExternal(&x_initial, memspace_, memspace_);
-          final_r_norm   = initial_r_norm;
+          final_r_norm  = initial_r_norm;
           true_res_norm = final_r_norm;
         }
 

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -178,9 +178,9 @@ namespace ReSolve
     real_type   rhs_norm      = 0.0; // Right-hand side norm used for convergence
     real_type   true_res_norm = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
     real_type   true_rhs_norm = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
-    real_type   initial_rnorm = 0.0;
-    real_type   final_rnorm   = 0.0;
-    real_type   xnorm         = 0.0;
+    real_type   initial_r_norm = 0.0;
+    real_type   final_r_norm   = 0.0;
+    real_type   x_norm         = 0.0;
     real_type   tolrel;
     vector_type vec_v(n_);
     vector_type vec_z(n_);
@@ -190,10 +190,10 @@ namespace ReSolve
     x_initial.allocate(memspace_);
     x_initial.copyFromExternal(x, memspace_, memspace_);
 
-    xnorm = vector_handler_->dot(&x_initial, &x_initial, memspace_);
-    xnorm = std::sqrt(xnorm);
+    x_norm = vector_handler_->dot(&x_initial, &x_initial, memspace_);
+    x_norm = std::sqrt(x_norm);
 
-    bool check_initial_guess = (xnorm > MACHINE_EPSILON);
+    bool check_initial_guess = (x_norm > MACHINE_EPSILON);
 
     // Compute initial residual norm.
     // V[0] = ||b - A*x0||         for right preconditioning
@@ -216,9 +216,9 @@ namespace ReSolve
     true_rhs_norm = vector_handler_->dot(rhs, rhs, memspace_);
     true_rhs_norm = std::sqrt(true_rhs_norm);
 
-    initial_rnorm = true_res_norm;
+    initial_r_norm = true_res_norm;
 
-    if (check_initial_guess && initial_rnorm > true_rhs_norm)
+    if (check_initial_guess && initial_r_norm > true_rhs_norm)
     {
       out::warning() << "Initial guess has a larger residual than the zero vector. Ignoring initial guess.\n";
 
@@ -236,7 +236,7 @@ namespace ReSolve
 
       true_res_norm = vector_handler_->dot(&vec_v, &vec_v, memspace_);
       true_res_norm = std::sqrt(true_res_norm);
-      initial_rnorm = true_res_norm;
+      initial_r_norm = true_res_norm;
     }
 
     // Left preconditioning uses preconditioned norms for convergence
@@ -522,14 +522,14 @@ namespace ReSolve
         // Compute the true residual norm = ||b - A*x||
         true_res_norm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
         true_res_norm = std::sqrt(true_res_norm);
-        final_rnorm   = true_res_norm;
+        final_r_norm   = true_res_norm;
 
-        if (check_initial_guess && final_rnorm > initial_rnorm)
+        if (check_initial_guess && final_r_norm > initial_r_norm)
         {
           out::warning() << "Iterative solver did not improve the initial guess. Returning the initial guess.\n";
           x->copyFromExternal(&x_initial, memspace_, memspace_);
-          final_rnorm   = initial_rnorm;
-          true_res_norm = final_rnorm;
+          final_r_norm   = initial_r_norm;
+          true_res_norm = final_r_norm;
         }
 
         io::Logger::misc() << "End of cycle, COMPUTED norm of residual "

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -181,7 +181,7 @@ namespace ReSolve
     real_type   initial_r_norm = 0.0;
     real_type   final_r_norm   = 0.0;
     real_type   x_norm         = 0.0;
-    real_type   tolrel;
+    real_type   tol_rel;
     vector_type vec_v(n_);
     vector_type vec_z(n_);
     vector_type vec_s(k_rand_);
@@ -278,10 +278,10 @@ namespace ReSolve
     {
       if (it == 0)
       {
-        tolrel = tol_ * res_norm;
-        if (std::abs(tolrel) < MACHINE_EPSILON)
+        tol_rel = tol_ * res_norm;
+        if (std::abs(tol_rel) < MACHINE_EPSILON)
         {
-          tolrel = MACHINE_EPSILON;
+          tol_rel = MACHINE_EPSILON;
         }
       }
 
@@ -417,7 +417,7 @@ namespace ReSolve
                            << std::scientific << std::setprecision(16)
                            << res_norm << "\n";
         // check convergence
-        if (i + 1 >= restart_ || res_norm <= tolrel || it >= maxit_)
+        if (i + 1 >= restart_ || res_norm <= tol_rel || it >= maxit_)
         {
           notconv = 0;
         }
@@ -482,7 +482,7 @@ namespace ReSolve
       }
 
       /* test solution */
-      if (res_norm <= tolrel || it >= maxit_)
+      if (res_norm <= tol_rel || it >= maxit_)
       {
         outer_flag = 0;
       }

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -173,11 +173,11 @@ namespace ReSolve
     int        k;
     int        k1;
 
-    real_type   t             = 0.0;
-    real_type   res_norm      = 0.0; // Residual norm used for convergence
-    real_type   rhs_norm      = 0.0; // Right-hand side norm used for convergence
-    real_type   true_res_norm = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
-    real_type   true_rhs_norm = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
+    real_type   t              = 0.0;
+    real_type   res_norm       = 0.0; // Residual norm used for convergence
+    real_type   rhs_norm       = 0.0; // Right-hand side norm used for convergence
+    real_type   true_res_norm  = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
+    real_type   true_rhs_norm  = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
     real_type   initial_r_norm = 0.0;
     real_type   final_r_norm   = 0.0;
     real_type   x_norm         = 0.0;
@@ -234,8 +234,8 @@ namespace ReSolve
 
       vec_v.setData(vec_V_->getData(0, memspace_), memspace_);
 
-      true_res_norm = vector_handler_->dot(&vec_v, &vec_v, memspace_);
-      true_res_norm = std::sqrt(true_res_norm);
+      true_res_norm  = vector_handler_->dot(&vec_v, &vec_v, memspace_);
+      true_res_norm  = std::sqrt(true_res_norm);
       initial_r_norm = true_res_norm;
     }
 
@@ -522,13 +522,13 @@ namespace ReSolve
         // Compute the true residual norm = ||b - A*x||
         true_res_norm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
         true_res_norm = std::sqrt(true_res_norm);
-        final_r_norm   = true_res_norm;
+        final_r_norm  = true_res_norm;
 
         if (check_initial_guess && final_r_norm > initial_r_norm)
         {
           out::warning() << "Iterative solver did not improve the initial guess. Returning the initial guess.\n";
           x->copyFromExternal(&x_initial, memspace_, memspace_);
-          final_r_norm   = initial_r_norm;
+          final_r_norm  = initial_r_norm;
           true_res_norm = final_r_norm;
         }
 

--- a/resolve/LinSolverIterativeRandFGMRES.cpp
+++ b/resolve/LinSolverIterativeRandFGMRES.cpp
@@ -174,14 +174,26 @@ namespace ReSolve
     int        k1;
 
     real_type   t             = 0.0;
-    real_type   res_norm      = 0.0; // Residual norm used used for convergence
+    real_type   res_norm      = 0.0; // Residual norm used for convergence
     real_type   rhs_norm      = 0.0; // Right-hand side norm used for convergence
     real_type   true_res_norm = 0.0; // True (unpreconditioned) residual norm ||b - Ax|| for reporting
     real_type   true_rhs_norm = 0.0; // True (unpreconditioned) right-hand side norm ||b|| for reporting
+    real_type   initial_rnorm = 0.0;
+    real_type   final_rnorm   = 0.0;
+    real_type   xnorm         = 0.0;
     real_type   tolrel;
     vector_type vec_v(n_);
     vector_type vec_z(n_);
     vector_type vec_s(k_rand_);
+    vector_type x_initial(x->getSize());
+
+    x_initial.allocate(memspace_);
+    x_initial.copyFromExternal(x, memspace_, memspace_);
+
+    xnorm = vector_handler_->dot(&x_initial, &x_initial, memspace_);
+    xnorm = std::sqrt(xnorm);
+
+    bool check_initial_guess = (xnorm > MACHINE_EPSILON);
 
     // Compute initial residual norm.
     // V[0] = ||b - A*x0||         for right preconditioning
@@ -203,6 +215,29 @@ namespace ReSolve
     // True right-hand side norm ||b||
     true_rhs_norm = vector_handler_->dot(rhs, rhs, memspace_);
     true_rhs_norm = std::sqrt(true_rhs_norm);
+
+    initial_rnorm = true_res_norm;
+
+    if (check_initial_guess && initial_rnorm > true_rhs_norm)
+    {
+      out::warning() << "Initial guess has a larger residual than the zero vector. Ignoring initial guess.\n";
+
+      x->setToZero(memspace_);
+      x_initial.copyFromExternal(x, memspace_, memspace_);
+      check_initial_guess = false;
+
+      vec_Z_->setToZero(memspace_);
+      vec_V_->setToZero(memspace_);
+
+      rhs->copyToExternal(vec_V_->getData(memspace_), 0, memspace_, memspace_);
+      matrix_handler_->matvec(A_, x, vec_V_, &MINUS_ONE, &ONE, memspace_);
+
+      vec_v.setData(vec_V_->getData(0, memspace_), memspace_);
+
+      true_res_norm = vector_handler_->dot(&vec_v, &vec_v, memspace_);
+      true_res_norm = std::sqrt(true_res_norm);
+      initial_rnorm = true_res_norm;
+    }
 
     // Left preconditioning uses preconditioned norms for convergence
     if (preconditioner_->getSide() == Preconditioner::LEFT)
@@ -487,6 +522,15 @@ namespace ReSolve
         // Compute the true residual norm = ||b - A*x||
         true_res_norm = vector_handler_->dot(vec_V_, vec_V_, memspace_);
         true_res_norm = std::sqrt(true_res_norm);
+        final_rnorm   = true_res_norm;
+
+        if (check_initial_guess && final_rnorm > initial_rnorm)
+        {
+          out::warning() << "Iterative solver did not improve the initial guess. Returning the initial guess.\n";
+          x->copyFromExternal(&x_initial, memspace_, memspace_);
+          final_rnorm   = initial_rnorm;
+          true_res_norm = final_rnorm;
+        }
 
         io::Logger::misc() << "End of cycle, COMPUTED norm of residual "
                            << std::scientific << std::setprecision(16)

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -177,6 +177,110 @@ int test(int argc, char* argv[])
   status = solver.solve(vec_rhs, &vec_x);
   error_sum += status;
 
+  // Test initial guess handling with separate solver objects.
+  //
+  // A large initial guess should be rejected because it increases the
+  // residual compared with the zero vector. A later accepted initial guess
+  // should not be returned with a larger residual than it had on input.
+  const real_type residual_tol = 1e-10;
+
+  // Create a large initial guess with a larger residual than the zero vector.
+  vector_type bad_guess_x(A->getNumRows());
+  bad_guess_x.allocate(ReSolve::memory::HOST);
+  bad_guess_x.allocate(memspace);
+  bad_guess_x.setToConst(1.0e6, memspace);
+
+  ReSolve::SystemSolver bad_guess_solver(&workspace, "none", "none", method, "ilu0", "none");
+  bad_guess_solver.setGramSchmidtMethod(gs);
+  bad_guess_solver.getIterativeSolver().setCliParam("maxit", "2500");
+  bad_guess_solver.getIterativeSolver().setCliParam("tol", "1e-12");
+
+  matrix_handler.setValuesChanged(true, memspace);
+
+  status = bad_guess_solver.setMatrix(A);
+  error_sum += status;
+
+  if (method == "randgmres")
+  {
+    bad_guess_solver.setSketchingMethod(sketch);
+  }
+
+  bad_guess_solver.getIterativeSolver().setCliParam("flexible", flexible);
+  bad_guess_solver.getIterativeSolver().setCliParam("restart", "200");
+
+  status = bad_guess_solver.preconditionerSetup(side);
+  error_sum += status;
+
+  const real_type bad_guess_rnorm = bad_guess_solver.getResidualNorm(vec_rhs, &bad_guess_x);
+
+  if (bad_guess_rnorm <= 1.0)
+  {
+    std::cout << "Bad initial guess test setup failed:\n";
+    std::cout << std::scientific << std::setprecision(16)
+              << "\tInitial guess residual : " << bad_guess_rnorm << "\n"
+              << "\tZero-vector residual   : " << 1.0 << "\n\n";
+    error_sum++;
+  }
+
+  status = bad_guess_solver.solve(vec_rhs, &bad_guess_x);
+  error_sum += status;
+
+  const real_type rejected_guess_rnorm = bad_guess_solver.getResidualNorm(vec_rhs, &bad_guess_x);
+
+  if (rejected_guess_rnorm > bad_guess_rnorm + residual_tol)
+  {
+    std::cout << "Bad initial guess rejection check failed:\n";
+    std::cout << std::scientific << std::setprecision(16)
+              << "\tInitial guess residual : " << bad_guess_rnorm << "\n"
+              << "\tReturned residual      : " << rejected_guess_rnorm << "\n\n";
+    error_sum++;
+  }
+
+  // Use a scaled converged solution as a nonzero initial guess.
+  vector_type vec_x_guess(vec_x.getSize());
+  vec_x_guess.copyFromExternal(&vec_x, memspace, memspace);
+  vector_handler.scal(0.9, &vec_x_guess, memspace);
+
+  ReSolve::SystemSolver accepted_guess_solver(&workspace, "none", "none", method, "ilu0", "none");
+  accepted_guess_solver.setGramSchmidtMethod(gs);
+  accepted_guess_solver.getIterativeSolver().setCliParam("maxit", "2500");
+  accepted_guess_solver.getIterativeSolver().setCliParam("tol", "1e-12");
+
+  matrix_handler.setValuesChanged(true, memspace);
+
+  status = accepted_guess_solver.setMatrix(A);
+  error_sum += status;
+
+  if (method == "randgmres")
+  {
+    accepted_guess_solver.setSketchingMethod(sketch);
+  }
+
+  accepted_guess_solver.getIterativeSolver().setCliParam("flexible", flexible);
+  accepted_guess_solver.getIterativeSolver().setCliParam("restart", "200");
+
+  status = accepted_guess_solver.preconditionerSetup(side);
+  error_sum += status;
+
+  const real_type initial_guess_rnorm = accepted_guess_solver.getResidualNorm(vec_rhs, &vec_x_guess);
+
+  if (initial_guess_rnorm < 1.0)
+  {
+    status = accepted_guess_solver.solve(vec_rhs, &vec_x_guess);
+    error_sum += status;
+
+    const real_type final_guess_rnorm = accepted_guess_solver.getResidualNorm(vec_rhs, &vec_x_guess);
+
+    if (final_guess_rnorm > initial_guess_rnorm + residual_tol)
+    {
+      std::cout << "Initial guess correction check failed:\n";
+      std::cout << std::scientific << std::setprecision(16)
+                << "\tInitial guess residual : " << initial_guess_rnorm << "\n"
+                << "\tFinal residual         : " << final_guess_rnorm << "\n\n";
+      error_sum++;
+    }
+  }
+
   // Check results and print summary
   helper.setSystem(A, vec_rhs, &vec_x);
 


### PR DESCRIPTION
## Description

The current solver already uses `solve(rhs, x)` for the initial guess path. This PR adds the remaining safeguards requested in #376 and adds tests for the bad guess and accepted guess cases.
 
Closes #376 
 
@shakedregev 

 ## Proposed changes

- Warn and ignore the initial guess if its residual is worse than the zero-vector residual.
- Restore the accepted initial guess if the correction does not improve it.
- Preserve the current left/right preconditioning behavior and true residual reporting.
- Add tests for bad and accepted initial guesses in `testSysGmres.cpp`.
- Update `CHANGELOG.md`.

 
 ## Checklist
 
 <!-- Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code. -->
 

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments

During CUDA validation, the warning build surfaced existing CUDA deprecation warnings in unrelated direct-solver/cuSPARSE/cuSolverRF paths. The modified files compiled without new warnings.

One manual CUDA `sysGmres.exe` run using the `ACTIVSg200` matrix hit an existing Gram-Schmidt zero-norm assertion. The same example passed on CUDA with the smaller `A_asymmetric01/b_asymmetric01` test pair, and the targeted CUDA GMRES tests passed.
