### PR TITLE
expect warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 - Set Re::Solve's real type and matrix/vector index type at CMake configuration time.
 * Added size assertions to `VectorHandler::gemv` and fixed vector sizing in `GramSchmidt` accordingly.
 
+- Added line to testlog to tell the user to expect warnings as part of normal testing.
+
 ## Changes to Re::Solve in release 0.99.2
 
 ### Major Features

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -235,7 +235,7 @@ int test(int argc, char* argv[])
   }
   else
   {
-    std::cout << "A warning on the next line is expected for the bad initial guess test" << std::endl;
+    std::cout << "Expect a warning on the next line for the bad initial guess test." << std::endl;
   }
 
   // Use a scaled converged solution as a nonzero initial guess.

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -233,6 +233,10 @@ int test(int argc, char* argv[])
               << "\tReturned residual      : " << rejected_guess_rnorm << "\n\n";
     error_sum++;
   }
+  else
+  {
+    std::cout << "A warning on the next line is expected for the bad initial guess test" << std::endl;
+  }
 
   // Use a scaled converged solution as a nonzero initial guess.
   vector_type vec_x_guess(vec_x.getSize());

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -235,7 +235,7 @@ int test(int argc, char* argv[])
   }
   else
   {
-    std::cout << "Expect a warning on the next line for the bad initial guess test." << std::endl;
+    Log::misc << "Expect a warning on the next line for the bad initial guess test." << std::endl;
   }
 
   // Use a scaled converged solution as a nonzero initial guess.


### PR DESCRIPTION
## Description
 
We deliberately have tests to ensure our code prints warnings correctly. But the user cannot guess this.
 
Closes #446  

 ## Proposed changes
 
The user now sees a print statement telling them to expect a warning.
 
 ## Checklist
 
 <!-- Put an `x` in the boxes that apply. You can also fill these out after creating
 the PR. If you're unsure about any of them, don't hesitate to ask. We're here
 to help! This is simply a reminder of what we are going to look for before
 merging your code. -->
 
- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.