### PR TITLE
Fix memory handling in KLU examples

### DIFF
--- a/examples/experimental/r_KLU_GLU_matrix_values_update.cpp
+++ b/examples/experimental/r_KLU_GLU_matrix_values_update.cpp
@@ -101,9 +101,17 @@ int main(int argc, char* argv[])
       x       = new real_type[A->getNumRows()];
       vec_rhs = new vector_type(A->getNumRows());
       vec_x   = new vector_type(A->getNumRows());
+      vec_r   = new vector_type(A->getNumRows());
+
+      A->allocateMatrixData(ReSolve::memory::DEVICE);
+
+      vec_rhs->allocate(ReSolve::memory::HOST);
+      vec_rhs->allocate(ReSolve::memory::DEVICE);
+
       vec_x->allocate(ReSolve::memory::HOST); // for KLU
       vec_x->allocate(ReSolve::memory::DEVICE);
-      vec_r = new vector_type(A->getNumRows());
+
+      vec_r->allocate(ReSolve::memory::DEVICE);
     }
     else
     {
@@ -121,7 +129,6 @@ int main(int argc, char* argv[])
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
     // Copy matrix data to device
-    A->allocateMatrixData(ReSolve::memory::DEVICE);
     A->syncData(ReSolve::memory::DEVICE);
 
     std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x " << A->getNumColumns()
@@ -131,17 +138,10 @@ int main(int argc, char* argv[])
     mat_file.close();
     rhs_file.close();
 
-    // Update host and device data.
-    if (i < 1)
-    {
-      vec_rhs->allocate(ReSolve::memory::HOST);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-    }
-    else
-    {
-      vec_rhs->allocate(ReSolve::memory::DEVICE);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-    }
+    // Update the host copy of the rhs, then synchronize it to the device.
+    vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+    vec_rhs->syncData(ReSolve::memory::DEVICE);
+
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
     // Now call direct solver
@@ -176,7 +176,6 @@ int main(int argc, char* argv[])
       status = GLU->solve(vec_rhs, vec_x);
       std::cout << "CUSOLVER GLU solve status: " << status << std::endl;
     }
-    vec_r->allocate(ReSolve::memory::DEVICE);
     vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -196,9 +195,10 @@ int main(int argc, char* argv[])
   delete[] rhs;
   delete vec_r;
   delete vec_x;
-  delete workspace_CUDA;
+  delete vec_rhs;
   delete matrix_handler;
   delete vector_handler;
+  delete workspace_CUDA;
 
   return 0;
 }

--- a/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_cusolverrf_redo_factorization.cpp
@@ -110,6 +110,16 @@ int main(int argc, char* argv[])
       vec_rhs = new vector_type(A->getNumRows());
       vec_x   = new vector_type(A->getNumRows());
       vec_r   = new vector_type(A->getNumRows());
+
+      A->allocateMatrixData(ReSolve::memory::DEVICE);
+
+      vec_rhs->allocate(ReSolve::memory::HOST);
+      vec_rhs->allocate(ReSolve::memory::DEVICE);
+
+      vec_x->allocate(ReSolve::memory::HOST);
+      vec_x->allocate(ReSolve::memory::DEVICE);
+
+      vec_r->allocate(ReSolve::memory::DEVICE);
     }
     else
     {
@@ -117,7 +127,6 @@ int main(int argc, char* argv[])
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
     // Copy matrix data to device
-    A->allocateMatrixData(ReSolve::memory::DEVICE);
     A->syncData(ReSolve::memory::DEVICE);
 
     std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x " << A->getNumColumns()
@@ -127,17 +136,10 @@ int main(int argc, char* argv[])
     mat_file.close();
     rhs_file.close();
 
-    // Update host and device data.
-    if (i < 2)
-    {
-      vec_rhs->allocate(ReSolve::memory::HOST);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-    }
-    else
-    {
-      vec_rhs->allocate(ReSolve::memory::DEVICE);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-    }
+    // Update the host copy of the rhs, then synchronize it to the device.
+    vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+    vec_rhs->syncData(ReSolve::memory::DEVICE);
+
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
     // Now call direct solver
@@ -150,6 +152,10 @@ int main(int argc, char* argv[])
       std::cout << "KLU factorization status: " << status << std::endl;
       status = KLU->solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
+      if (status == 0)
+      {
+        vec_x->syncData(ReSolve::memory::DEVICE);
+      }
       if (i == 1)
       {
         L = (ReSolve::matrix::Csr*) KLU->getLFactor();
@@ -185,7 +191,6 @@ int main(int argc, char* argv[])
     }
 
     // Make sure vec_r is properly initialized before using it.
-    vec_r->allocate(ReSolve::memory::DEVICE);
     vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
@@ -214,6 +219,11 @@ int main(int argc, char* argv[])
       std::cout << "KLU factorization status: " << status << std::endl;
       status = KLU->solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
+
+      if (status == 0)
+      {
+        vec_x->syncData(ReSolve::memory::DEVICE);
+      }
 
       vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
@@ -246,33 +256,6 @@ int main(int argc, char* argv[])
     }
   } // for (int i = 0; i < numSystems; ++i)
 
-  if (vec_r != nullptr)
-  {
-    delete vec_r;
-    vec_r = nullptr;
-  }
-  if (vec_x != nullptr)
-  {
-    delete vec_x;
-    vec_x = nullptr;
-  }
-  if (vec_rhs != nullptr)
-  {
-    delete vec_rhs;
-    vec_rhs = nullptr;
-  }
-
-  if (x != nullptr)
-  {
-    delete[] x;
-    x = nullptr;
-  }
-  if (rhs != nullptr)
-  {
-    delete[] rhs;
-    rhs = nullptr;
-  }
-
   if (Rf != nullptr)
   {
     delete Rf;
@@ -288,6 +271,26 @@ int main(int argc, char* argv[])
   {
     delete A;
     A = nullptr;
+  }
+  delete[] x;
+  x = nullptr;
+
+  delete[] rhs;
+  rhs = nullptr;
+  if (vec_r != nullptr)
+  {
+    delete vec_r;
+    vec_r = nullptr;
+  }
+  if (vec_x != nullptr)
+  {
+    delete vec_x;
+    vec_x = nullptr;
+  }
+  if (vec_rhs != nullptr)
+  {
+    delete vec_rhs;
+    vec_rhs = nullptr;
   }
 
   if (matrix_handler != nullptr)

--- a/examples/experimental/r_KLU_rf_FGMRES_reuse_factorization.cpp
+++ b/examples/experimental/r_KLU_rf_FGMRES_reuse_factorization.cpp
@@ -53,9 +53,10 @@ int main(int argc, char* argv[])
 
   ReSolve::GramSchmidt* GS = new ReSolve::GramSchmidt(vector_handler, ReSolve::GramSchmidt::CGS2);
 
-  ReSolve::LinSolverDirectKLU*        KLU    = new ReSolve::LinSolverDirectKLU;
-  ReSolve::LinSolverDirectCuSolverRf* Rf     = new ReSolve::LinSolverDirectCuSolverRf;
-  ReSolve::LinSolverIterativeFGMRES*  FGMRES = new ReSolve::LinSolverIterativeFGMRES(matrix_handler, vector_handler, GS);
+  ReSolve::LinSolverDirectKLU*        KLU            = new ReSolve::LinSolverDirectKLU;
+  ReSolve::LinSolverDirectCuSolverRf* Rf             = new ReSolve::LinSolverDirectCuSolverRf;
+  ReSolve::LinSolverIterativeFGMRES*  FGMRES         = new ReSolve::LinSolverIterativeFGMRES(matrix_handler, vector_handler, GS);
+  ReSolve::PreconditionerLU*          preconditioner = nullptr;
 
   for (int i = 0; i < numSystems; ++i)
   {
@@ -104,9 +105,14 @@ int main(int argc, char* argv[])
       x       = new real_type[A->getNumRows()];
       vec_rhs = new vector_type(A->getNumRows());
       vec_x   = new vector_type(A->getNumRows());
+      vec_r   = new vector_type(A->getNumRows());
+
+      A->allocateMatrixData(ReSolve::memory::DEVICE);
+
+      vec_rhs->allocate(ReSolve::memory::HOST);
+      vec_rhs->allocate(ReSolve::memory::DEVICE);
       vec_x->allocate(ReSolve::memory::HOST); // for KLU
       vec_x->allocate(ReSolve::memory::DEVICE);
-      vec_r = new vector_type(A->getNumRows());
       vec_r->allocate(ReSolve::memory::DEVICE);
     }
     else
@@ -115,7 +121,6 @@ int main(int argc, char* argv[])
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
     // Copy matrix data to device
-    A->allocateMatrixData(ReSolve::memory::DEVICE);
     A->syncData(ReSolve::memory::DEVICE);
 
     std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x " << A->getNumColumns()
@@ -125,21 +130,10 @@ int main(int argc, char* argv[])
     mat_file.close();
     rhs_file.close();
 
-    // Update host and device data.
-    if (i < 2)
-    {
-      vec_rhs->allocate(ReSolve::memory::HOST);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-      vec_rhs->setDataUpdated(ReSolve::memory::HOST);
-    }
-    else
-    {
-      vec_rhs->allocate(ReSolve::memory::HOST);
-      vec_rhs->allocate(ReSolve::memory::DEVICE);
-      A->setUpdated(ReSolve::memory::HOST);
-      A->syncData(ReSolve::memory::DEVICE);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-    }
+    // Update the host copy of the rhs, then synchronize it to the device.
+    vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+    vec_rhs->syncData(ReSolve::memory::DEVICE);
+
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
     // Now call direct solver
@@ -155,6 +149,10 @@ int main(int argc, char* argv[])
       std::cout << "KLU factorization status: " << status << std::endl;
       status = KLU->solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
+      if (status == 0)
+      {
+        vec_x->syncData(ReSolve::memory::DEVICE);
+      }
       vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
@@ -174,10 +172,12 @@ int main(int argc, char* argv[])
         index_type* P = KLU->getPOrdering();
         index_type* Q = KLU->getQOrdering();
         Rf->setup(A, L, U, P, Q);
+        preconditioner = new ReSolve::PreconditionerLU(Rf);
         std::cout << "about to set FGMRES" << std::endl;
         FGMRES->setRestart(1000);
         FGMRES->setMaxit(2000);
         FGMRES->setup(A);
+        FGMRES->setPreconditioner(preconditioner);
       }
     }
     else
@@ -189,10 +189,7 @@ int main(int argc, char* argv[])
         status = Rf->refactorize();
         std::cout << "CUSOLVER RF, using REAL refactorization, refactorization status: "
                   << status << std::endl;
-        vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         status = Rf->solve(vec_rhs, vec_x);
-        ReSolve::PreconditionerLU preconditioner(Rf);
-        FGMRES->setPreconditioner(&preconditioner);
       }
       // if (i%2!=0)  vec_x->setToZero(ReSolve::memory::DEVICE);
       real_type norm_x = vector_handler->dot(vec_x, vec_x, ReSolve::memory::DEVICE);
@@ -201,7 +198,6 @@ int main(int argc, char* argv[])
                 << sqrt(norm_x) << "\n";
       std::cout << "CUSOLVER RF solve status: " << status << std::endl;
 
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       norm_b = vector_handler->dot(vec_r, vec_r, ReSolve::memory::DEVICE);
       norm_b = sqrt(norm_b);
@@ -218,7 +214,6 @@ int main(int argc, char* argv[])
                 << std::scientific << std::setprecision(16)
                 << norm_b << "\n";
 
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
       FGMRES->solve(vec_rhs, vec_x);
 
       std::cout << "FGMRES: init nrm: "
@@ -234,16 +229,23 @@ int main(int argc, char* argv[])
     }
   }
 
-  delete A;
-  delete KLU;
+  delete FGMRES;
+  delete preconditioner;
   delete Rf;
+  delete KLU;
+  delete GS;
+
+  delete A;
   delete[] x;
   delete[] rhs;
+
   delete vec_r;
   delete vec_x;
-  delete workspace_CUDA;
+  delete vec_rhs;
+
   delete matrix_handler;
   delete vector_handler;
+  delete workspace_CUDA;
 
   return 0;
 }

--- a/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
+++ b/examples/experimental/r_KLU_rocsolverrf_redo_factorization.cpp
@@ -99,6 +99,16 @@ int main(int argc, char* argv[])
       vec_rhs = new vector_type(A->getNumRows());
       vec_x   = new vector_type(A->getNumRows());
       vec_r   = new vector_type(A->getNumRows());
+
+      A->allocateMatrixData(ReSolve::memory::DEVICE);
+
+      vec_rhs->allocate(ReSolve::memory::HOST);
+      vec_rhs->allocate(ReSolve::memory::DEVICE);
+
+      vec_x->allocate(ReSolve::memory::HOST);
+      vec_x->allocate(ReSolve::memory::DEVICE);
+
+      vec_r->allocate(ReSolve::memory::DEVICE);
     }
     else
     {
@@ -106,7 +116,6 @@ int main(int argc, char* argv[])
       ReSolve::io::updateArrayFromFile(rhs_file, &rhs);
     }
     // Copy matrix data to device
-    A->allocateMatrixData(ReSolve::memory::DEVICE);
     A->syncData(ReSolve::memory::DEVICE);
 
     std::cout << "Finished reading the matrix and rhs, size: " << A->getNumRows() << " x " << A->getNumColumns()
@@ -116,17 +125,10 @@ int main(int argc, char* argv[])
     mat_file.close();
     rhs_file.close();
 
-    // Update host and device data.
-    if (i < 2)
-    {
-      vec_rhs->allocate(ReSolve::memory::HOST);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
-    }
-    else
-    {
-      vec_rhs->allocate(ReSolve::memory::DEVICE);
-      vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
-    }
+    // Update the host copy of the rhs, then synchronize it to the device.
+    vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::HOST);
+    vec_rhs->syncData(ReSolve::memory::DEVICE);
+
     std::cout << "CSR matrix loaded. Expanded NNZ: " << A->getNnz() << std::endl;
 
     // Now call direct solver
@@ -140,13 +142,16 @@ int main(int argc, char* argv[])
       std::cout << "KLU factorization status: " << status << std::endl;
       status = KLU->solve(vec_rhs, vec_x);
       std::cout << "KLU solve status: " << status << std::endl;
+      if (status == 0)
+      {
+        vec_x->syncData(ReSolve::memory::DEVICE);
+      }
       if (i == 1)
       {
         ReSolve::matrix::Csr* L = (ReSolve::matrix::Csr*) KLU->getLFactor();
         ReSolve::matrix::Csr* U = (ReSolve::matrix::Csr*) KLU->getUFactor();
         index_type*           P = KLU->getPOrdering();
         index_type*           Q = KLU->getQOrdering();
-        vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         Rf->setup(A, L, U, P, Q, vec_rhs);
         Rf->refactorize();
       }
@@ -161,7 +166,6 @@ int main(int argc, char* argv[])
     }
 
     // Check accuracy of the solution
-    vec_rhs->allocate(ReSolve::memory::DEVICE);
     vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
     matrix_handler->setValuesChanged(true, ReSolve::memory::DEVICE);
     matrix_handler->matvec(A, vec_x, vec_r, &ONE, &MINUS_ONE, ReSolve::memory::DEVICE);
@@ -184,6 +188,11 @@ int main(int argc, char* argv[])
         std::cout << "KLU factorization status: " << status << std::endl;
         status = KLU->solve(vec_rhs, vec_x);
         std::cout << "KLU solve status: " << status << std::endl;
+
+        if (status == 0)
+        {
+          vec_x->syncData(ReSolve::memory::DEVICE);
+        }
 
         vec_rhs->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
         vec_r->copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
@@ -217,8 +226,9 @@ int main(int argc, char* argv[])
   delete[] rhs;
   delete vec_r;
   delete vec_x;
-  delete workspace_HIP;
+  delete vec_rhs;
   delete matrix_handler;
   delete vector_handler;
+  delete workspace_HIP;
   return 0;
 }

--- a/examples/kluFactor.cpp
+++ b/examples/kluFactor.cpp
@@ -159,6 +159,7 @@ int main(int argc, char* argv[])
 
       vec_rhs = ReSolve::io::createVectorFromFile(rhs_file);
       vec_x   = new vector_type(A->getNumRows());
+      vec_x->allocate(memory::HOST);
     }
     else
     {

--- a/examples/kluRefactor.cpp
+++ b/examples/kluRefactor.cpp
@@ -162,6 +162,7 @@ int main(int argc, char* argv[])
 
       vec_rhs = ReSolve::io::createVectorFromFile(rhs_file);
       vec_x   = new vector_type(A->getNumRows());
+      vec_x->allocate(memory::HOST);
     }
     else
     {


### PR DESCRIPTION
## Description

Fixes the missing host allocation in the KLU examples reported in #448.

Both `kluFactor.cpp` and `kluRefactor.cpp` create the solution vector but do not allocate its host storage before calling the KLU solve. This causes the solve to report:

```text
[ERROR] Trying to copy from external vector, but destination (host) is not allocated!
KLU solve status: 1
```
and `kluRefactor.exe` then terminates with a segmentation fault.

I also checked the remaining examples and found similar memory handling issues in four experimental KLU examples. These changes allocate host and device storage once, synchronize updated data before device use, and clean up the allocated objects.

The FGMRES example stored a pointer to a local preconditioner that was destroyed at the end of the iteration. The preconditioner now remains valid until cleanup.
 
Closes #448
 
@shakedregev
 

 ## Proposed changes

- Allocate the solution vector in host memory after it is created in `kluFactor.cpp`.
- Allocate the solution vector in host memory after it is created in `kluRefactor.cpp`.
- Fix repeated and missing allocations in four experimental KLU examples.
- Synchronize updated RHS and solution data before device use.
- Fix the preconditioner lifetime in the FGMRES example.
- Update the cleanup blocks to delete `vec_rhs`, the solver objects, and the handlers in the correct order.

 
 ## Checklist

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [x] I have manually run the affected KLU examples and verified that the fixed paths complete without allocation errors. Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A: The existing KLU examples reproduce the bug.
- N/A: This fix does not add a new feature or public API that needs documentation.
- [x] The feature branch is rebased with respect to the target branch.
- N/A: This is a small follow-up fix to the explicit memory management change already listed in `CHANGELOG.md`.
 
 ## Further comments
 
On the current `develop` branch, `kluRefactor.exe` later reaches a separate allocation failure in `ExampleHelper::printSummary()`. That issue is addressed in #447. With the pending #447 fix temporarily applied, the 20-system ACTIVSg10k run completes with exit code 0.

The experimental CUDA RF examples complete their initial KLU solves but still fail in the later RF path because of the separate factor transfer issue tracked in #451.

The experimental GLU example no longer reports allocation errors and its initial solve succeeds, but the later updated systems still produce inaccurate residuals. That issue is separate from the memory handling changes in this PR.