### PR TITLE
Fix make test_install failure

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -112,7 +112,7 @@ install(FILES ${PROJECT_SOURCE_DIR}/tests/functionality/TestHelper.hpp
 # Shell script argumets: 1. Path to where resolve is installed. 2. Path to data
 # directory. 3. CXX compiler (propagated so consumer uses same ABI as ReSolve).
 add_custom_target(
-  test_install COMMAND ${CONSUMER_PATH}/test.sh ${CMAKE_INSTALL_PREFIX}
-                       ${test_data_dir} ${sym_matrix_path} ${sym_rhs_path}
-                       ${CMAKE_CXX_COMPILER}
+  test_install
+  COMMAND ${CONSUMER_PATH}/test.sh ${CMAKE_INSTALL_PREFIX} ${test_data_dir}
+          ${sym_matrix_path} ${sym_rhs_path} ${CMAKE_CXX_COMPILER}
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -110,8 +110,9 @@ install(FILES ${PROJECT_SOURCE_DIR}/tests/functionality/TestHelper.hpp
 )
 
 # Shell script argumets: 1. Path to where resolve is installed. 2. Path to data
-# directory
+# directory. 3. CXX compiler (propagated so consumer uses same ABI as ReSolve).
 add_custom_target(
   test_install COMMAND ${CONSUMER_PATH}/test.sh ${CMAKE_INSTALL_PREFIX}
                        ${test_data_dir} ${sym_matrix_path} ${sym_rhs_path}
+                       ${CMAKE_CXX_COMPILER}
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -110,7 +110,7 @@ install(FILES ${PROJECT_SOURCE_DIR}/tests/functionality/TestHelper.hpp
 )
 
 # Shell script argumets: 1. Path to where resolve is installed. 2. Path to data
-# directory. 3. CXX compiler (propagated so consumer uses same ABI as ReSolve).
+# directory. 3. CXX compiler (propagated so consumer uses same API as ReSolve).
 add_custom_target(
   test_install
   COMMAND ${CONSUMER_PATH}/test.sh ${CMAKE_INSTALL_PREFIX} ${test_data_dir}

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script get executed in `make test_install`. 
+# This script get executed in `make test_install`.
 
 # Defines where Resolve is and is set in line #47 in examples/CMakeLists.txt
 export ReSolve_DIR=${1}
@@ -18,6 +18,9 @@ echo ${MATRICES}
 export RHS=${4}
 echo ${RHS}
 
+# CXX compiler used to build ReSolve -- must match to avoid ABI mismatch
+export CXX_COMPILER=${5}
+
 # Locate source of the consumer test app
 export INSTALL_BUILD_CONSUME=${ReSolve_DIR}/share/examples/resolve_consumer
 echo ${INSTALL_BUILD_CONSUME}
@@ -27,7 +30,8 @@ mkdir -p ${INSTALL_BUILD_CONSUME}/build
 rm -rf ${INSTALL_BUILD_CONSUME}/build/* &&
 
 cmake -B ${INSTALL_BUILD_CONSUME}/build -S ${INSTALL_BUILD_CONSUME} -DReSolve_DATA_DIR=${DATA_DIR} \
-  -DReSolve_MATRICES=${MATRICES} -DReSolve_RHS=${RHS} -DReSolve_DIR=${ReSolve_DIR} &&
+  -DReSolve_MATRICES=${MATRICES} -DReSolve_RHS=${RHS} -DReSolve_DIR=${ReSolve_DIR} \
+  ${CXX_COMPILER:+-DCMAKE_CXX_COMPILER=${CXX_COMPILER}} &&
 
 cmake --build ${INSTALL_BUILD_CONSUME}/build -- -j 12 &&
 


### PR DESCRIPTION
## Description
 
 Target `make test_install` fails if the default compiler on the installation machine is different from the compiler Re::Solve is built with, for example, if you build Re::Solve with GCC on a Mac.

 ## Proposed changes
 
 Test script should pass compiler installation to the consumer test, together with all the other build info.

 ## Checklist
 
 
- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- N/A I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 <!-- If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc. -->
