### PR TITLE
SystemSolver: use Preconditioner::Side enum for preconditioning side

### DIFF
--- a/examples/sysGmres.cpp
+++ b/examples/sysGmres.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "ExampleHelper.hpp"
+#include <resolve/Preconditioner.hpp>
 #include <resolve/SystemSolver.hpp>
 #include <resolve/matrix/Csr.hpp>
 #include <resolve/matrix/io.hpp>
@@ -171,6 +172,11 @@ int sysGmres(int argc, char* argv[])
 
   processInputs(method, gs, sketch, flexible, side);
 
+  // processInputs guarantees `side` is "left" or "right".
+  ReSolve::Preconditioner::Side prec_side =
+      (side == "left") ? ReSolve::Preconditioner::Side::LEFT
+                       : ReSolve::Preconditioner::Side::RIGHT;
+
   std::cout << "Matrix file: " << matrix_pathname << "\n"
             << "RHS file: " << rhs_pathname << "\n";
 
@@ -255,7 +261,7 @@ int sysGmres(int argc, char* argv[])
   // Set up the preconditioner
   if (return_code == 0)
   {
-    status = solver.preconditionerSetup(side);
+    status = solver.preconditionerSetup(prec_side);
     std::cout << "solver.preconditionerSetup returned status: " << status << "\n";
     if (status != 0)
     {

--- a/resolve/SystemSolver.cpp
+++ b/resolve/SystemSolver.cpp
@@ -619,9 +619,12 @@ namespace ReSolve
    *
    * Initializes and attaches the preconditioner to the iterative solver.
    *
+   * @param[in] side - preconditioning side (Preconditioner::Side::LEFT or
+   *                   Preconditioner::Side::RIGHT)
+   *
    * @return int 0 if successful, 1 if it fails
    */
-  int SystemSolver::preconditionerSetup(std::string side)
+  int SystemSolver::preconditionerSetup(Preconditioner::Side side)
   {
     int status = 0;
 
@@ -642,23 +645,7 @@ namespace ReSolve
       return status;
     }
 
-    Preconditioner::Side prec_side;
-    if (side == "left")
-    {
-      prec_side = Preconditioner::LEFT;
-    }
-    else if (side == "right")
-    {
-      prec_side = Preconditioner::RIGHT;
-    }
-    else
-    {
-      out::error() << "Preconditioning side '" << side
-                   << "' not recognized. Use 'left' or 'right'.\n";
-      return 1;
-    }
-
-    status += preconditioner_->setSide(prec_side);
+    status += preconditioner_->setSide(side);
     status += preconditioner_->setup(A_);
 
     if (memspace_ != "cpu")

--- a/resolve/SystemSolver.hpp
+++ b/resolve/SystemSolver.hpp
@@ -61,7 +61,7 @@ namespace ReSolve
     int factorize(); //  numeric part
     int refactorize();
     int refactorizationSetup();
-    int preconditionerSetup(std::string side);
+    int preconditionerSetup(Preconditioner::Side side);
     int resetPreconditioner(matrix_type* A);
     int solve(vector_type* rhs, vector_type* x);  // for direct and iterative
     int refine(vector_type* rhs, vector_type* x); // for iterative refinement

--- a/tests/functionality/testSysGmres.cpp
+++ b/tests/functionality/testSysGmres.cpp
@@ -109,6 +109,11 @@ int test(int argc, char* argv[])
 
   processInputs(method, gs, sketch, side);
 
+  // processInputs guarantees `side` is "left" or "right".
+  ReSolve::Preconditioner::Side prec_side =
+      (side == "left") ? ReSolve::Preconditioner::Side::LEFT
+                       : ReSolve::Preconditioner::Side::RIGHT;
+
   // Create workspace and initialize its handles.
   workspace_type workspace;
   workspace.initializeHandles();
@@ -170,7 +175,7 @@ int test(int argc, char* argv[])
   solver.getIterativeSolver().setCliParam("restart", "200");
 
   // Set preconditioner (default in this case ILU0)
-  status = solver.preconditionerSetup(side);
+  status = solver.preconditionerSetup(prec_side);
   error_sum += status;
 
   // Solve system
@@ -207,7 +212,7 @@ int test(int argc, char* argv[])
   bad_guess_solver.getIterativeSolver().setCliParam("flexible", flexible);
   bad_guess_solver.getIterativeSolver().setCliParam("restart", "200");
 
-  status = bad_guess_solver.preconditionerSetup(side);
+  status = bad_guess_solver.preconditionerSetup(prec_side);
   error_sum += status;
 
   const real_type bad_guess_rnorm = bad_guess_solver.getResidualNorm(vec_rhs, &bad_guess_x);
@@ -265,7 +270,7 @@ int test(int argc, char* argv[])
   accepted_guess_solver.getIterativeSolver().setCliParam("flexible", flexible);
   accepted_guess_solver.getIterativeSolver().setCliParam("restart", "200");
 
-  status = accepted_guess_solver.preconditionerSetup(side);
+  status = accepted_guess_solver.preconditionerSetup(prec_side);
   error_sum += status;
 
   const real_type initial_guess_rnorm = accepted_guess_solver.getResidualNorm(vec_rhs, &vec_x_guess);


### PR DESCRIPTION
Closes #439.

## Summary
`SystemSolver::preconditionerSetup()` accepted a `std::string` and manually mapped `"left"`/`"right"` to `Preconditioner::Side`. Left preconditioning was introduced in #417, and the other solvers already select the side through the `Preconditioner::Side` enum. `SystemSolver` was the last place still doing string-based selection, so this brings it in line.

## Changes
- `preconditionerSetup()` now takes `Preconditioner::Side` directly; the internal `"left"`/`"right"` string parsing (and the associated error branch) is removed.
- The string-to-enum conversion now happens once at the CLI boundary in `examples/sysGmres.cpp` and `tests/functionality/testSysGmres.cpp`, where the `-p` option is already validated by `processInputs`.

## Testing
Configured and built the `cpu` preset (`-DCMAKE_BUILD_TYPE=Release`); library, `sysGmres` example, and `sys_rand_gmres_test` all compile cleanly.

- `sys_rand_gmres_test.exe` (default, right preconditioning): **PASSED**
- `sys_rand_gmres_test.exe -p right`: **PASSED**
- unrecognized `-p sideways`: falls back to the default (right) as before, **PASSED**

Behavior is unchanged: the same `Preconditioner::Side` value is passed as before — only where the string is interpreted has moved. (`-p left` does not converge for the randomized FGMRES test problem, but that reproduces identically on `main` and is unrelated to this change.)