### PR TITLE
Fix potential failure in `make test_install`

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -113,6 +113,7 @@ install(FILES ${PROJECT_SOURCE_DIR}/tests/functionality/TestHelper.hpp
 # directory. 3. CXX compiler (propagated so consumer uses same API as ReSolve).
 add_custom_target(
   test_install
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target install
   COMMAND ${CONSUMER_PATH}/test.sh ${CMAKE_INSTALL_PREFIX} ${test_data_dir}
           ${sym_matrix_path} ${sym_rhs_path} ${CMAKE_CXX_COMPILER}
 )


### PR DESCRIPTION
## Description
 
If `make test_install` is called before `make install` call, the test will fail giving misleading feedback that something is wrong with the installation configuration. See e.g. #428 

 ## Proposed changes
 
 Enforce installation as a part of the target `test_install`. One-line fix suggested.

 ## Checklist
 

- [ ] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [ ] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A There are unit tests for the new code.
- N/A The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- N/A I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 <!-- If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc. -->
