### PR TITLE
Configure data types on build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 
 - Remove automatic memory allocation and memory syncing in various memory management functions and require the user to explicitly manage their own memory.
 
+- Set Re::Solve's real type and matrix/vector index type at CMake configuration time.
+
 ## Changes to Re::Solve in release 0.99.2
 
 ### Major Features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,52 @@ set(RESOLVE_CTEST_OUTPUT_DIR
     CACHE PATH "Directory where CTest outputs are saved"
 )
 
+# Configurable Re::Solve scalar types (see resolve/Common.hpp). Cache
+# variables with a STRINGS property show up as a pull-down menu in cmake-gui
+# and ccmake.
+set(RESOLVE_REAL_TYPE
+    "double"
+    CACHE STRING "Floating-point type used for ReSolve::real_type"
+)
+set_property(CACHE RESOLVE_REAL_TYPE PROPERTY STRINGS "double" "float")
+
+set(RESOLVE_INDEX_TYPE
+    "int32"
+    CACHE STRING "Integer type used for ReSolve::index_type"
+)
+set_property(CACHE RESOLVE_INDEX_TYPE PROPERTY STRINGS "int32" "int64" "uint32"
+                                                "uint64"
+)
+
+if(RESOLVE_REAL_TYPE STREQUAL "double")
+  set(RESOLVE_REAL_TYPE_CPP "double")
+elseif(RESOLVE_REAL_TYPE STREQUAL "float")
+  set(RESOLVE_REAL_TYPE_CPP "float")
+else()
+  message(
+    FATAL_ERROR
+    "Unsupported RESOLVE_REAL_TYPE '${RESOLVE_REAL_TYPE}'. Valid options are: double, float."
+  )
+endif()
+
+if(RESOLVE_INDEX_TYPE STREQUAL "int32")
+  set(RESOLVE_INDEX_TYPE_CPP "std::int32_t")
+elseif(RESOLVE_INDEX_TYPE STREQUAL "int64")
+  set(RESOLVE_INDEX_TYPE_CPP "std::int64_t")
+elseif(RESOLVE_INDEX_TYPE STREQUAL "uint32")
+  set(RESOLVE_INDEX_TYPE_CPP "std::uint32_t")
+elseif(RESOLVE_INDEX_TYPE STREQUAL "uint64")
+  set(RESOLVE_INDEX_TYPE_CPP "std::uint64_t")
+else()
+  message(
+    FATAL_ERROR
+    "Unsupported RESOLVE_INDEX_TYPE '${RESOLVE_INDEX_TYPE}'. Valid options are: int32, int64, uint32, uint64."
+  )
+endif()
+
+message(STATUS "Re::Solve real_type set to ${RESOLVE_REAL_TYPE_CPP}")
+message(STATUS "Re::Solve index_type set to ${RESOLVE_INDEX_TYPE_CPP}")
+
 # update this if more fortran code is added. this should be good enough for now
 # though
 if(RESOLVE_USE_LUSOL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,8 @@ set(RESOLVE_CTEST_OUTPUT_DIR
     CACHE PATH "Directory where CTest outputs are saved"
 )
 
-# Configurable Re::Solve scalar types (see resolve/Common.hpp). Cache
-# variables with a STRINGS property show up as a pull-down menu in cmake-gui
-# and ccmake.
+# Configurable Re::Solve scalar types (see resolve/Common.hpp). Cache variables
+# with a STRINGS property show up as a pull-down menu in cmake-gui and ccmake.
 set(RESOLVE_REAL_TYPE
     "double"
     CACHE STRING "Floating-point type used for ReSolve::real_type"
@@ -62,8 +61,8 @@ set(RESOLVE_INDEX_TYPE
     "int32"
     CACHE STRING "Integer type used for ReSolve::index_type"
 )
-set_property(CACHE RESOLVE_INDEX_TYPE PROPERTY STRINGS "int32" "int64" "uint32"
-                                                "uint64"
+set_property(
+  CACHE RESOLVE_INDEX_TYPE PROPERTY STRINGS "int32" "int64" "uint32" "uint64"
 )
 
 if(RESOLVE_REAL_TYPE STREQUAL "double")
@@ -73,7 +72,7 @@ elseif(RESOLVE_REAL_TYPE STREQUAL "float")
 else()
   message(
     FATAL_ERROR
-    "Unsupported RESOLVE_REAL_TYPE '${RESOLVE_REAL_TYPE}'. Valid options are: double, float."
+      "Unsupported RESOLVE_REAL_TYPE '${RESOLVE_REAL_TYPE}'. Valid options are: double, float."
   )
 endif()
 
@@ -88,7 +87,7 @@ elseif(RESOLVE_INDEX_TYPE STREQUAL "uint64")
 else()
   message(
     FATAL_ERROR
-    "Unsupported RESOLVE_INDEX_TYPE '${RESOLVE_INDEX_TYPE}'. Valid options are: int32, int64, uint32, uint64."
+      "Unsupported RESOLVE_INDEX_TYPE '${RESOLVE_INDEX_TYPE}'. Valid options are: int32, int64, uint32, uint64."
   )
 endif()
 

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -1,16 +1,10 @@
 #pragma once
 
 #include <limits>
-
-// TODO: temporary
-#include <cstdint>
+#include <resolve/resolve_defs.hpp>
 
 namespace ReSolve
 {
-
-  /// @todo Provide CMake option to se these types at config time
-  using real_type  = double;
-  using index_type = std::int32_t;
 
   namespace constants
   {

--- a/resolve/Common.hpp
+++ b/resolve/Common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <limits>
+
 #include <resolve/resolve_defs.hpp>
 
 namespace ReSolve

--- a/resolve/resolve_defs.hpp.in
+++ b/resolve/resolve_defs.hpp.in
@@ -3,6 +3,8 @@
 #ifndef __RESOLVE_DEFINITIONS_HPP__
 #define __RESOLVE_DEFINITIONS_HPP__
 
+#include <cstdint>
+
 #cmakedefine RESOLVE_USE_GPU
 #cmakedefine RESOLVE_USE_CUDA
 #cmakedefine RESOLVE_USE_HIP
@@ -26,5 +28,12 @@
 #endif
 #endif
 
+namespace ReSolve
+{
+  // Set at configure time via the RESOLVE_REAL_TYPE / RESOLVE_INDEX_TYPE
+  // CMake cache variables.
+  using real_type  = @RESOLVE_REAL_TYPE_CPP@;
+  using index_type = @RESOLVE_INDEX_TYPE_CPP@;
+} // namespace ReSolve
 
 #endif // __RESOLVE_DEFINITIONS_HPP__


### PR DESCRIPTION
## Description
 
Makes Re::Solve's core scalar type (`real_type`) and matrix/vector index type (`index_type`) configurable at CMake configure time instead of hard-coded in `resolve/Common.hpp`.

 
 Closes #161
 
 <!-- Mention users/developers who may have interest in this PR, e.g. @supewhiskars --> 
 

 ## Proposed changes
 
### Changes

- **`CMakeLists.txt`**: added two cache variables, `RESOLVE_REAL_TYPE` (default `double`, alternative `float`) and `RESOLVE_INDEX_TYPE` (default `int32`, alternatives `int64`, `uint32`, `uint64`). Each has a `STRINGS` property set, so `cmake-gui`/`ccmake` render them as pull-down menus. The selected option is validated and mapped to the corresponding C++ type (e.g. `int64` → `std::int32_t`/`std::int64_t`), with a `FATAL_ERROR` for any unrecognized value.
- **`resolve/resolve_defs.hpp.in`**: the existing generated config header now also emits `namespace ReSolve { using real_type = ...; using index_type = ...; }`, substituted at configure time from the new cache variables (plus a `<cstdint>` include for the fixed-width integer types).
- **`resolve/Common.hpp`**: removed the hard-coded `using real_type = double; using index_type = std::int32_t;` (and the accompanying `@todo`), replaced with `#include <resolve/resolve_defs.hpp>` — the same pattern already used by `MemoryUtils.hpp` for pulling in generated configuration.

### Behavior

- Default build is unchanged: `real_type = double`, `index_type = std::int32_t`.
- `real_type`/`index_type` are now visible/settable to any consumer of the header, propagated automatically to all 50+ files that include `Common.hpp`, with no changes required at call sites.
 
 ## Checklist
 
 <!-- Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code. -->
 

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- N/A (see #444) I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [ ] CPU backend
     - [ ] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
 <!-- If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc. -->
