### PR TITLE
Fix device allocations in GLU example

### DIFF
--- a/examples/ExampleHelper.hpp
+++ b/examples/ExampleHelper.hpp
@@ -163,6 +163,7 @@ namespace ReSolve
         if (res_ == nullptr)
         {
           res_ = new ReSolve::vector::Vector(A->getNumRows());
+          res_->allocate(memspace_);
         }
         else
         {
@@ -170,6 +171,7 @@ namespace ReSolve
           {
             delete res_;
             res_ = new ReSolve::vector::Vector(A->getNumRows());
+            res_->allocate(memspace_);
           }
         }
 

--- a/examples/gluRefactor.cpp
+++ b/examples/gluRefactor.cpp
@@ -220,10 +220,13 @@ int gluRefactor(int argc, char* argv[])
     mat_file.close();
     rhs_file.close();
 
-    // Copy data to device
-    A->allocateMatrixData(memory::DEVICE);
+    // Allocate device storage once, then update it for each system
+    if (i == 1)
+    {
+      A->allocateMatrixData(memory::DEVICE);
+      vec_rhs->allocate(memory::DEVICE);
+    }
     A->syncData(memory::DEVICE);
-    vec_rhs->allocate(memory::DEVICE);
     vec_rhs->syncData(memory::DEVICE);
     RESOLVE_RANGE_POP("File input");
 


### PR DESCRIPTION
## Description
 
Fixes the memory and CUDA errors in `gluRefactor` reported in #444.

I used `git bisect` and found that commit `a93fb65` from #436 introduced the failure. Its parent commit, `f79151e`, does not produce the error.

I found two memory allocation issues:

1. `ExampleHelper::printSummary()` creates `res_` but does not allocate it.
2. `gluRefactor.cpp` allocates the reused matrix and RHS device memory on every loop instead of only once.

Closes #444
 
@shakedregev 
 

 ## Proposed changes
 
- Allocate `res_` when it is created or resized.
- Allocate the matrix and RHS device memory only for the first system.
- Continue copying the updated matrix and RHS data to the device for each system.

 
 ## Checklist

- [ ] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [ ] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [ ] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [ ] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A: The existing `gluRefactor` example reproduces the bug.
- N/A: This fix does not add a new feature or public API that needs documentation.
- [x] The feature branch is rebased with respect to the target branch.
- N/A: This is a small follow-up fix to the explicit memory management change already listed in `CHANGELOG.md`.
 
 ## Further comments
 
After the fix:

The 20-system ACTIVSg10k run completes without memory or CUDA errors.

The full CUDA test suite passes 67/67.

`make test_install` passes.

The CUDA build also passes with `-Wall -Wpedantic -Wconversion -Wextra` and warnings treated as errors, except for existing CUDA API deprecation warnings.

CPU testing exposed a separate missing host allocation in the KLU examples, tracked in #448.