### PR TITLE
Protect MemoryHandler alias with a namespace

### DIFF
--- a/resolve/MemoryUtils.hpp
+++ b/resolve/MemoryUtils.hpp
@@ -131,10 +131,8 @@ namespace ReSolve
 // Check if GPU support is enabled in Re::Solve and set appropriate device memory manager.
 #if defined RESOLVE_USE_CUDA
 #include <resolve/cuda/CudaMemory.hpp>
-using MemoryHandler = ReSolve::MemoryUtils<ReSolve::memory::Cuda>;
 #elif defined RESOLVE_USE_HIP
 #include <resolve/hip/HipMemory.hpp>
-using MemoryHandler = ReSolve::MemoryUtils<ReSolve::memory::Hip>;
 #else
 #error Unrecognized device, probably bug in CMake configuration
 #endif
@@ -143,6 +141,18 @@ using MemoryHandler = ReSolve::MemoryUtils<ReSolve::memory::Hip>;
 
 // If no GPU support is present, set device memory manager to a dummy object.
 #include <resolve/cpu/CpuMemory.hpp>
-using MemoryHandler = ReSolve::MemoryUtils<ReSolve::memory::Cpu>;
 
 #endif
+
+namespace ReSolve
+{
+#ifdef RESOLVE_USE_GPU
+#if defined RESOLVE_USE_CUDA
+  using MemoryHandler = MemoryUtils<memory::Cuda>;
+#elif defined RESOLVE_USE_HIP
+  using MemoryHandler = MemoryUtils<memory::Hip>;
+#endif
+#else
+  using MemoryHandler = MemoryUtils<memory::Cpu>;
+#endif
+} // namespace ReSolve


### PR DESCRIPTION
## Description
 
Protect `MemoryHandler` alias with `ReSolve` namespace. 
 

 ## Proposed changes
 
 ` MemoryHandler` was placed in global namespace by accident. Now it is within `ReSolve` namespace.

 ## Checklist
 
 <!-- Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code. -->
 

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- N/A (see #444) I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [ ] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- N/A I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 <!-- If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc. -->
