### PR TITLE
Avoid host-device synchronization in Gram-Schmidt CGS2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,14 @@
 - Remove automatic memory allocation and memory syncing in various memory management functions and require the user to explicitly manage their own memory.
 
 - Set Re::Solve's real type and matrix/vector index type at CMake configuration time.
-* Added size assertions to `VectorHandler::gemv` and fixed vector sizing in `GramSchmidt` accordingly.
+
+- Added size assertions to `VectorHandler::gemv` and fixed vector sizing in `GramSchmidt` accordingly.
 
 - Added line to testlog to tell the user to expect warnings as part of normal testing.
+
 - Fixed GPU refactorization allocation and synchronization errors, uninitialized GMRES example initial guesses, and CUDA ILU0 failures on stored numerical zero pivots.
+
+- Optimized CGS2 coefficient accumulation in `GramSchmidt` by eliminating an unnecessary device-to-host synchronization.
 
 ## Changes to Re::Solve in release 0.99.2
 

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -119,7 +119,6 @@ namespace ReSolve
     }
     if (variant_ == CGS2)
     {
-      h_aux_       = new real_type[num_vecs_ + 1]();
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
       vec_Hcolumn_->allocate(memspace_);
       vec_Hcolumn_->setToZero(memspace_);
@@ -429,10 +428,10 @@ namespace ReSolve
 
     if (variant_ == CGS2)
     {
-      delete[] h_aux_;
-      h_aux_ = nullptr;
       delete vec_Hcolumn_;
       vec_Hcolumn_ = nullptr;
+      delete vec_Hcolumn_aux_;
+      vec_Hcolumn_aux_ = nullptr;
     }
 
     if (variant_ == CGS1)

--- a/resolve/GramSchmidt.cpp
+++ b/resolve/GramSchmidt.cpp
@@ -123,6 +123,10 @@ namespace ReSolve
       vec_Hcolumn_ = new vector_type(num_vecs_ + 1);
       vec_Hcolumn_->allocate(memspace_);
       vec_Hcolumn_->setToZero(memspace_);
+
+      vec_Hcolumn_aux_ = new vector_type(num_vecs_ + 1);
+      vec_Hcolumn_aux_->allocate(memspace_);
+      vec_Hcolumn_aux_->setToZero(memspace_);
     }
     if (variant_ == CGS1)
     {
@@ -179,40 +183,30 @@ namespace ReSolve
 
     case CGS2:
       vec_v_->setData(V->getData(i + 1, memspace_), memspace_);
+      vec_Hcolumn_aux_->resize(i + 1);
       vec_Hcolumn_->resize(i + 1);
 
+      // First CGS orthogonalization
+
+      // Hcol = V(:,1:i)^T*V(:,i+1), then V(:,i+1) = V(:, i+1) - V(:,1:i)*Hcol
+      vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_aux_, memspace_);
+      vector_handler_->gemv('N', i + 1, ONE, MINUS_ONE, V, vec_Hcolumn_aux_, vec_v_, memspace_);
+
+      // Second CGS orthogonalization
+
+      // Hcol = V(:,1:i)^T*V(:,i+1), then V(:,i+1) = V(:, i+1) - V(:,1:i)*Hcol
       vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_, memspace_);
-      // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
       vector_handler_->gemv('N', i + 1, ONE, MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_);
 
-      // copy H_col to aux, we will need it later
-      vec_Hcolumn_->setDataUpdated(memspace_);
-      if (memspace_ == memory::DEVICE)
-      {
-        vec_Hcolumn_->syncData(memory::HOST);
-      }
-      vec_Hcolumn_->copyToExternal(h_aux_, 0, memory::HOST, memory::HOST);
-
-      // Hcol = V(:,1:i)^T*V(:,i+1);
-      vector_handler_->gemv('T', i + 1, ONE, ZERO, V, vec_v_, vec_Hcolumn_, memspace_);
-
-      // V(:,i+1) = V(:, i+1) -  V(:,1:i)*Hcol
-      vector_handler_->gemv('N', i + 1, ONE, MINUS_ONE, V, vec_Hcolumn_, vec_v_, memspace_);
+      // Accumulate the coefficients from both CGS steps
+      vector_handler_->axpy(ONE, vec_Hcolumn_aux_, vec_Hcolumn_, memspace_);
 
       // copy H_col to H
-      vec_Hcolumn_->setDataUpdated(memspace_);
       if (memspace_ == memory::DEVICE)
       {
         vec_Hcolumn_->syncData(memory::HOST);
       }
       vec_Hcolumn_->copyToExternal(&H[idxmap(i, 0, num_vecs_ + 1)], 0, memory::HOST, memory::HOST);
-
-      // add both pieces together (unstable otherwise, careful here!!)
-      t = 0.0;
-      for (int j = 0; j <= i; ++j)
-      {
-        H[idxmap(i, j, num_vecs_ + 1)] += h_aux_[j];
-      }
 
       t = vector_handler_->dot(vec_v_, vec_v_, memspace_);
       // set the last entry in Hessenberg matrix

--- a/resolve/GramSchmidt.hpp
+++ b/resolve/GramSchmidt.hpp
@@ -44,6 +44,7 @@ namespace ReSolve
     index_type   num_vecs_; // the same as restart
     vector_type* vec_rv_{nullptr};
     vector_type* vec_Hcolumn_{nullptr};
+    vector_type* vec_Hcolumn_aux_{nullptr};
 
     real_type*     h_L_{nullptr};
     real_type*     h_aux_{nullptr};


### PR DESCRIPTION
## Description

While working on #452, I noticed CGS2 was performing an extra device-to-host copy and synchronization in every orthogonalization step on GPU backends.

The coefficients from the first CGS pass were copied to the host and later added to those from the second pass on the host. Instead, we can keep both coefficient vectors in the active memory space and combine them using `VectorHandler::axpy()`.

 ## Proposed changes

- Removed an unnecessary device-to-host synchronization from CGS2.
- Added `vec_Hcolumn_aux_` to store the coefficients from the first CGS pass, then accumulated them with the second coefficients in the active memory space using `VectorHandler::axpy()` (the additional allocation is small, only `restart + 1` elements).

Timed `solver.solve()` in `sysGmres` using `matrix_ACTIVSg200_AC_renumbered_add9_01.mtx`.

Average over five runs
- Before: 0.852530 s
- After: 0.699054 s

The impact of this is easier to observe on smaller matrices.

Test environment:

- NVIDIA GeForce RTX 5050 Laptop GPU
- CUDA 12.9 

 ## Checklist

- [ ] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [ ] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [ ] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [N/A] There are unit tests for the new code.
- [x] The new code is documented.
- [N/A] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
