### PR TITLE
Use enum for SystemSolver preconditioner side

### DIFF
--- a/examples/sysGmres.cpp
+++ b/examples/sysGmres.cpp
@@ -57,8 +57,7 @@ static int sysGmres(int argc, char* argv[]);
 static void processInputs(std::string& method,
                           std::string& gs,
                           std::string& sketch,
-                          std::string& flexible,
-                          std::string& side);
+                          std::string& flexible);
 
 /// Main function selects example to be run
 int main(int argc, char* argv[])
@@ -166,10 +165,27 @@ int sysGmres(int argc, char* argv[])
   opt                  = options.getParamFromKey("-x");
   std::string flexible = opt ? (*opt).second : "yes";
 
-  opt              = options.getParamFromKey("-p");
-  std::string side = opt ? (*opt).second : "right";
+  opt                                      = options.getParamFromKey("-p");
+  Preconditioner::Side preconditioner_side = Preconditioner::RIGHT;
+  if (opt)
+  {
+    if (opt->second == "left")
+    {
+      preconditioner_side = Preconditioner::LEFT;
+    }
+    else if (opt->second == "right")
+    {
+      preconditioner_side = Preconditioner::RIGHT;
+    }
+    else
+    {
+      std::cout << "Preconditioning side '" << opt->second
+                << "' not recognized. Use 'left' or 'right'.\n";
+      return 1;
+    }
+  }
 
-  processInputs(method, gs, sketch, flexible, side);
+  processInputs(method, gs, sketch, flexible);
 
   std::cout << "Matrix file: " << matrix_pathname << "\n"
             << "RHS file: " << rhs_pathname << "\n";
@@ -255,7 +271,7 @@ int sysGmres(int argc, char* argv[])
   // Set up the preconditioner
   if (return_code == 0)
   {
-    status = solver.preconditionerSetup(side);
+    status = solver.preconditionerSetup(preconditioner_side);
     std::cout << "solver.preconditionerSetup returned status: " << status << "\n";
     if (status != 0)
     {
@@ -289,7 +305,10 @@ int sysGmres(int argc, char* argv[])
   return return_code;
 }
 
-void processInputs(std::string& method, std::string& gs, std::string& sketch, std::string& flexible, std::string& side)
+void processInputs(std::string& method,
+                   std::string& gs,
+                   std::string& sketch,
+                   std::string& flexible)
 {
   if (method == "randgmres")
   {
@@ -321,11 +340,5 @@ void processInputs(std::string& method, std::string& gs, std::string& sketch, st
     std::cout << "Flexible option " << flexible << " not recognized.\n";
     std::cout << "Setting flexible to the default (yes).\n\n";
     flexible = "yes";
-  }
-
-  if ((side != "left") && (side != "right"))
-  {
-    std::cout << "Preconditioning side " << side << " not recognized.\n";
-    std::cout << "Setting preconditioning side to the default (right).\n\n";
   }
 }

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -593,7 +593,7 @@ namespace ReSolve
    *
    * @return int 0 if successful, 1 if it fails
    */
-  int SystemSolver::preconditionerSetup(std::string side)
+  int SystemSolver::preconditionerSetup(Preconditioner::Side side)
   {
     int status = 0;
 
@@ -614,23 +614,7 @@ namespace ReSolve
       return status;
     }
 
-    Preconditioner::Side prec_side;
-    if (side == "left")
-    {
-      prec_side = Preconditioner::LEFT;
-    }
-    else if (side == "right")
-    {
-      prec_side = Preconditioner::RIGHT;
-    }
-    else
-    {
-      out::error() << "Preconditioning side '" << side
-                   << "' not recognized. Use 'left' or 'right'.\n";
-      return 1;
-    }
-
-    status += preconditioner_->setSide(prec_side);
+    status += preconditioner_->setSide(side);
     status += preconditioner_->setup(A_);
 
     if (memspace_ != "cpu")

--- a/resolve/SystemSolver.hpp
+++ b/resolve/SystemSolver.hpp
@@ -61,7 +61,7 @@ namespace ReSolve
     int factorize(); //  numeric part
     int refactorize();
     int refactorizationSetup();
-    int preconditionerSetup(std::string side);
+    int preconditionerSetup(Preconditioner::Side side);
     int resetPreconditioner(matrix_type* A);
     int solve(vector_type* rhs, vector_type* x);  // for direct and iterative
     int refine(vector_type* rhs, vector_type* x); // for iterative refinement

--- a/tests/functionality/CMakeLists.txt
+++ b/tests/functionality/CMakeLists.txt
@@ -182,6 +182,12 @@ add_test(NAME sys_gmres_mgspm_test
          COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-x" "no" "-i" "fgmres"
                  "-g" "mgs_pm"
 )
+add_test(NAME sys_gmres_invalid_preconditioner_side_test
+         COMMAND $<TARGET_FILE:sys_rand_gmres_test.exe> "-p" "bogus"
+)
+set_tests_properties(
+  sys_gmres_invalid_preconditioner_side_test PROPERTIES WILL_FAIL TRUE
+)
 
 # Left-preconditioned Krylov solvers tests (GMRES)
 add_test(NAME sys_rand_count_gmres_left_cgs2_test

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -22,6 +22,7 @@
 #include <resolve/matrix/Csr.hpp>
 #include <resolve/matrix/MatrixHandler.hpp>
 #include <resolve/matrix/io.hpp>
+#include <resolve/utilities/logger/Logger.hpp>
 #include <resolve/utilities/params/CliOptions.hpp>
 #include <resolve/vector/Vector.hpp>
 #include <resolve/vector/VectorHandler.hpp>
@@ -42,7 +43,7 @@ template <class workspace_type>
 static int test(int argc, char* argv[]);
 
 /// Checks if inputs are valid, otherwise sets defaults
-static void processInputs(std::string& method, std::string& gs, std::string& sketch, std::string& side);
+static void processInputs(std::string& method, std::string& gs, std::string& sketch);
 
 /// Creates string with test description
 static std::string headerInfo(const std::string& method,
@@ -103,10 +104,27 @@ int test(int argc, char* argv[])
   opt                  = options.getParamFromKey("-x");
   std::string flexible = opt ? (*opt).second : "yes";
 
-  opt              = options.getParamFromKey("-p");
-  std::string side = opt ? (*opt).second : "right";
+  opt                                               = options.getParamFromKey("-p");
+  ReSolve::Preconditioner::Side preconditioner_side = ReSolve::Preconditioner::RIGHT;
+  if (opt)
+  {
+    if (opt->second == "left")
+    {
+      preconditioner_side = ReSolve::Preconditioner::LEFT;
+    }
+    else if (opt->second == "right")
+    {
+      preconditioner_side = ReSolve::Preconditioner::RIGHT;
+    }
+    else
+    {
+      std::cout << "Preconditioning side '" << opt->second
+                << "' not recognized. Use 'left' or 'right'.\n";
+      return 1;
+    }
+  }
 
-  processInputs(method, gs, sketch, side);
+  processInputs(method, gs, sketch);
 
   // Create workspace and initialize its handles.
   workspace_type workspace;
@@ -169,7 +187,7 @@ int test(int argc, char* argv[])
   solver.getIterativeSolver().setCliParam("restart", "200");
 
   // Set preconditioner (default in this case ILU0)
-  status = solver.preconditionerSetup(side);
+  status = solver.preconditionerSetup(preconditioner_side);
   error_sum += status;
 
   // Solve system
@@ -206,7 +224,7 @@ int test(int argc, char* argv[])
   bad_guess_solver.getIterativeSolver().setCliParam("flexible", flexible);
   bad_guess_solver.getIterativeSolver().setCliParam("restart", "200");
 
-  status = bad_guess_solver.preconditionerSetup(side);
+  status = bad_guess_solver.preconditionerSetup(preconditioner_side);
   error_sum += status;
 
   const real_type bad_guess_rnorm = bad_guess_solver.getResidualNorm(vec_rhs, &bad_guess_x);
@@ -235,7 +253,7 @@ int test(int argc, char* argv[])
   }
   else
   {
-    Log::misc << "Expect a warning on the next line for the bad initial guess test." << std::endl;
+    ReSolve::io::Logger::misc() << "Expect a warning on the next line for the bad initial guess test." << std::endl;
   }
 
   // Use a scaled converged solution as a nonzero initial guess.
@@ -262,7 +280,7 @@ int test(int argc, char* argv[])
   accepted_guess_solver.getIterativeSolver().setCliParam("flexible", flexible);
   accepted_guess_solver.getIterativeSolver().setCliParam("restart", "200");
 
-  status = accepted_guess_solver.preconditionerSetup(side);
+  status = accepted_guess_solver.preconditionerSetup(preconditioner_side);
   error_sum += status;
 
   const real_type initial_guess_rnorm = accepted_guess_solver.getResidualNorm(vec_rhs, &vec_x_guess);
@@ -311,7 +329,7 @@ int test(int argc, char* argv[])
 // Definitions of helper functions
 //
 
-void processInputs(std::string& method, std::string& gs, std::string& sketch, std::string& side)
+void processInputs(std::string& method, std::string& gs, std::string& sketch)
 {
   if (method == "randgmres")
   {
@@ -336,13 +354,6 @@ void processInputs(std::string& method, std::string& gs, std::string& sketch, st
     std::cout << "Unknown orthogonalization " << gs << "\n";
     std::cout << "Setting orthogonalization to the default (CGS2).\n\n";
     gs = "cgs2";
-  }
-
-  if ((side != "left") && (side != "right"))
-  {
-    std::cout << "Preconditioning side " << side << " not recognized.\n";
-    std::cout << "Setting preconditioning side to the default (right).\n\n";
-    side = "right";
   }
 }
 


### PR DESCRIPTION
## Description

Use `Preconditioner::Side` at the CLI boundary for the `sysGmres` example and functionality test while preserving the typed `SystemSolver` API.

Closes #439

## Proposed changes

- keep `SystemSolver::preconditionerSetup(Preconditioner::Side)` typed in `resolve/SystemSolver.hpp` and `resolve/SystemSolver.cpp`
- parse `-p left|right` into `Preconditioner::Side` in `examples/sysGmres.cpp` and `tests/functionality/testSysGmres.cpp`, defaulting to `RIGHT` only when `-p` is omitted
- return a clear nonzero error for explicit invalid `-p` values instead of silently falling through to right preconditioning
- add `sys_gmres_invalid_preconditioner_side_test` with `WILL_FAIL TRUE` in `tests/functionality/CMakeLists.txt`
- switch the inherited warning-path log call in `tests/functionality/testSysGmres.cpp` to `ReSolve::io::Logger::misc()` so the functionality target builds during warning-enabled CPU validation

## Checklist

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
    - [x] CPU backend
    - [ ] CUDA backend
    - [ ] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
    - [x] CPU backend
    - [ ] CUDA backend
    - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [ ] There are unit tests for the new code.
- [ ] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [ ] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.

## Further comments

- `make test`: `51/51` passed.
- `make test_install`: consumer `ctest` `1/1` passed.
- Automated functionality coverage: `sys_gmres_invalid_preconditioner_side_test` runs `sys_rand_gmres_test.exe -p bogus` with `WILL_FAIL TRUE`; explicit invalid `-p` now prints `Preconditioning side 'bogus' not recognized. Use 'left' or 'right'.` and exits `1`.
- Focused functionality checks on CPU:
  - default `sys_rand_gmres_test.exe -x no -i fgmres -g cgs2`: residual `2.1137376763106819e-16`
  - `-p right`: residual `2.1137376763106819e-16`
  - `-p left`: residual `2.0607333461083850e-16`
- Manual CPU example checks:
  - default omitted `-p`: residual `9.9464723774203639e-13`
  - `-x no -p right`: residual `1.0545376349847963e-12`
  - `-x no -p left`: residual `3.7412173369307980e-14`
- Existing solver behavior remains unchanged: default flexible GMRES rejects left preconditioning and reports `Flexible GMRES does not support left preconditioning. Use right preconditioning or disable flexible GMRES.`