### PR TITLE
Fix GramSchmidt gemv sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 
 - Remove automatic memory allocation and memory syncing in various memory management functions and require the user to explicitly manage their own memory.
 
+* Added size assertions to `VectorHandler::gemv` and fixed vector sizing in `GramSchmidt` accordingly.
+
 ## Changes to Re::Solve in release 0.99.2
 
 ### Major Features

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -178,19 +178,15 @@ namespace ReSolve
       return 0;
 
     case CGS2:
-      // std::cout << "k = " << i + 1 << std::endl;
-      // std::cout << "size of V: " << V->getSize() << std::endl;
-      // std::cout << "num vecs in V: " << V->getNumVectors() << std::endl;
-      // std::cout << "size of y (vec_v_): " << vec_v_->getSize() << std::endl;
-      // std::cout << "size of x (vec_Hcolumn_): " << vec_Hcolumn_->getSize() << std::endl << std::endl;
       vec_v_->setData(V->getData(i + 1, memspace_), memspace_);
+      vec_Hcolumn_->resize(i + 1);
+
       vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_, memspace_);
       // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
       vector_handler_->gemv('N', i + 1, ONE, MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_);
 
       // copy H_col to aux, we will need it later
       vec_Hcolumn_->setDataUpdated(memspace_);
-      vec_Hcolumn_->resize(i + 1);
       if (memspace_ == memory::DEVICE)
       {
         vec_Hcolumn_->syncData(memory::HOST);
@@ -380,6 +376,8 @@ namespace ReSolve
 
     case CGS1:
       vec_v_->setData(V->getData(i + 1, memspace_), memspace_);
+      vec_Hcolumn_->resize(i + 1);
+
       // Hcol = V(:,1:i)^T*V(:,i+1);
       vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_, memspace_);
       // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
@@ -391,7 +389,7 @@ namespace ReSolve
       {
         vec_Hcolumn_->syncData(memory::HOST);
       }
-      vec_Hcolumn_->resize(i + 1);
+
       vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
 
       t = vector_handler_->dot(vec_v_, vec_v_, memspace_);

--- a/resolve/vector/VectorHandler.cpp
+++ b/resolve/vector/VectorHandler.cpp
@@ -196,7 +196,6 @@ namespace ReSolve
    * where `x` is `[k x 1]`, `V` is `[n x k]` and `y` is `[n x 1]`.
    *
    * @param[in] Transpose - yes (T) or no (N)
-   * @param[in] n         - Number of rows in (non-transposed) matrix
    * @param[in] k         - Number of columns in (non-transposed) matrix to use
    * @param[in] alpha     - Constant real number
    * @param[in] beta      - Constant real number
@@ -208,7 +207,7 @@ namespace ReSolve
    * @note Parameter k is not the total number of columns in V but the number
    * of columns to use in matrix-vector product.
    *
-   * @pre _n_ > 0, _k_ > 0
+   * @pre Number of rows in V > 0 and k > 0.
    * @pre Number of columns in V >= k
    * @pre If transpose = N, size of y must equal k. If transpose = T, size of
    * x must equal k.
@@ -224,6 +223,20 @@ namespace ReSolve
                            memory::MemorySpace memspace)
   {
     using namespace ReSolve::memory;
+
+    assert(V != nullptr && y != nullptr && x != nullptr && "V, y, and x must not be null.");
+    assert(k > 0 && "k must be positive.");
+    assert(V->getSize() > 0 && "V must have at least one row.");
+    assert(V->getNumVectors() >= k && "V must have at least k columns.");
+
+    if (transpose == 'N')
+    {
+      assert(y->getSize() == k && "N: y size must equal k.");
+    }
+    else if (transpose == 'T')
+    {
+      assert(x->getSize() == k && "T: x size must equal k.");
+    }
 
     switch (memspace)
     {


### PR DESCRIPTION
## Description

Closes #415

In `GramSchmidt`, `vec_Hcolumn_` was resized only after it was passed to `gemv`. This could cause dimension checks to fail in debug builds when only part of the multivector is used.

 ## Proposed changes
 
- Resize `vec_Hcolumn_` before calling `gemv` in both CGS1 and CGS2.
- Add assertions to `VectorHandler::gemv` to check vector sizes.
 
 ## Checklist

- [ ] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [ ] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [N/A] There are unit tests for the new code.
- [x] The new code is documented.
- [N/A] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
