### PR TITLE
Fix cuSPARSE handle and test buffer leaks under ASAN

### DIFF
--- a/resolve/LinSolverDirectCuSparseILU0.cpp
+++ b/resolve/LinSolverDirectCuSparseILU0.cpp
@@ -19,6 +19,55 @@ namespace ReSolve
     mem_.deleteOnDevice(d_aux1_);
     mem_.deleteOnDevice(d_aux2_);
     mem_.deleteOnDevice(d_ILU_vals_);
+
+    if (buffer_ != nullptr)
+    {
+      mem_.deleteOnDevice(buffer_);
+      buffer_ = nullptr;
+    }
+    if (buffer_L_ != nullptr)
+    {
+      mem_.deleteOnDevice(buffer_L_);
+      buffer_L_ = nullptr;
+    }
+    if (buffer_U_ != nullptr)
+    {
+      mem_.deleteOnDevice(buffer_U_);
+      buffer_U_ = nullptr;
+    }
+
+    if (descr_spsv_L_ != nullptr)
+    {
+      cusparseSpSV_destroyDescr(descr_spsv_L_);
+      descr_spsv_L_ = nullptr;
+    }
+    if (descr_spsv_U_ != nullptr)
+    {
+      cusparseSpSV_destroyDescr(descr_spsv_U_);
+      descr_spsv_U_ = nullptr;
+    }
+
+    if (mat_L_ != nullptr)
+    {
+      cusparseDestroySpMat(mat_L_);
+      mat_L_ = nullptr;
+    }
+    if (mat_U_ != nullptr)
+    {
+      cusparseDestroySpMat(mat_U_);
+      mat_U_ = nullptr;
+    }
+
+    if (info_A_ != nullptr)
+    {
+      cusparseDestroyCsrilu02Info(info_A_);
+      info_A_ = nullptr;
+    }
+    if (descr_A_ != nullptr)
+    {
+      cusparseDestroyMatDescr(descr_A_);
+      descr_A_ = nullptr;
+    }
   }
 
   int LinSolverDirectCuSparseILU0::setup(matrix::Sparse* A,

--- a/tests/unit/matrix/SparseTests.hpp
+++ b/tests/unit/matrix/SparseTests.hpp
@@ -240,6 +240,13 @@ namespace ReSolve
         // Clean up allocated memory
         delete[] val_data;
 
+        // In the device case h_val_data is a scratch host buffer allocated
+        // above; on host it aliases the matrix-owned data and must not be freed.
+        if (memspace_ != memory::HOST)
+        {
+          delete[] h_val_data;
+        }
+
         if (A.destroyMatrixData(memspace_) != 0)
         {
           std::cout << "Failed to destroy matrix data.\n";


### PR DESCRIPTION
## Summary

Addresses #387. When ReSolve is built with the address sanitizer (`-DRESOLVE_USE_ASAN=yes`) on CUDA, many unit tests fail with leaks reported from `libcusparse`. The root cause is that the cuSPARSE ILU0 direct solver never releases the cuSPARSE resources it creates.

`LinSolverDirectCuSparseILU0::setup()` allocates:
- a matrix descriptor (`descr_A_`),
- two sparse-matrix descriptors (`mat_L_`, `mat_U_`),
- two SpSV descriptors (`descr_spsv_L_`, `descr_spsv_U_`),
- a `csrilu02Info_t` info structure (`info_A_`),
- and three device work buffers (`buffer_`, `buffer_L_`, `buffer_U_`),

but the destructor only freed `d_aux1_`, `d_aux2_`, and `d_ILU_vals_`. Every solver instance therefore leaked the descriptors, info struct, and buffers, which ASAN attributes to the cuSPARSE library.

## Changes

- Destroy all cuSPARSE descriptors/info and free the device work buffers in `~LinSolverDirectCuSparseILU0()`.
- Free the scratch host buffer allocated in the device path of the sparse matrix copy test (`tests/unit/matrix/SparseTests.hpp`), which leaked on device builds.

This mirrors the approach taken for the rocSPARSE analog in #388.

## Notes

Some of the allocations reported by ASAN in the issue originate inside NVIDIA libraries (`libcuda`/`libcublas` one-time initialization via `cuInit`) and are outside ReSolve's control; those are not addressed here.

## Test plan

- [ ] Configure with `-DRESOLVE_USE_ASAN=yes -DRESOLVE_USE_UBSAN=yes -DRESOLVE_USE_CUDA=yes` and run `ctest -j`; verify the previously failing tests no longer report leaks from the ILU0 solver or the sparse matrix copy test.