### PR TITLE
Reset iterative solver matrix before refinement

### DIFF
--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -673,6 +673,7 @@ namespace ReSolve
   {
     int status = 0;
 
+    status += iterativeSolver_->resetMatrix(A_);
     status += iterativeSolver_->solve(rhs, x);
 
     return status;


### PR DESCRIPTION
## Description

`SystemSolver::refine()` reused the iterative solver after the system matrix values changed without resetting its matrix. This caused the provided refactorization sequence to abort in Gram-Schmidt on system 18.

Closes #435
 
@pelesh 
 

 ## Proposed changes
 
- Reset the iterative solver matrix before calling the refinement solve.
 
 ## Checklist
 
- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the affected non-experimental refactorization example and verified that the 19-system sequence completes without the Gram-Schmidt assertion. Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
     - There was one existing unrelated warning.
- [x] The new code follows Re::Solve style guidelines.
- N/A: The existing refactorization reproducer covers the reported bug.
- N/A: This fix does not add a new feature or public API that needs documentation.
- [x] The feature branch is rebased with respect to the target branch.
- N/A: This is a small bug fix that does not require a changelog entry.
 
 ## Further comments
 
 <!-- If this is a relatively large or complex change, kick off the discussion by explaining
 why you chose the solution you did and what alternatives you considered, etc. -->
