### PR TITLE
Fix HyKKT solver reuse and add export support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HyKKT Release changes
 
+- Exported HyKKT libraries and fixed solver reuse by refreshing numerical data, reusing allocations, resizing GPU transpose workspaces, and handling zero residuals.
 - Added classes and tests for permutation, Ruiz scaling, Cholesky factorization, Schur complement conjugate gradient and matrix multiplication and addition.
 
 - Changed random number generation int tests to be C++ style and fixed-seed, to avoid random failures.

--- a/resolve/CMakeLists.txt
+++ b/resolve/CMakeLists.txt
@@ -157,6 +157,16 @@ endif()
 # Add HyKKT solver
 if(RESOLVE_USE_KLU)
   add_subdirectory(hykkt)
+  list(
+    APPEND
+    ReSolve_Targets_List
+    resolve_hykkt
+    resolve_hykkt_ruiz
+    resolve_hykkt_chol
+    resolve_hykkt_spgemm
+    resolve_hykkt_sccg
+    resolve_hykkt_solver
+  )
 endif()
 
 # Set installable targets

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -403,6 +403,10 @@ namespace ReSolve
    */
   void hykkt::HyKKTSolver::computeSpGEMMHgamma()
   {
+    // Numerical values can change between solves while the sparsity pattern
+    // remains fixed, so refresh the SpGEMM inputs before recomputing H_gamma.
+    spgemm_hgamma_->loadProductMatrices(J_tr_, J_);
+    spgemm_hgamma_->loadSumMatrix(H_tilde_);
     spgemm_hgamma_->compute();
     r_x_hat_->copyFromExternal(r_x_til_, memspace_, memspace_);
     matrixHandler_->matvec(J_tr_, r_y_, r_x_hat_, &gamma_, &ONE, memspace_);

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -79,9 +79,13 @@ namespace ReSolve
     J_d_ = J_d;
 
     bool J_d_flag = J_d->getNnz() > 0;
-    // status_ = (J_d_flag_ == J_d_flag);
-    status_   = true; // when using API, we can't check if sparsity pattern changed
-    J_d_flag_ = J_d_flag;
+    // Arbitrary sparsity changes remain the caller's responsibility, but
+    // switching between empty and nonempty J_d invalidates cached HyKKT data.
+    if (!allocated_)
+    {
+      J_d_flag_ = J_d_flag;
+    }
+    status_ = (J_d_flag_ == J_d_flag);
   }
 
   /**

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -214,8 +214,8 @@ namespace ReSolve
   /**
    * @brief allocates and initiates variables for KKT system
    *
-   * @pre jd_flag_ determines if variables used for Spgemm H_tilde
-   *      should be initiated
+   * @pre J_d_flag_ determines whether variables used to form H_tilde with
+   *      SpGEMM should be initialized.
    *
    * @post all variables used for hykkt are allocated for; J_d-
    *       related variables are not initiated if J_d nnz == 0
@@ -392,9 +392,6 @@ namespace ReSolve
   void hykkt::HyKKTSolver::setupSpGEMMHgamma()
   {
     spgemm_hgamma_ = new SpGEMM(memspace_, gamma_, ONE);
-    spgemm_hgamma_->loadProductMatrices(J_tr_, J_);
-    spgemm_hgamma_->loadSumMatrix(H_tilde_);
-    spgemm_hgamma_->loadResultMatrix(&H_gamma_); // H_gamma_ will be created when calling SpGEMM->compute()
   }
 
   /*
@@ -412,6 +409,9 @@ namespace ReSolve
     spgemm_hgamma_->setAlpha(gamma_);
     spgemm_hgamma_->loadProductMatrices(J_tr_, J_);
     spgemm_hgamma_->loadSumMatrix(H_tilde_);
+    // HIP initializes the result descriptor using dimensions established by
+    // the product and sum inputs, so load the result matrix after both inputs.
+    spgemm_hgamma_->loadResultMatrix(&H_gamma_);
     spgemm_hgamma_->compute();
     r_x_hat_->copyFromExternal(r_x_til_, memspace_, memspace_);
     matrixHandler_->matvec(J_tr_, r_y_, r_x_hat_, &gamma_, &ONE, memspace_);

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -513,7 +513,15 @@ namespace ReSolve
     schur_->copyFromExternal(r_y_, memspace_, memspace_);
     matrixHandler_->matvec(J_perm_, omega_perm_, schur_, &ONE, &MINUS_ONE, memspace_);
 
-    sccg_ = new SchurComplementConjugateGradient(J_->getNumRows(), J_->getNumColumns(), cholesky_, matrixHandler_, vectorHandler_, memspace_);
+    if (!allocated_)
+    {
+      sccg_ = new SchurComplementConjugateGradient(J_->getNumRows(),
+                                                   J_->getNumColumns(),
+                                                   cholesky_,
+                                                   matrixHandler_,
+                                                   vectorHandler_,
+                                                   memspace_);
+    }
     sccg_->addMatrixInfo(J_perm_, J_tr_perm_);
     y_->setToZero(memspace_);
     sccg_->addVectorInfo(y_, schur_);

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -642,7 +642,11 @@ namespace ReSolve
 
     // Calculate final relative norm
     norm_resx_sq += norm_resy_sq;
-    real_type norm_res = sqrt(norm_resx_sq) / sqrt(norm_r_x_sq);
+    real_type norm_res = sqrt(norm_resx_sq);
+    if (norm_r_x_sq > 0)
+    {
+      norm_res /= sqrt(norm_r_x_sq);
+    }
     printf("||Ax-b||/||b|| = %32.32g\n\n", norm_res);
 
     allocated_ = true;

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -313,7 +313,10 @@ namespace ReSolve
     else
     {
       H_tilde_->setNnz(H_->getNnz());
-      H_tilde_->allocateMatrixData(memspace_);
+      if (!allocated_)
+      {
+        H_tilde_->allocateMatrixData(memspace_);
+      }
       H_tilde_->copyFromExternal(H_->getRowData(memspace_),
                                  H_->getColData(memspace_),
                                  H_->getValues(memspace_),

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -258,11 +258,6 @@ namespace ReSolve
       J_d_scaled_->allocateWithExternalSparsityPattern(J_d_->getRowData(memspace_), J_d_->getColData(memspace_), J_d_->getNnz(), memspace_);
       // H_tilde_ does not need to be allocated because loadResultMatrix() does it later
     }
-    else if (memspace_ == memory::DEVICE)
-    {
-      J_d_->syncData(memory::DEVICE); // check if this is redundant
-    }
-
     r_y_copy_->copyFromExternal(r_y_, memspace_, memspace_);
 
     // check if this is redundant in later iterations
@@ -557,10 +552,6 @@ namespace ReSolve
     // block-recovering the solution to the original system by parts
     // this part is to recover delta_x
     cholesky_->solve(z_, r_x_perm_);
-    if (memspace_ == memory::DEVICE)
-    {
-      x_->syncData(memory::DEVICE);
-    }
     permutation_->mapIndex(REV_PERM_V, z_->getData(memspace_), x_->getData(memspace_));
     x_->setDataUpdated(memspace_);
 

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -7,10 +7,12 @@
 #include "HyKKTSolver.hpp"
 
 #include <resolve/matrix/io.hpp>
+#include <resolve/utilities/logger/Logger.hpp>
 
 namespace ReSolve
 {
   using namespace constants;
+  using out = io::Logger;
 
   /**
    * @brief basic constructor
@@ -73,22 +75,32 @@ namespace ReSolve
    * (m_c x n_x).
    * @param[in] J_d - Pointer to the inequality constraints Jacobian block
    * (m_d x n_x)
+   *
+   * @return 0 if successful, 1 if the supplied blocks are incompatible with
+   *         the allocated solver state. On failure, the previously stored
+   *         blocks are left unchanged.
    */
-  void hykkt::HyKKTSolver::setMatrixBlocks(matrix::Csr* H_plus_D_x, matrix::Csr* D_s, matrix::Csr* J, matrix::Csr* J_d)
+  int hykkt::HyKKTSolver::setMatrixBlocks(matrix::Csr* H_plus_D_x, matrix::Csr* D_s, matrix::Csr* J, matrix::Csr* J_d)
   {
+    const bool J_d_flag = J_d->getNnz() > 0;
+
+    if (allocated_ && J_d_flag_ != J_d_flag)
+    {
+      out::error() << "Changing J_d between empty and nonempty is not "
+                      "supported when reusing HyKKT.\n";
+      return 1;
+    }
+
     H_   = H_plus_D_x;
     D_s_ = D_s;
     J_   = J;
     J_d_ = J_d;
 
-    bool J_d_flag = J_d->getNnz() > 0;
-    // Arbitrary sparsity changes remain the caller's responsibility, but
-    // switching between empty and nonempty J_d invalidates cached HyKKT data.
     if (!allocated_)
     {
       J_d_flag_ = J_d_flag;
     }
-    status_ = (J_d_flag_ == J_d_flag);
+    return 0;
   }
 
   /**
@@ -163,13 +175,6 @@ namespace ReSolve
    */
   real_type hykkt::HyKKTSolver::solve()
   {
-    if (!status_ && allocated_)
-    {
-      std::cout << "ERROR: Changing J_d between empty and nonempty is not "
-                   "supported when reusing HyKKT.\n";
-      return 1;
-    }
-
     setupParameters();
 
     if (!allocated_)

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -212,6 +212,7 @@ namespace ReSolve
                                                    matrixHandler_,
                                                    vectorHandler_,
                                                    memspace_);
+      sccg_->setup();
     }
     setupConjugateGradient();
     computeConjugateGradient();
@@ -535,7 +536,6 @@ namespace ReSolve
     sccg_->addMatrixInfo(J_perm_, J_tr_perm_);
     y_->setToZero(memspace_);
     sccg_->addVectorInfo(y_, schur_);
-    sccg_->setup();
   }
 
   /**

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -246,7 +246,6 @@ namespace ReSolve
       J_tr_perm_   = new matrix::Csr(J_tr_->getNumRows(), J_tr_->getNumColumns(), J_tr_->getNnz());
       J_d_scaled_  = new matrix::Csr(J_d_->getNumRows(), J_d_->getNumColumns(), J_d_->getNnz());
 
-      D_s_vals_->setData(D_s_->getValues(memspace_), memspace_);
       r_yd_scaled_->allocate(memspace_);
       r_x_perm_->allocate(memspace_);
       omega_perm_->allocate(memspace_);
@@ -262,6 +261,9 @@ namespace ReSolve
       J_d_scaled_->allocateWithExternalSparsityPattern(J_d_->getRowData(memspace_), J_d_->getColData(memspace_), J_d_->getNnz(), memspace_);
       // H_tilde_ does not need to be allocated because loadResultMatrix() does it later
     }
+
+    // D_s may be replaced between solves, so refresh the external value pointer.
+    D_s_vals_->setData(D_s_->getValues(memspace_), memspace_);
     r_y_copy_->copyFromExternal(r_y_, memspace_, memspace_);
 
     // check if this is redundant in later iterations

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -407,6 +407,7 @@ namespace ReSolve
   {
     // Numerical values can change between solves while the sparsity pattern
     // remains fixed, so refresh the SpGEMM inputs before recomputing H_gamma.
+    spgemm_hgamma_->setAlpha(gamma_);
     spgemm_hgamma_->loadProductMatrices(J_tr_, J_);
     spgemm_hgamma_->loadSumMatrix(H_tilde_);
     spgemm_hgamma_->compute();

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -204,6 +204,15 @@ namespace ReSolve
     }
     computeHgammaFactorization();
 
+    if (!allocated_)
+    {
+      sccg_ = new SchurComplementConjugateGradient(J_->getNumRows(),
+                                                   J_->getNumColumns(),
+                                                   cholesky_,
+                                                   matrixHandler_,
+                                                   vectorHandler_,
+                                                   memspace_);
+    }
     setupConjugateGradient();
     computeConjugateGradient();
 
@@ -523,15 +532,6 @@ namespace ReSolve
     schur_->copyFromExternal(r_y_, memspace_, memspace_);
     matrixHandler_->matvec(J_perm_, omega_perm_, schur_, &ONE, &MINUS_ONE, memspace_);
 
-    if (!allocated_)
-    {
-      sccg_ = new SchurComplementConjugateGradient(J_->getNumRows(),
-                                                   J_->getNumColumns(),
-                                                   cholesky_,
-                                                   matrixHandler_,
-                                                   vectorHandler_,
-                                                   memspace_);
-    }
     sccg_->addMatrixInfo(J_perm_, J_tr_perm_);
     y_->setToZero(memspace_);
     sccg_->addVectorInfo(y_, schur_);

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -416,7 +416,7 @@ namespace ReSolve
   {
     // Numerical values can change between solves while the sparsity pattern
     // remains fixed, so refresh the SpGEMM inputs before recomputing H_gamma.
-    spgemm_hgamma_->setAlpha(gamma_);
+    spgemm_hgamma_->setCoefficients(gamma_, ONE);
     spgemm_hgamma_->loadProductMatrices(J_tr_, J_);
     spgemm_hgamma_->loadSumMatrix(H_tilde_);
     // HIP initializes the result descriptor using dimensions established by

--- a/resolve/hykkt/HyKKTSolver.cpp
+++ b/resolve/hykkt/HyKKTSolver.cpp
@@ -62,6 +62,9 @@ namespace ReSolve
    * values. It will only set pointers to user provided data; it is user's
    * responsibility to supply and later delete that memory.
    *
+   * Reusing the solver requires the sparsity patterns of the matrix blocks
+   * to remain unchanged. Changing J_d between empty and nonempty is rejected.
+   *
    * @param[in] H_plus_D_x - Pointer to the Hessian matrix block (n_x x n_x),
    * corresponding to H + D_x in the HyKKT paper.
    * @param[in] D_s - Pointer to the slack variables derivatives matrix block
@@ -160,13 +163,10 @@ namespace ReSolve
    */
   real_type hykkt::HyKKTSolver::solve()
   {
-    // TODO: Review sparsity pattern checking in HyKKT
     if (!status_ && allocated_)
     {
-      printf("\n\nERROR: USING HYKKT WITH NEW NONZERO STRUCTURE\n\n");
-      std::cout << "status = " << status_
-                << ", allocated = " << allocated_
-                << "\n";
+      std::cout << "ERROR: Changing J_d between empty and nonempty is not "
+                   "supported when reusing HyKKT.\n";
       return 1;
     }
 
@@ -266,7 +266,7 @@ namespace ReSolve
     D_s_vals_->setData(D_s_->getValues(memspace_), memspace_);
     r_y_copy_->copyFromExternal(r_y_, memspace_, memspace_);
 
-    // check if this is redundant in later iterations
+    // Matrix values may change between solves, so refresh the transpose.
     matrixHandler_->transpose(J_, J_tr_, memspace_);
     if (J_d_flag_)
     {
@@ -640,14 +640,17 @@ namespace ReSolve
     matrixHandler_->matvec(J_copy_, x_, r_y_copy_, &MINUS_ONE, &ONE, memspace_);
     norm_resy_sq = vectorHandler_->dot(r_y_copy_, r_y_copy_, memspace_);
 
-    // Calculate final relative norm
     norm_resx_sq += norm_resy_sq;
     real_type norm_res = sqrt(norm_resx_sq);
     if (norm_r_x_sq > 0)
     {
       norm_res /= sqrt(norm_r_x_sq);
+      printf("||Ax-b||/||b|| = %32.32g\n\n", norm_res);
     }
-    printf("||Ax-b||/||b|| = %32.32g\n\n", norm_res);
+    else
+    {
+      printf("||Ax-b|| = %32.32g\n\n", norm_res);
+    }
 
     allocated_ = true;
 

--- a/resolve/hykkt/HyKKTSolver.hpp
+++ b/resolve/hykkt/HyKKTSolver.hpp
@@ -41,7 +41,7 @@ namespace ReSolve
           std::istream& r_y_file,
           std::istream& r_yd_file);
 
-      void setMatrixBlocks(matrix::Csr* H_plus_D_x, matrix::Csr* D_s, matrix::Csr* J, matrix::Csr* J_d);
+      int  setMatrixBlocks(matrix::Csr* H_plus_D_x, matrix::Csr* D_s, matrix::Csr* J, matrix::Csr* J_d);
       void setRHSBlocks(vector::Vector* r_x, vector::Vector* r_s, vector::Vector* r_y, vector::Vector* r_yd);
       void setLHSPointers(vector::Vector* x, vector::Vector* s, vector::Vector* y, vector::Vector* y_d);
 
@@ -77,10 +77,6 @@ namespace ReSolve
 
       bool allocated_ = false;
       bool J_d_flag_  = false;
-
-      // Whether the solver is correctly used with matrices of
-      // the same nonzero structure
-      bool status_ = true;
 
       RuizScaling*                      ruiz_{nullptr};
       SpGEMM*                           spgemm_htil_{nullptr};

--- a/resolve/hykkt/cholesky/CholeskySolverCpu.cpp
+++ b/resolve/hykkt/cholesky/CholeskySolverCpu.cpp
@@ -39,11 +39,12 @@ namespace ReSolve
 
     void CholeskySolverCpu::addMatrixInfo(matrix::Csr* A)
     {
+      A_ = A;
       if (A_chol_)
       {
         cholmod_free_sparse(&A_chol_, &Common_);
       }
-      A_chol_ = convertToCholmod(A);
+      A_chol_ = convertToCholmod(A_);
     }
 
     /**
@@ -71,6 +72,12 @@ namespace ReSolve
     void CholeskySolverCpu::numericalFactorization(real_type tol)
     {
       (void) tol; // Mark tol as unused
+
+      // CHOLMOD stores its own copy of the matrix values. Refresh that copy
+      // before numerical refactorization when the solver is reused.
+      mem_.copyArrayHostToHost(static_cast<real_type*>(A_chol_->x),
+                               A_->getValues(memory::HOST),
+                               A_->getNnz());
 
       cholmod_factorize(A_chol_, factorization_, &Common_);
       if (Common_.status < 0)

--- a/resolve/hykkt/cholesky/CholeskySolverCpu.hpp
+++ b/resolve/hykkt/cholesky/CholeskySolverCpu.hpp
@@ -27,6 +27,7 @@ namespace ReSolve
       MemoryHandler mem_;
 
       cholmod_common  Common_;
+      matrix::Csr*    A_ = nullptr;
       cholmod_sparse* A_chol_; // cholmod sparse matrix representation
       cholmod_factor* factorization_;
 

--- a/resolve/hykkt/sccg/SchurComplementConjugateGradient.cpp
+++ b/resolve/hykkt/sccg/SchurComplementConjugateGradient.cpp
@@ -124,6 +124,12 @@ namespace ReSolve
       matrix_handler_->matvec(J_, z_, r_, &MINUS_ONE, &ONE, memspace_);
       gamma_i_ = vector_handler_->dot(r_, r_, memspace_);
 
+      if (sqrt(gamma_i_) < tol_)
+      {
+        gamma_i1_ = gamma_i_;
+        return 0;
+      }
+
       matrix_handler_->matvec(J_tr_, r_, y_, &ONE, &ZERO, memspace_);
       choleskySolver_->solve(z_, y_);
       matrix_handler_->matvec(J_, z_, w_, &ONE, &ZERO, memspace_);

--- a/resolve/hykkt/sccg/SchurComplementConjugateGradient.cpp
+++ b/resolve/hykkt/sccg/SchurComplementConjugateGradient.cpp
@@ -86,19 +86,22 @@ namespace ReSolve
 
     void SchurComplementConjugateGradient::setup()
     {
-      y_ = new vector::Vector(m_);
-      z_ = new vector::Vector(m_);
-      r_ = new vector::Vector(n_);
-      p_ = new vector::Vector(n_);
-      s_ = new vector::Vector(n_);
-      w_ = new vector::Vector(n_);
+      if (!y_)
+      {
+        y_ = new vector::Vector(m_);
+        z_ = new vector::Vector(m_);
+        r_ = new vector::Vector(n_);
+        p_ = new vector::Vector(n_);
+        s_ = new vector::Vector(n_);
+        w_ = new vector::Vector(n_);
 
-      y_->allocate(memspace_);
-      z_->allocate(memspace_);
-      r_->allocate(memspace_);
-      p_->allocate(memspace_);
-      s_->allocate(memspace_);
-      w_->allocate(memspace_);
+        y_->allocate(memspace_);
+        z_->allocate(memspace_);
+        r_->allocate(memspace_);
+        p_->allocate(memspace_);
+        s_->allocate(memspace_);
+        w_->allocate(memspace_);
+      }
 
       y_->setToZero(memspace_);
       z_->setToZero(memspace_);

--- a/resolve/hykkt/sccg/SchurComplementConjugateGradient.cpp
+++ b/resolve/hykkt/sccg/SchurComplementConjugateGradient.cpp
@@ -86,22 +86,24 @@ namespace ReSolve
 
     void SchurComplementConjugateGradient::setup()
     {
-      if (!y_)
-      {
-        y_ = new vector::Vector(m_);
-        z_ = new vector::Vector(m_);
-        r_ = new vector::Vector(n_);
-        p_ = new vector::Vector(n_);
-        s_ = new vector::Vector(n_);
-        w_ = new vector::Vector(n_);
+      y_ = new vector::Vector(m_);
+      z_ = new vector::Vector(m_);
+      r_ = new vector::Vector(n_);
+      p_ = new vector::Vector(n_);
+      s_ = new vector::Vector(n_);
+      w_ = new vector::Vector(n_);
 
-        y_->allocate(memspace_);
-        z_->allocate(memspace_);
-        r_->allocate(memspace_);
-        p_->allocate(memspace_);
-        s_->allocate(memspace_);
-        w_->allocate(memspace_);
-      }
+      y_->allocate(memspace_);
+      z_->allocate(memspace_);
+      r_->allocate(memspace_);
+      p_->allocate(memspace_);
+      s_->allocate(memspace_);
+      w_->allocate(memspace_);
+    }
+
+    int SchurComplementConjugateGradient::solve()
+    {
+      using namespace constants;
 
       y_->setToZero(memspace_);
       z_->setToZero(memspace_);
@@ -113,11 +115,6 @@ namespace ReSolve
       x_0_->setToZero(memspace_);
 
       beta_ = 0;
-    }
-
-    int SchurComplementConjugateGradient::solve()
-    {
-      using namespace constants;
 
       matrix_handler_->matvec(J_tr_, x_0_, y_, &ONE, &ZERO, memspace_);
       choleskySolver_->solve(z_, y_);

--- a/resolve/hykkt/sccg/SchurComplementConjugateGradient.hpp
+++ b/resolve/hykkt/sccg/SchurComplementConjugateGradient.hpp
@@ -49,6 +49,11 @@ namespace ReSolve
       void setSolverTolerance(double tol);
       void setSolverItmax(int itmax);
 
+      /**
+       * @brief Allocates internal work vectors.
+       *
+       * @pre Must be called exactly once before the first call to solve().
+       */
       void setup();
       int  solve();
 

--- a/resolve/hykkt/spgemm/SpGEMM.cpp
+++ b/resolve/hykkt/spgemm/SpGEMM.cpp
@@ -54,13 +54,14 @@ namespace ReSolve
     }
 
     /**
-     * Updates the scalar multiplier for the matrix product.
+     * Updates the coefficients for the SpGEMM operation.
      *
-     * @param[in] alpha - Scalar multiplier for the product.
+     * @param[in] alpha - Scalar multiplier for the matrix product.
+     * @param[in] beta  - Scalar multiplier for the sum matrix.
      */
-    void SpGEMM::setAlpha(real_type alpha)
+    void SpGEMM::setCoefficients(real_type alpha, real_type beta)
     {
-      impl_->setAlpha(alpha);
+      impl_->setCoefficients(alpha, beta);
     }
 
     /**

--- a/resolve/hykkt/spgemm/SpGEMM.cpp
+++ b/resolve/hykkt/spgemm/SpGEMM.cpp
@@ -54,6 +54,16 @@ namespace ReSolve
     }
 
     /**
+     * Updates the scalar multiplier for the matrix product.
+     *
+     * @param[in] alpha - Scalar multiplier for the product.
+     */
+    void SpGEMM::setAlpha(real_type alpha)
+    {
+      impl_->setAlpha(alpha);
+    }
+
+    /**
      * Loads the two matrices for the product
      * @param A[in] - Pointer to CSR matrix
      * @param B[in] - Pointer to CSR matrix

--- a/resolve/hykkt/spgemm/SpGEMM.hpp
+++ b/resolve/hykkt/spgemm/SpGEMM.hpp
@@ -22,6 +22,11 @@ namespace ReSolve
       SpGEMM(memory::MemorySpace memspace, real_type alpha, real_type beta);
       ~SpGEMM();
 
+      void setAlpha(real_type alpha)
+      {
+        impl_->setAlpha(alpha);
+      }
+
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);
       void loadResultMatrix(matrix::Csr** E_ptr);

--- a/resolve/hykkt/spgemm/SpGEMM.hpp
+++ b/resolve/hykkt/spgemm/SpGEMM.hpp
@@ -22,7 +22,7 @@ namespace ReSolve
       SpGEMM(memory::MemorySpace memspace, real_type alpha, real_type beta);
       ~SpGEMM();
 
-      void setAlpha(real_type alpha);
+      void setCoefficients(real_type alpha, real_type beta);
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMM.hpp
+++ b/resolve/hykkt/spgemm/SpGEMM.hpp
@@ -22,10 +22,7 @@ namespace ReSolve
       SpGEMM(memory::MemorySpace memspace, real_type alpha, real_type beta);
       ~SpGEMM();
 
-      void setAlpha(real_type alpha)
-      {
-        impl_->setAlpha(alpha);
-      }
+      void setAlpha(real_type alpha);
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMMCpu.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.cpp
@@ -47,6 +47,11 @@ namespace ReSolve
       cholmod_finish(&Common_);
     }
 
+    void SpGEMMCpu::setAlpha(real_type alpha)
+    {
+      alpha_ = alpha;
+    }
+
     void SpGEMMCpu::loadProductMatrices(matrix::Csr* A, matrix::Csr* B)
     {
       if (!A_)

--- a/resolve/hykkt/spgemm/SpGEMMCpu.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.cpp
@@ -47,9 +47,10 @@ namespace ReSolve
       cholmod_finish(&Common_);
     }
 
-    void SpGEMMCpu::setAlpha(real_type alpha)
+    void SpGEMMCpu::setCoefficients(real_type alpha, real_type beta)
     {
       alpha_ = alpha;
+      beta_  = beta;
     }
 
     void SpGEMMCpu::loadProductMatrices(matrix::Csr* A, matrix::Csr* B)

--- a/resolve/hykkt/spgemm/SpGEMMCpu.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.hpp
@@ -16,7 +16,7 @@ namespace ReSolve
       SpGEMMCpu(real_type alpha, real_type beta);
       ~SpGEMMCpu();
 
-      void setAlpha(real_type alpha) override;
+      void setCoefficients(real_type alpha, real_type beta) override;
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMMCpu.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.hpp
@@ -16,6 +16,11 @@ namespace ReSolve
       SpGEMMCpu(real_type alpha, real_type beta);
       ~SpGEMMCpu();
 
+      void setAlpha(real_type alpha) override
+      {
+        alpha_ = alpha;
+      }
+
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);
       void loadResultMatrix(matrix::Csr** E_ptr);

--- a/resolve/hykkt/spgemm/SpGEMMCpu.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.hpp
@@ -16,10 +16,7 @@ namespace ReSolve
       SpGEMMCpu(real_type alpha, real_type beta);
       ~SpGEMMCpu();
 
-      void setAlpha(real_type alpha) override
-      {
-        alpha_ = alpha;
-      }
+      void setAlpha(real_type alpha) override;
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMMCpu.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCpu.hpp
@@ -18,11 +18,11 @@ namespace ReSolve
 
       void setCoefficients(real_type alpha, real_type beta) override;
 
-      void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
-      void loadSumMatrix(matrix::Csr* D);
-      void loadResultMatrix(matrix::Csr** E_ptr);
+      void loadProductMatrices(matrix::Csr* A, matrix::Csr* B) override;
+      void loadSumMatrix(matrix::Csr* D) override;
+      void loadResultMatrix(matrix::Csr** E_ptr) override;
 
-      void compute();
+      void compute() override;
 
     private:
       real_type alpha_;

--- a/resolve/hykkt/spgemm/SpGEMMCuda.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCuda.cpp
@@ -29,6 +29,11 @@ namespace ReSolve
       cusparseDestroy(handle_);
     }
 
+    void SpGEMMCuda::setAlpha(real_type alpha)
+    {
+      alpha_ = alpha;
+    }
+
     void SpGEMMCuda::loadProductMatrices(matrix::Csr* A, matrix::Csr* B)
     {
       A_descr_ = convertToCusparseType(A);

--- a/resolve/hykkt/spgemm/SpGEMMCuda.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCuda.cpp
@@ -29,9 +29,10 @@ namespace ReSolve
       cusparseDestroy(handle_);
     }
 
-    void SpGEMMCuda::setAlpha(real_type alpha)
+    void SpGEMMCuda::setCoefficients(real_type alpha, real_type beta)
     {
       alpha_ = alpha;
+      beta_  = beta;
     }
 
     void SpGEMMCuda::loadProductMatrices(matrix::Csr* A, matrix::Csr* B)

--- a/resolve/hykkt/spgemm/SpGEMMCuda.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMCuda.cpp
@@ -149,7 +149,7 @@ namespace ReSolve
         mem_.deleteOnDevice(temp_buffer_2);
 
         int64_t C_num_cols = 0;
-        int64_t C_nnz_     = 0;
+        C_nnz_             = 0;
         cusparseSpMatGetSize(C_descr_, &n_, &C_num_cols, &C_nnz_);
 
         mem_.allocateArrayOnDevice(&C_col_ind_, (index_type) C_nnz_);

--- a/resolve/hykkt/spgemm/SpGEMMCuda.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCuda.hpp
@@ -22,10 +22,7 @@ namespace ReSolve
       SpGEMMCuda(real_type alpha, real_type beta);
       ~SpGEMMCuda();
 
-      void setAlpha(real_type alpha) override
-      {
-        alpha_ = alpha;
-      }
+      void setAlpha(real_type alpha) override;
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMMCuda.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCuda.hpp
@@ -22,7 +22,7 @@ namespace ReSolve
       SpGEMMCuda(real_type alpha, real_type beta);
       ~SpGEMMCuda();
 
-      void setAlpha(real_type alpha) override;
+      void setCoefficients(real_type alpha, real_type beta) override;
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMMCuda.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMCuda.hpp
@@ -22,6 +22,11 @@ namespace ReSolve
       SpGEMMCuda(real_type alpha, real_type beta);
       ~SpGEMMCuda();
 
+      void setAlpha(real_type alpha) override
+      {
+        alpha_ = alpha;
+      }
+
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);
       void loadResultMatrix(matrix::Csr** E_ptr);

--- a/resolve/hykkt/spgemm/SpGEMMHip.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMHip.cpp
@@ -30,9 +30,10 @@ namespace ReSolve
       mem_.deleteOnDevice(buffer_);
     }
 
-    void SpGEMMHip::setAlpha(real_type alpha)
+    void SpGEMMHip::setCoefficients(real_type alpha, real_type beta)
     {
       alpha_ = alpha;
+      beta_  = beta;
     }
 
     void SpGEMMHip::loadProductMatrices(matrix::Csr* A, matrix::Csr* B)

--- a/resolve/hykkt/spgemm/SpGEMMHip.cpp
+++ b/resolve/hykkt/spgemm/SpGEMMHip.cpp
@@ -30,6 +30,11 @@ namespace ReSolve
       mem_.deleteOnDevice(buffer_);
     }
 
+    void SpGEMMHip::setAlpha(real_type alpha)
+    {
+      alpha_ = alpha;
+    }
+
     void SpGEMMHip::loadProductMatrices(matrix::Csr* A, matrix::Csr* B)
     {
       if (A_descr_)

--- a/resolve/hykkt/spgemm/SpGEMMHip.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMHip.hpp
@@ -22,7 +22,7 @@ namespace ReSolve
       SpGEMMHip(real_type alpha, real_type beta);
       ~SpGEMMHip();
 
-      void setAlpha(real_type alpha) override;
+      void setCoefficients(real_type alpha, real_type beta) override;
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMMHip.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMHip.hpp
@@ -24,11 +24,11 @@ namespace ReSolve
 
       void setCoefficients(real_type alpha, real_type beta) override;
 
-      void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
-      void loadSumMatrix(matrix::Csr* D);
-      void loadResultMatrix(matrix::Csr** E_ptr);
+      void loadProductMatrices(matrix::Csr* A, matrix::Csr* B) override;
+      void loadSumMatrix(matrix::Csr* D) override;
+      void loadResultMatrix(matrix::Csr** E_ptr) override;
 
-      void compute();
+      void compute() override;
 
     private:
       MemoryHandler mem_;

--- a/resolve/hykkt/spgemm/SpGEMMHip.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMHip.hpp
@@ -22,6 +22,11 @@ namespace ReSolve
       SpGEMMHip(real_type alpha, real_type beta);
       ~SpGEMMHip();
 
+      void setAlpha(real_type alpha) override
+      {
+        alpha_ = alpha;
+      }
+
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);
       void loadResultMatrix(matrix::Csr** E_ptr);

--- a/resolve/hykkt/spgemm/SpGEMMHip.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMHip.hpp
@@ -22,10 +22,7 @@ namespace ReSolve
       SpGEMMHip(real_type alpha, real_type beta);
       ~SpGEMMHip();
 
-      void setAlpha(real_type alpha) override
-      {
-        alpha_ = alpha;
-      }
+      void setAlpha(real_type alpha) override;
 
       void loadProductMatrices(matrix::Csr* A, matrix::Csr* B);
       void loadSumMatrix(matrix::Csr* D);

--- a/resolve/hykkt/spgemm/SpGEMMImpl.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMImpl.hpp
@@ -23,6 +23,8 @@ namespace ReSolve
       SpGEMMImpl()          = default;
       virtual ~SpGEMMImpl() = default;
 
+      virtual void setAlpha(real_type alpha) = 0;
+
       virtual void loadProductMatrices(matrix::Csr* A, matrix::Csr* B) = 0;
       virtual void loadSumMatrix(matrix::Csr* D)                       = 0;
       virtual void loadResultMatrix(matrix::Csr** E_ptr)               = 0;

--- a/resolve/hykkt/spgemm/SpGEMMImpl.hpp
+++ b/resolve/hykkt/spgemm/SpGEMMImpl.hpp
@@ -23,7 +23,7 @@ namespace ReSolve
       SpGEMMImpl()          = default;
       virtual ~SpGEMMImpl() = default;
 
-      virtual void setAlpha(real_type alpha) = 0;
+      virtual void setCoefficients(real_type alpha, real_type beta) = 0;
 
       virtual void loadProductMatrices(matrix::Csr* A, matrix::Csr* B) = 0;
       virtual void loadSumMatrix(matrix::Csr* D)                       = 0;

--- a/resolve/matrix/MatrixHandlerCuda.cpp
+++ b/resolve/matrix/MatrixHandlerCuda.cpp
@@ -306,30 +306,25 @@ namespace ReSolve
     index_type       n         = A->getNumColumns();
     index_type       nnz       = A->getNnz();
     cusparseStatus_t status;
-    bool             allocated = workspace_->isTransposeBufferAllocated();
-    // check dimensions of A and At
-    if (!allocated)
-    {
-      // allocate transpose buffer
-      size_t bufferSize;
-      status = cusparseCsr2cscEx2_bufferSize(workspace_->getCusparseHandle(),
-                                             m,
-                                             n,
-                                             nnz,
-                                             A->getValues(memory::DEVICE),
-                                             A->getRowData(memory::DEVICE),
-                                             A->getColData(memory::DEVICE),
-                                             At->getValues(memory::DEVICE),
-                                             At->getRowData(memory::DEVICE),
-                                             At->getColData(memory::DEVICE),
-                                             CUDA_R_64F,
-                                             CUSPARSE_ACTION_NUMERIC,
-                                             CUSPARSE_INDEX_BASE_ZERO,
-                                             CUSPARSE_CSR2CSC_ALG1,
-                                             &bufferSize);
-      error_sum += status;
-      workspace_->setTransposeBufferWorkspace(bufferSize);
-    }
+    // Ensure the shared transpose workspace is large enough for this matrix.
+    size_t bufferSize;
+    status = cusparseCsr2cscEx2_bufferSize(workspace_->getCusparseHandle(),
+                                           m,
+                                           n,
+                                           nnz,
+                                           A->getValues(memory::DEVICE),
+                                           A->getRowData(memory::DEVICE),
+                                           A->getColData(memory::DEVICE),
+                                           At->getValues(memory::DEVICE),
+                                           At->getRowData(memory::DEVICE),
+                                           At->getColData(memory::DEVICE),
+                                           CUDA_R_64F,
+                                           CUSPARSE_ACTION_NUMERIC,
+                                           CUSPARSE_INDEX_BASE_ZERO,
+                                           CUSPARSE_CSR2CSC_ALG1,
+                                           &bufferSize);
+    error_sum += status;
+    error_sum += workspace_->setTransposeBufferWorkspace(bufferSize);
     status = cusparseCsr2cscEx2(workspace_->getCusparseHandle(),
                                 m,
                                 n,

--- a/resolve/matrix/MatrixHandlerHip.cpp
+++ b/resolve/matrix/MatrixHandlerHip.cpp
@@ -281,22 +281,18 @@ namespace ReSolve
     index_type       n         = A->getNumColumns();
     index_type       nnz       = A->getNnz();
     rocsparse_status status;
-    bool             allocated = workspace_->isTransposeBufferAllocated();
-    if (!allocated)
-    {
-      // allocate transpose buffer
-      size_t bufferSize;
-      status = rocsparse_csr2csc_buffer_size(workspace_->getRocsparseHandle(),
-                                             m,
-                                             n,
-                                             nnz,
-                                             A->getRowData(memory::DEVICE),
-                                             A->getColData(memory::DEVICE),
-                                             rocsparse_action_numeric,
-                                             &bufferSize);
-      error_sum += status;
-      workspace_->setTransposeBufferWorkspace(bufferSize);
-    }
+    // Ensure the shared transpose workspace is large enough for this matrix.
+    size_t bufferSize;
+    status = rocsparse_csr2csc_buffer_size(workspace_->getRocsparseHandle(),
+                                           m,
+                                           n,
+                                           nnz,
+                                           A->getRowData(memory::DEVICE),
+                                           A->getColData(memory::DEVICE),
+                                           rocsparse_action_numeric,
+                                           &bufferSize);
+    error_sum += status;
+    error_sum += workspace_->setTransposeBufferWorkspace(bufferSize);
     status = rocsparse_dcsr2csc(workspace_->getRocsparseHandle(),
                                 m,
                                 n,

--- a/resolve/workspace/LinAlgWorkspaceCUDA.cpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.cpp
@@ -95,12 +95,19 @@ namespace ReSolve
 
   int LinAlgWorkspaceCUDA::setTransposeBufferWorkspace(size_t bufferSize)
   {
+    if (transpose_workspace_ready_ && bufferSize <= transpose_workspace_size_)
+    {
+      return 0;
+    }
+
     if (transpose_workspace_ready_)
     {
-      out::error() << "Transpose workspace already set!\n";
-      return 1;
+      mem_.deleteOnDevice(transpose_workspace_);
+      transpose_workspace_ = nullptr;
     }
+
     mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
+    transpose_workspace_size_  = bufferSize;
     transpose_workspace_ready_ = true;
     return 0;
   }

--- a/resolve/workspace/LinAlgWorkspaceCUDA.hpp
+++ b/resolve/workspace/LinAlgWorkspaceCUDA.hpp
@@ -74,8 +74,9 @@ namespace ReSolve
 
     bool matvec_setup_done_{false}; // check if setup is done for matvec i.e. if buffer is allocated, csr structure is set etc.
 
-    void* transpose_workspace_{nullptr};     // needed for transpose
-    bool  transpose_workspace_ready_{false}; // to track if allocated
+    void*  transpose_workspace_{nullptr};     // needed for transpose
+    size_t transpose_workspace_size_{0};      // allocated size in bytes
+    bool   transpose_workspace_ready_{false}; // to track if allocated
 
     real_type* d_r_{nullptr}; // needed for one-norm
     index_type d_r_size_{0};

--- a/resolve/workspace/LinAlgWorkspaceHIP.cpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.cpp
@@ -193,12 +193,19 @@ namespace ReSolve
 
   int LinAlgWorkspaceHIP::setTransposeBufferWorkspace(size_t bufferSize)
   {
+    if (transpose_workspace_ready_ && bufferSize <= transpose_workspace_size_)
+    {
+      return 0;
+    }
+
     if (transpose_workspace_ready_)
     {
-      out::error() << "Transpose workspace already set!\n";
-      return 1;
+      mem_.deleteOnDevice(transpose_workspace_);
+      transpose_workspace_ = nullptr;
     }
+
     mem_.allocateBufferOnDevice(&transpose_workspace_, bufferSize);
+    transpose_workspace_size_  = bufferSize;
     transpose_workspace_ready_ = true;
     return 0;
   }

--- a/resolve/workspace/LinAlgWorkspaceHIP.hpp
+++ b/resolve/workspace/LinAlgWorkspaceHIP.hpp
@@ -71,6 +71,7 @@ namespace ReSolve
     real_type*    d_r_{nullptr};                     // needed for inf-norm
     real_type*    norm_buffer_{nullptr};             // needed for inf-norm
     void*         transpose_workspace_{nullptr};     // needed for transpose
+    size_t        transpose_workspace_size_{0};      // allocated size in bytes
     bool          transpose_workspace_ready_{false}; // to track if allocated
     index_type    d_r_size_{0};
     bool          norm_buffer_ready_{false}; // to track if allocated

--- a/tests/unit/hykkt/HykktSCCGTests.hpp
+++ b/tests/unit/hykkt/HykktSCCGTests.hpp
@@ -104,6 +104,16 @@ namespace ReSolve
         testname += " n=" + std::to_string(n) + ", m=" + std::to_string(m) + ", nnz =" + std::to_string(nnz);
         status *= validateResult(x_0, converged_n);
 
+        // A zero initial residual is already converged and must not enter
+        // conjugate-gradient divisions with zero numerator and denominator.
+        x_0->setToZero(memspace_);
+        b->setToZero(memspace_);
+        sccg.addVectorInfo(x_0, b);
+        sccg.setup();
+        int zero_residual_converged_n = sccg.solve();
+        status *= (zero_residual_converged_n == 0);
+        status *= (vector_handler_.dot(x_0, x_0, memspace_) <= sccg_tol);
+
         delete H;
         delete J;
         delete J_tr;

--- a/tests/unit/hykkt/HykktSCCGTests.hpp
+++ b/tests/unit/hykkt/HykktSCCGTests.hpp
@@ -109,7 +109,6 @@ namespace ReSolve
         x_0->setToZero(memspace_);
         b->setToZero(memspace_);
         sccg.addVectorInfo(x_0, b);
-        sccg.setup();
         int zero_residual_converged_n = sccg.solve();
         status *= (zero_residual_converged_n == 0);
         status *= (vector_handler_.dot(x_0, x_0, memspace_) <= sccg_tol);

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -195,6 +195,15 @@ namespace ReSolve
         real_type second_error = hykktSolver.solve();
         status *= validateResult(second_error, tol);
 
+        // Changing J_d between nonempty and empty invalidates cached solver data.
+        matrix::Csr* J_d_empty = new matrix::Csr(J_d->getNumRows(),
+                                                 J_d->getNumColumns(),
+                                                 0);
+        hykktSolver.setMatrixBlocks(H, D_s, J, J_d_empty);
+        real_type structure_error = hykktSolver.solve();
+        status *= (structure_error == 1);
+        delete J_d_empty;
+
         delete H;
         delete D_s;
         delete J;

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -203,6 +203,14 @@ namespace ReSolve
         real_type second_error = hykktSolver.solve();
         status *= validateResult(second_error, tol);
 
+        // Verify an exact zero RHS is handled without producing NaNs.
+        r_x->setToZero(memspace_);
+        r_s->setToZero(memspace_);
+        r_y->setToZero(memspace_);
+        r_yd->setToZero(memspace_);
+        real_type zero_rhs_error = hykktSolver.solve();
+        status *= validateResult(zero_rhs_error, tol);
+
         // Changing J_d between nonempty and empty invalidates cached solver data.
         matrix::Csr* J_d_empty = new matrix::Csr(J_d->getNumRows(),
                                                  J_d->getNumColumns(),

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -202,6 +202,21 @@ namespace ReSolve
         hykktSolver.setMatrixBlocks(H, D_s, J, J_d_empty);
         real_type structure_error = hykktSolver.solve();
         status *= (structure_error == 1);
+
+        // Starting without J_d is valid and must remain reusable.
+        hykkt::HyKKTSolver no_jd_solver(n_x, m_d, m_c, memspace_);
+        no_jd_solver.setMatrixBlocks(H, D_s, J, J_d_empty);
+        no_jd_solver.setRHSBlocks(r_x, r_s, r_y, r_yd);
+        no_jd_solver.setLHSPointers(x, s, y, y_d);
+        no_jd_solver.setGamma(gamma);
+        no_jd_solver.addHandlers(&matrixHandler_, &vectorHandler_);
+
+        real_type no_jd_error = no_jd_solver.solve();
+        status *= validateResult(no_jd_error, tol);
+
+        real_type no_jd_reuse_error = no_jd_solver.solve();
+        status *= validateResult(no_jd_reuse_error, tol);
+
         delete J_d_empty;
 
         delete H;

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -192,6 +192,8 @@ namespace ReSolve
         delete r_y_reuse;
         delete r_yd_reuse;
 
+        // Change gamma to verify the cached SpGEMM coefficient is refreshed.
+        hykktSolver.setGamma(gamma * 1.1);
         real_type second_error = hykktSolver.solve();
         status *= validateResult(second_error, tol);
 

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -142,13 +142,16 @@ namespace ReSolve
         testname += " N=" + std::to_string(N) + ", nnz =" + std::to_string(nnz) + '\n';
         status *= validateResult(error, tol);
 
-        // Update D_s and restore data modified by the first solve.
-        real_type* D_s_values = D_s->getValues(memory::HOST);
-        for (index_type i = 0; i < D_s->getNnz(); ++i)
+        // Replace D_s and restore data modified by the first solve.
+        std::ifstream D_s_reuse_file(D_s_file_name);
+        matrix::Csr*  D_s_reuse = io::createCsrFromFile(D_s_reuse_file, false);
+
+        real_type* D_s_values = D_s_reuse->getValues(memory::HOST);
+        for (index_type i = 0; i < D_s_reuse->getNnz(); ++i)
         {
           D_s_values[i] *= 1.1;
         }
-        D_s->setUpdated(memory::HOST);
+        D_s_reuse->setUpdated(memory::HOST);
 
         std::ifstream J_reuse_file(J_file_name);
         std::ifstream r_x_reuse_file(r_x_file_name);
@@ -176,7 +179,8 @@ namespace ReSolve
 
         if (memspace_ == memory::DEVICE)
         {
-          restore_status |= D_s->syncData(memory::DEVICE);
+          restore_status |= D_s_reuse->allocateMatrixData(memory::DEVICE);
+          restore_status |= D_s_reuse->syncData(memory::DEVICE);
           restore_status |= J->syncData(memory::DEVICE);
           restore_status |= r_x->syncData(memory::DEVICE);
           restore_status |= r_s->syncData(memory::DEVICE);
@@ -192,6 +196,8 @@ namespace ReSolve
         delete r_y_reuse;
         delete r_yd_reuse;
 
+        hykktSolver.setMatrixBlocks(H, D_s_reuse, J, J_d);
+
         // Change gamma to verify the cached SpGEMM coefficient is refreshed.
         hykktSolver.setGamma(gamma * 1.1);
         real_type second_error = hykktSolver.solve();
@@ -202,6 +208,7 @@ namespace ReSolve
                                                  J_d->getNumColumns(),
                                                  0);
         hykktSolver.setMatrixBlocks(H, D_s, J, J_d_empty);
+        delete D_s_reuse;
         real_type structure_error = hykktSolver.solve();
         status *= (structure_error == 1);
 

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -142,6 +142,59 @@ namespace ReSolve
         testname += " N=" + std::to_string(N) + ", nnz =" + std::to_string(nnz) + '\n';
         status *= validateResult(error, tol);
 
+        // Update D_s and restore data modified by the first solve.
+        real_type* D_s_values = D_s->getValues(memory::HOST);
+        for (index_type i = 0; i < D_s->getNnz(); ++i)
+        {
+          D_s_values[i] *= 1.1;
+        }
+        D_s->setUpdated(memory::HOST);
+
+        std::ifstream J_reuse_file(J_file_name);
+        std::ifstream r_x_reuse_file(r_x_file_name);
+        std::ifstream r_s_reuse_file(r_s_file_name);
+        std::ifstream r_y_reuse_file(r_y_file_name);
+        std::ifstream r_yd_reuse_file(r_yd_file_name);
+
+        matrix::Csr* J_reuse = io::createCsrFromFile(J_reuse_file, false);
+
+        vector::Vector* r_x_reuse  = io::createVectorFromFile(r_x_reuse_file);
+        vector::Vector* r_s_reuse  = io::createVectorFromFile(r_s_reuse_file);
+        vector::Vector* r_y_reuse  = io::createVectorFromFile(r_y_reuse_file);
+        vector::Vector* r_yd_reuse = io::createVectorFromFile(r_yd_reuse_file);
+
+        int restore_status = 0;
+        restore_status |= J->copyFromExternal(J_reuse->getRowData(memory::HOST),
+                                              J_reuse->getColData(memory::HOST),
+                                              J_reuse->getValues(memory::HOST),
+                                              memory::HOST,
+                                              memory::HOST);
+        restore_status |= r_x->copyFromExternal(r_x_reuse, memory::HOST, memory::HOST);
+        restore_status |= r_s->copyFromExternal(r_s_reuse, memory::HOST, memory::HOST);
+        restore_status |= r_y->copyFromExternal(r_y_reuse, memory::HOST, memory::HOST);
+        restore_status |= r_yd->copyFromExternal(r_yd_reuse, memory::HOST, memory::HOST);
+
+        if (memspace_ == memory::DEVICE)
+        {
+          restore_status |= D_s->syncData(memory::DEVICE);
+          restore_status |= J->syncData(memory::DEVICE);
+          restore_status |= r_x->syncData(memory::DEVICE);
+          restore_status |= r_s->syncData(memory::DEVICE);
+          restore_status |= r_y->syncData(memory::DEVICE);
+          restore_status |= r_yd->syncData(memory::DEVICE);
+        }
+
+        status *= (restore_status == 0);
+
+        delete J_reuse;
+        delete r_x_reuse;
+        delete r_s_reuse;
+        delete r_y_reuse;
+        delete r_yd_reuse;
+
+        real_type second_error = hykktSolver.solve();
+        status *= validateResult(second_error, tol);
+
         delete H;
         delete D_s;
         delete J;

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -201,9 +201,9 @@ namespace ReSolve
         matrix::Csr* J_d_empty = new matrix::Csr(J_d->getNumRows(),
                                                  J_d->getNumColumns(),
                                                  0);
-        hykktSolver.setMatrixBlocks(H, D_s_reuse, J, J_d_empty);
-        real_type structure_error = hykktSolver.solve();
-        status *= (structure_error == 1);
+
+        int structure_status = hykktSolver.setMatrixBlocks(H, D_s_reuse, J, J_d_empty);
+        status *= (structure_status != 0);
 
         // Exercise initialization and reuse with an empty J_d.
         hykkt::HyKKTSolver no_jd_solver(n_x, m_d, m_c, memspace_);

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -203,7 +203,7 @@ namespace ReSolve
         real_type second_error = hykktSolver.solve();
         status *= validateResult(second_error, tol);
 
-        // Verify an exact zero RHS is handled without producing NaNs.
+        // Check that a zero RHS doesn't result in NaNs.
         r_x->setToZero(memspace_);
         r_s->setToZero(memspace_);
         r_y->setToZero(memspace_);
@@ -211,7 +211,8 @@ namespace ReSolve
         real_type zero_rhs_error = hykktSolver.solve();
         status *= validateResult(zero_rhs_error, tol);
 
-        // Changing J_d between nonempty and empty invalidates cached solver data.
+        // Check that the solver raises an error when trying to change J_d
+        // from nonempty to empty.
         matrix::Csr* J_d_empty = new matrix::Csr(J_d->getNumRows(),
                                                  J_d->getNumColumns(),
                                                  0);

--- a/tests/unit/hykkt/HykktSolverTests.hpp
+++ b/tests/unit/hykkt/HykktSolverTests.hpp
@@ -142,43 +142,35 @@ namespace ReSolve
         testname += " N=" + std::to_string(N) + ", nnz =" + std::to_string(nnz) + '\n';
         status *= validateResult(error, tol);
 
-        // Replace D_s and restore data modified by the first solve.
+        // Replace D_s to exercise its pointer refresh; restore other inputs
+        // in place.
         std::ifstream D_s_reuse_file(D_s_file_name);
-        matrix::Csr*  D_s_reuse = io::createCsrFromFile(D_s_reuse_file, false);
+        std::ifstream J_update_file(J_file_name);
+        std::ifstream r_x_update_file(r_x_file_name);
+        std::ifstream r_s_update_file(r_s_file_name);
+        std::ifstream r_y_update_file(r_y_file_name);
+        std::ifstream r_yd_update_file(r_yd_file_name);
+
+        matrix::Csr* D_s_reuse = io::createCsrFromFile(D_s_reuse_file, false);
+
+        io::updateMatrixFromFile(J_update_file, J);
+        io::updateVectorFromFile(r_x_update_file, r_x);
+        io::updateVectorFromFile(r_s_update_file, r_s);
+        io::updateVectorFromFile(r_y_update_file, r_y);
+        io::updateVectorFromFile(r_yd_update_file, r_yd);
 
         real_type* D_s_values = D_s_reuse->getValues(memory::HOST);
         for (index_type i = 0; i < D_s_reuse->getNnz(); ++i)
         {
           D_s_values[i] *= 1.1;
         }
+
         D_s_reuse->setUpdated(memory::HOST);
-
-        std::ifstream J_reuse_file(J_file_name);
-        std::ifstream r_x_reuse_file(r_x_file_name);
-        std::ifstream r_s_reuse_file(r_s_file_name);
-        std::ifstream r_y_reuse_file(r_y_file_name);
-        std::ifstream r_yd_reuse_file(r_yd_file_name);
-
-        matrix::Csr* J_reuse = io::createCsrFromFile(J_reuse_file, false);
-
-        vector::Vector* r_x_reuse  = io::createVectorFromFile(r_x_reuse_file);
-        vector::Vector* r_s_reuse  = io::createVectorFromFile(r_s_reuse_file);
-        vector::Vector* r_y_reuse  = io::createVectorFromFile(r_y_reuse_file);
-        vector::Vector* r_yd_reuse = io::createVectorFromFile(r_yd_reuse_file);
-
-        int restore_status = 0;
-        restore_status |= J->copyFromExternal(J_reuse->getRowData(memory::HOST),
-                                              J_reuse->getColData(memory::HOST),
-                                              J_reuse->getValues(memory::HOST),
-                                              memory::HOST,
-                                              memory::HOST);
-        restore_status |= r_x->copyFromExternal(r_x_reuse, memory::HOST, memory::HOST);
-        restore_status |= r_s->copyFromExternal(r_s_reuse, memory::HOST, memory::HOST);
-        restore_status |= r_y->copyFromExternal(r_y_reuse, memory::HOST, memory::HOST);
-        restore_status |= r_yd->copyFromExternal(r_yd_reuse, memory::HOST, memory::HOST);
+        J->setUpdated(memory::HOST);
 
         if (memspace_ == memory::DEVICE)
         {
+          int restore_status = 0;
           restore_status |= D_s_reuse->allocateMatrixData(memory::DEVICE);
           restore_status |= D_s_reuse->syncData(memory::DEVICE);
           restore_status |= J->syncData(memory::DEVICE);
@@ -186,15 +178,8 @@ namespace ReSolve
           restore_status |= r_s->syncData(memory::DEVICE);
           restore_status |= r_y->syncData(memory::DEVICE);
           restore_status |= r_yd->syncData(memory::DEVICE);
+          status *= (restore_status == 0);
         }
-
-        status *= (restore_status == 0);
-
-        delete J_reuse;
-        delete r_x_reuse;
-        delete r_s_reuse;
-        delete r_y_reuse;
-        delete r_yd_reuse;
 
         hykktSolver.setMatrixBlocks(H, D_s_reuse, J, J_d);
 
@@ -216,14 +201,13 @@ namespace ReSolve
         matrix::Csr* J_d_empty = new matrix::Csr(J_d->getNumRows(),
                                                  J_d->getNumColumns(),
                                                  0);
-        hykktSolver.setMatrixBlocks(H, D_s, J, J_d_empty);
-        delete D_s_reuse;
+        hykktSolver.setMatrixBlocks(H, D_s_reuse, J, J_d_empty);
         real_type structure_error = hykktSolver.solve();
         status *= (structure_error == 1);
 
-        // Starting without J_d is valid and must remain reusable.
+        // Exercise initialization and reuse with an empty J_d.
         hykkt::HyKKTSolver no_jd_solver(n_x, m_d, m_c, memspace_);
-        no_jd_solver.setMatrixBlocks(H, D_s, J, J_d_empty);
+        no_jd_solver.setMatrixBlocks(H, D_s_reuse, J, J_d_empty);
         no_jd_solver.setRHSBlocks(r_x, r_s, r_y, r_yd);
         no_jd_solver.setLHSPointers(x, s, y, y_d);
         no_jd_solver.setGamma(gamma);
@@ -235,6 +219,7 @@ namespace ReSolve
         real_type no_jd_reuse_error = no_jd_solver.solve();
         status *= validateResult(no_jd_reuse_error, tol);
 
+        delete D_s_reuse;
         delete J_d_empty;
 
         delete H;

--- a/tests/unit/hykkt/HykktSpGEMMTests.hpp
+++ b/tests/unit/hykkt/HykktSpGEMMTests.hpp
@@ -292,6 +292,59 @@ namespace ReSolve
 
         status *= verifyResult(E, 2.0);
 
+        // Recompute with updated product and sum coefficients.
+        spgemm.setCoefficients(3.0, 3.0);
+        spgemm.compute();
+
+        if (memspace_ == memory::DEVICE)
+        {
+          E->syncData(memory::HOST);
+        }
+
+        status *= verifyResult(E, 3.0);
+
+        // Change only beta and verify that the sum-matrix contribution changes.
+        real_type* equal_coefficient_values = new real_type[E->getNnz()];
+        for (index_type i = 0; i < E->getNnz(); ++i)
+        {
+          equal_coefficient_values[i] = E->getValues(memory::HOST)[i];
+        }
+
+        spgemm.setCoefficients(3.0, 5.0);
+        spgemm.compute();
+
+        if (memspace_ == memory::DEVICE)
+        {
+          E->syncData(memory::HOST);
+        }
+
+        bool beta_changed_result = false;
+        for (index_type i = 0; i < E->getNnz(); ++i)
+        {
+          if (fabs(E->getValues(memory::HOST)[i] -
+                   equal_coefficient_values[i]) > 1e-12)
+          {
+            beta_changed_result = true;
+            break;
+          }
+        }
+
+        if (!beta_changed_result)
+        {
+          std::cerr << "Changing beta did not change the SpGEMM result.\n";
+        }
+        status *= beta_changed_result;
+        delete[] equal_coefficient_values;
+
+        // Restore equal coefficients for the matrix-value reuse check below.
+        spgemm.setCoefficients(3.0, 3.0);
+        spgemm.compute();
+
+        if (memspace_ == memory::DEVICE)
+        {
+          E->syncData(memory::HOST);
+        }
+
         for (index_type j = 0; j < A->getNnz(); j++)
         {
           A->getValues(memory::HOST)[j] *= 2.0;
@@ -318,7 +371,7 @@ namespace ReSolve
           E->syncData(memory::HOST);
         }
 
-        status *= verifyResult(E, 4.0);
+        status *= verifyResult(E, 6.0);
 
         delete A;
         delete B;

--- a/tests/unit/hykkt/HykktSpGEMMTests.hpp
+++ b/tests/unit/hykkt/HykktSpGEMMTests.hpp
@@ -321,8 +321,7 @@ namespace ReSolve
         bool beta_changed_result = false;
         for (index_type i = 0; i < E->getNnz(); ++i)
         {
-          if (fabs(E->getValues(memory::HOST)[i] -
-                   equal_coefficient_values[i]) > 1e-12)
+          if (fabs(E->getValues(memory::HOST)[i] - equal_coefficient_values[i]) > 1e-12)
           {
             beta_changed_result = true;
             break;

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -46,8 +46,8 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.csc2csr(1200, 1024);
   workspace.resetLinAlgWorkspace();
   result += test.transpose(3, 3);
-  // Reuse the same GPU workspace for a much larger transpose to exercise
-  // transpose-buffer growth rather than first-use-only allocation.
+  // Reuse the same workspace for a much larger transpose. CUDA and HIP
+  // should grow the buffer instead of reusing the first allocation.
   result += test.transpose(2048, 1024);
   workspace.resetLinAlgWorkspace();
   result += test.transpose(5, 3);

--- a/tests/unit/matrix/runMatrixHandlerTests.cpp
+++ b/tests/unit/matrix/runMatrixHandlerTests.cpp
@@ -46,6 +46,9 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.csc2csr(1200, 1024);
   workspace.resetLinAlgWorkspace();
   result += test.transpose(3, 3);
+  // Reuse the same GPU workspace for a much larger transpose to exercise
+  // transpose-buffer growth rather than first-use-only allocation.
+  result += test.transpose(2048, 1024);
   workspace.resetLinAlgWorkspace();
   result += test.transpose(5, 3);
   workspace.resetLinAlgWorkspace();
@@ -58,8 +61,6 @@ void runTests(const std::string& backend, ReSolve::tests::TestingResults& result
   result += test.transpose(1024, 1024);
   workspace.resetLinAlgWorkspace();
   result += test.transpose(1024, 2048);
-  workspace.resetLinAlgWorkspace();
-  result += test.transpose(2048, 1024);
   workspace.resetLinAlgWorkspace();
   result += test.transpose(1024, 1200);
   workspace.resetLinAlgWorkspace();


### PR DESCRIPTION
## Description
 
This PR exports the HyKKT libraries and fixes issues found while reusing `HyKKTSolver` through the HiOp integration.

The existing HyKKT tests primarily covered a single solve. Repeated solves with the same sparsity pattern and updated numerical values exposed stale matrix data, cached solver state, repeated allocations, undersized GPU transpose workspaces, and zero-residual handling issues.
 
@shakedregev 
 

 ## Proposed changes
 
- Export the HyKKT libraries through the installed ReSolve package so downstream packages can link them.
- Refresh numerical data when `HyKKTSolver` is reused:
  - Copy updated matrix values into the existing CHOLMOD matrix before numerical factorization.
  - Reload the SpGEMM matrix inputs before each computation.
  - Refresh the external `D_s` values pointer before each solve.
  - Update the SpGEMM coefficient when `gamma` changes.
- Fix CUDA SpGEMM output state. A local `C_nnz_` variable shadowed the class member, so the stored output nonzero count was not updated.
- Resize CUDA and HIP transpose workspaces when a later transpose requires a larger buffer. Reuse the existing allocation when it is large enough and grow it when necessary.
- Reuse HyKKT allocations:
  - Allocate the SCCG solver and its work vectors once instead of replacing them on every solve.
  - Reuse the existing `H_tilde_` allocation when solving without `J_d`.
  - Reset the SCCG work vectors and scalar state before each solve while reusing their allocations.
- Remove redundant device synchronizations from the repeated solve path.
- Preserve the initial `J_d` state and reject reuse when `J_d` changes between empty and nonempty. Reuse still requires unchanged sparsity patterns.
- Handle zero residuals:
  - Return from SCCG when the initial residual is zero to avoid division by zero.
  - Only normalize the final residual when the RHS norm is nonzero.
  - Return an absolute residual when the RHS norm is zero.
- Add regression coverage for:
  - Solver reuse after refreshing `J` and RHS data, replacing and updating `D_s`, and changing `gamma`.
  - Repeated solves that start without `J_d`.
  - Rejected reuse when `J_d` changes from nonempty to empty.
  - Exact zero SCCG residuals and zero RHS values.
  - Reusing one transpose workspace for a small transpose followed by a much larger transpose.
 
 ## Checklist

- [x] All tests pass (`make test` and `make test_install` per testing [instructions](https://github.com/ORNL/ReSolve?tab=readme-ov-file#test-and-deploy)). Code tested on
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] I have manually run the non-experimental examples and verified that residuals are close to machine precision. (In your build directory run: `./examples/<your_example>.exe -h` to get instructions how to run examples). Code tested on:
     - [x] CPU backend
     - [x] CUDA backend
     - [x] HIP backend
- [x] Code compiles cleanly with flags `-Wall -Wpedantic -Wconversion -Wextra`.
- [x] The new code follows Re::Solve style guidelines.
- [x] There are unit tests for the new code.
- [x] The new code is documented.
- [x] The feature branch is rebased with respect to the target branch.
- [x] I have updated [CHANGELOG.md](/CHANGELOG.md) to reflect the changes in this PR. If this is a minor PR that is part of a larger fix already included in the file, state so.
 
 ## Further comments
 
The transpose workspace change keeps the current workspace design and grows the CUDA and HIP transpose buffers when needed rather than implementing the broader redesign proposed in #345.
