### PR TITLE
Fix GPU refactorization and GMRES failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 - Set Re::Solve's real type and matrix/vector index type at CMake configuration time.
 * Added size assertions to `VectorHandler::gemv` and fixed vector sizing in `GramSchmidt` accordingly.
 
+- Fixed GPU refactorization allocation and synchronization errors, uninitialized GMRES example initial guesses, and CUDA ILU0 failures on stored numerical zero pivots.
+
 ## Changes to Re::Solve in release 0.99.2
 
 ### Major Features

--- a/examples/experimental/r_KLU_rocsolverrf_asym6x6.cpp
+++ b/examples/experimental/r_KLU_rocsolverrf_asym6x6.cpp
@@ -170,6 +170,7 @@ int main()
   }
   std::cout << "]" << std::endl;
 
+  vec_x->syncData(ReSolve::memory::DEVICE);
   helper.printShortSummary(A, vec_rhs, vec_x);
   ReSolve::matrix::Csr* L = (ReSolve::matrix::Csr*) KLU.getLFactor();
   ReSolve::matrix::Csr* U = (ReSolve::matrix::Csr*) KLU.getUFactor();

--- a/examples/gpuRefactor.cpp
+++ b/examples/gpuRefactor.cpp
@@ -280,7 +280,10 @@ int gpuRefactor(int argc, char* argv[])
 
       // Triangular solve
       status = KLU.solve(vec_rhs, vec_x);
-
+      if (status == 0)
+      {
+        vec_x->syncData(memory::DEVICE);
+      }
       syncDevice();
       auto solve_end = std::chrono::high_resolution_clock::now();
       solve_time_ms  = std::chrono::duration<double, std::milli>(solve_end - solve_start).count();

--- a/examples/gpuRefactor.cpp
+++ b/examples/gpuRefactor.cpp
@@ -238,6 +238,8 @@ int gpuRefactor(int argc, char* argv[])
       vec_x   = new vector_type(A->getNumRows());
       vec_x->allocate(memory::HOST);
       vec_x->allocate(memory::DEVICE);
+      A->allocateMatrixData(memory::DEVICE);
+      vec_rhs->allocate(memory::DEVICE);
     }
     else
     {
@@ -249,9 +251,7 @@ int gpuRefactor(int argc, char* argv[])
     rhs_file.close();
 
     // Copy data to device
-    A->allocateMatrixData(memory::DEVICE);
     A->syncData(memory::DEVICE);
-    vec_rhs->allocate(memory::DEVICE);
     vec_rhs->syncData(memory::DEVICE);
     RESOLVE_RANGE_POP("File input");
 

--- a/examples/randGmres.cpp
+++ b/examples/randGmres.cpp
@@ -160,6 +160,7 @@ int runGmresExample(int argc, char* argv[])
 
   vec_x = new vector_type(A->getNumRows());
   vec_x->allocate(memspace);
+  vec_x->setToZero(memspace);
   if (memspace == memory::DEVICE)
   {
     A->allocateMatrixData(memory::DEVICE);

--- a/examples/sysGmres.cpp
+++ b/examples/sysGmres.cpp
@@ -219,6 +219,7 @@ int sysGmres(int argc, char* argv[])
   // Create solution vector
   vector_type* vec_x = new vector_type(A->getNumRows());
   vec_x->allocate(memspace);
+  vec_x->setToZero(memspace);
 
   if (memspace == memory::DEVICE)
   {

--- a/examples/sysRefactor.cpp
+++ b/examples/sysRefactor.cpp
@@ -306,9 +306,12 @@ int sysRefactor(int argc, char* argv[])
     // Ensure matrix data is synced to the device before any GPU operations
     if (hw_backend == "CUDA" || hw_backend == "HIP")
     {
-      A->allocateMatrixData(memory::DEVICE);
+      if (i == 1)
+      {
+        A->allocateMatrixData(memory::DEVICE);
+        vec_rhs->allocate(memory::DEVICE);
+      }
       A->syncData(memory::DEVICE);
-      vec_rhs->allocate(memory::DEVICE);
       vec_rhs->syncData(memory::DEVICE);
     }
 
@@ -353,6 +356,12 @@ int sysRefactor(int argc, char* argv[])
     }
 
     status = solver.solve(vec_rhs, vec_x);
+
+    if ((hw_backend == "CUDA" || hw_backend == "HIP") && i == 1)
+    {
+      vec_x->syncData(memory::DEVICE);
+    }
+
     if (hw_backend == "CUDA" || hw_backend == "HIP")
     {
       syncDevice(hw_backend);

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -59,6 +59,7 @@ namespace ReSolve
    * @param[in] rhs - pointer to the right-hand side vector (optional)
    *
    * @pre The matrix A is in CSR format.
+   * @post Device storage for L and U is allocated and synchronized.
    */
 
   int LinSolverDirectCuSolverRf::setup(matrix::Sparse* A,

--- a/resolve/LinSolverDirectCuSolverRf.cpp
+++ b/resolve/LinSolverDirectCuSolverRf.cpp
@@ -106,6 +106,8 @@ namespace ReSolve
 
     status_cusolverrf_ = cusolverRfSetResetValuesFastMode(handle_cusolverrf_, CUSOLVERRF_RESET_VALUES_FAST_MODE_ON);
     error_sum += status_cusolverrf_;
+    L->allocateMatrixData(memory::DEVICE);
+    U->allocateMatrixData(memory::DEVICE);
     L->syncData(memory::DEVICE);
     U->syncData(memory::DEVICE);
     status_cusolverrf_ = cusolverRfSetupDevice(n,

--- a/resolve/LinSolverDirectCuSparseILU0.cpp
+++ b/resolve/LinSolverDirectCuSparseILU0.cpp
@@ -111,6 +111,25 @@ namespace ReSolve
                                                   buffer_);
 
     error_sum += status_cusparse_;
+
+    // Regularize small-magnitude pivots during CUDA ILU0 factorization.
+    real_type boost_tolerance = 1e-6;
+    real_type boost_value     = 1e-6;
+
+    status_cusparse_ =
+        cusparseDcsrilu02_numericBoost(workspace_->getCusparseHandle(),
+                                       info_A_,
+                                       1,
+                                       &boost_tolerance,
+                                       &boost_value);
+
+    if (status_cusparse_ != CUSPARSE_STATUS_SUCCESS)
+    {
+      out::error() << "CUDA ILU0 numerical boost setup failed with status "
+                   << static_cast<int>(status_cusparse_) << "\n";
+      return 1;
+    }
+
     // and now the actual decomposition
 
     // Compute incomplete LU factorization

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -484,8 +484,6 @@ namespace ReSolve
 
     L_ = factorizationSolver_->getLFactor();
     U_ = factorizationSolver_->getUFactor();
-    L_->allocateMatrixData(memory::DEVICE);
-    U_->allocateMatrixData(memory::DEVICE);
     P_ = factorizationSolver_->getPOrdering();
     Q_ = factorizationSolver_->getQOrdering();
 

--- a/tests/functionality/testRefactor.cpp
+++ b/tests/functionality/testRefactor.cpp
@@ -238,7 +238,6 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   }
   ReSolve::io::updateArrayFromFile(rhs2_file, &rhs);
   rhs2_file.close();
-  vec_rhs.allocate(ReSolve::memory::DEVICE);
   vec_rhs.copyFromExternal(rhs, ReSolve::memory::HOST, ReSolve::memory::DEVICE);
 
   // Refactorize second matrix

--- a/tests/functionality/testRefactor.cpp
+++ b/tests/functionality/testRefactor.cpp
@@ -174,8 +174,6 @@ int runTest(int argc, char* argv[], std::string& solver_name)
   matrix_type* U = KLU.getUFactor();
   index_type*  P = KLU.getPOrdering();
   index_type*  Q = KLU.getQOrdering();
-  L->allocateMatrixData(ReSolve::memory::DEVICE);
-  U->allocateMatrixData(ReSolve::memory::DEVICE);
 
   status = Rf.setup(A, L, U, P, Q, &vec_rhs);
   error_sum += status;


### PR DESCRIPTION
## Description
 
The KLU L and U factors were synchronized to the device without first allocating device storage. The solution produced by the initial KLU solve was also used by CUDA operations without being synchronized to the device.

While testing the fix, I found additional repeated allocations in the refactorization examples. I also found that the GMRES examples used an uninitialized solution vector and that CUDA ILU0 failed on a numerical zero pivot in the ACTIVSg200 matrix.

These issues caused allocation and copy errors, invalid residuals, NaNs, and later solver failures.

Closes #451
Closes #445

@shakedregev
 

 ## Proposed changes

- Allocate and synchronize the KLU factors in `LinSolverDirectCuSolverRf::setup()` and remove redundant caller-side allocations.
- Allocate reusable matrix and vector GPU storage once in the refactorization examples and tests.
- Synchronize the initial KLU solution to the device after a successful solve.
- Initialize the GMRES example solution vectors to zero before using them as initial guesses.
- Regularize small-magnitude CUDA ILU0 pivots using cuSPARSE numerical boosting.

 ## Checklist
 
- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- N/A: Existing examples reproduce the reported failures.
- N/A: This fix does not add a new feature or public API that needs documentation.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](https://github.com/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments

The CUDA RF setup now allocates and copies the KLU L and U factors to GPU memory because they are needed there during setup. This avoids requiring each caller to allocate them separately.

The GMRES solution vectors are initialized to zero because they are used as initial guesses, and allocating memory does not initialize its contents.

The ACTIVSg200 matrix contains an explicitly stored zero diagonal value. cuSPARSE numerical boosting is enabled before ILU0 factorization to handle small-magnitude numerical pivots. It does not add diagonal entries that are missing from the matrix structure.
